### PR TITLE
feat: stream all SBOM's with S3 metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
- "tokio-util",
  "tracing",
  "tracing-subscriber",
  "trustification-storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
  "anyhow",
  "bombastic-index",
  "clap",
+ "futures",
  "hex",
  "packageurl",
  "rand 0.8.5",
@@ -904,6 +905,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "trustification-storage",
@@ -4813,6 +4815,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "futures",
  "rust-s3",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,15 +849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,7 +921,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trustification-storage",
- "zstd",
 ]
 
 [[package]]
@@ -4813,9 +4825,10 @@ name = "trustification-storage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bincode",
+ "async-stream",
  "bytes",
  "futures",
+ "http",
  "rust-s3",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4815,11 +4815,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "bytes",
  "futures",
  "rust-s3",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/bombastic/api/Cargo.toml
+++ b/bombastic/api/Cargo.toml
@@ -10,6 +10,7 @@ actix-web = "4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
 tokio = { version = "1.0", features = ["full"] }
+tokio-util = "0.7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 bombastic-index = { path = "../index" }
@@ -21,3 +22,4 @@ sha2 = "0.10"
 hex = "0.4.3"
 packageurl = "0.3"
 rand = "0.8"
+futures = "0.3"

--- a/bombastic/api/Cargo.toml
+++ b/bombastic/api/Cargo.toml
@@ -10,7 +10,6 @@ actix-web = "4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
 tokio = { version = "1.0", features = ["full"] }
-tokio-util = "0.7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 bombastic-index = { path = "../index" }

--- a/bombastic/api/Cargo.toml
+++ b/bombastic/api/Cargo.toml
@@ -16,7 +16,6 @@ bombastic-index = { path = "../index" }
 trustification-storage = { path = "../../storage" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
-zstd = "0.12"
 sha2 = "0.10"
 hex = "0.4.3"
 packageurl = "0.3"

--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self};
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -96,7 +96,9 @@ async fn fetch_object(storage: &Storage, key: &str) -> HttpResponse {
     match storage.get(&key).await {
         Ok(obj) => {
             tracing::trace!("Retrieved object compressed: {}", obj.compressed);
-            if obj.compressed {
+            if obj.data.is_empty() {
+                HttpResponse::Ok().streaming(storage.get_stream(key).await)
+            } else if obj.compressed {
                 let mut out = Vec::new();
                 match ::zstd::stream::copy_decode(&obj.data[..], &mut out) {
                     Ok(_) => HttpResponse::Ok().body(out),

--- a/bombastic/indexer/src/indexer.rs
+++ b/bombastic/indexer/src/indexer.rs
@@ -32,9 +32,9 @@ pub async fn run<E: EventBus>(
                                     tracing::trace!("It's an index event, ignoring");
                                 } else {
                                     if let Some(key) = storage.extract_key(&data.key) {
-                                        match storage.get(key).await {
-                                            Ok(data) => {
-                                                if let Some(hash) = data.annotations.get("digest") {
+                                        match storage.get_metadata(key).await {
+                                            Ok(annotations) => {
+                                                if let Some(hash) = annotations.get("digest") {
                                                     match index.insert_or_replace(&data.key, hash.as_str(), key).await {
                                                         Ok(_) => {
                                                             tracing::trace!("Inserted entry into index");

--- a/spog/search/src/server.rs
+++ b/spog/search/src/server.rs
@@ -79,18 +79,7 @@ pub async fn run<B: Into<SocketAddr>>(
 
 pub async fn fetch_object(storage: &Storage, key: &str) -> Option<Vec<u8>> {
     match storage.get(&key).await {
-        Ok(obj) => {
-            tracing::trace!("Retrieved object compressed: {}", obj.compressed);
-            if obj.compressed {
-                let mut out = Vec::new();
-                match ::zstd::stream::copy_decode(&obj.data[..], &mut out) {
-                    Ok(_) => Some(out),
-                    Err(_) => None,
-                }
-            } else {
-                Some(obj.data)
-            }
-        }
+        Ok((obj, _)) => Some(obj), // TODO: not this; stream instead
         Err(e) => {
             tracing::warn!("Unable to locate object with key {}: {:?}", key, e);
             None

--- a/spog/search/src/vuln.rs
+++ b/spog/search/src/vuln.rs
@@ -18,6 +18,7 @@ pub async fn search(state: web::Data<SharedState>, params: web::Query<QueryParam
     let mut ret: Vec<serde_json::Value> = Vec::new();
     let storage = state.storage.read().await;
 
+    // TODO: stream these
     for key in result.iter() {
         if let Some(obj) = fetch_object(&storage, &key).await {
             if let Ok(data) = serde_json::from_slice(&obj[..]) {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -10,3 +10,4 @@ anyhow = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
 bincode = "1.3.3"
+futures = "0.3"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 [dependencies]
 rust-s3 = "0.33"
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
 anyhow = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
 bincode = "1.3.3"
 futures = "0.3"
+bytes = "1"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -10,6 +10,7 @@ tokio-util = "0.7"
 anyhow = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
-bincode = "1.3.3"
 futures = "0.3"
 bytes = "1"
+http = "0.2"
+async-stream = "0.3"

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,15 +1,18 @@
-use std::fmt::Display;
-use std::{collections::HashMap, marker::Unpin};
+use std::marker::Unpin;
+use std::{collections::HashMap, fmt::Display};
 
+use async_stream::try_stream;
 use bytes::{Buf, Bytes};
-use futures::{Stream, TryStreamExt};
+use futures::future::ok;
+use futures::stream::once;
+use futures::{Stream, StreamExt};
 use s3::creds::error::CredentialsError;
 pub use s3::creds::Credentials;
 use s3::error::S3Error;
 use s3::Bucket;
 pub use s3::Region;
-use serde::{Deserialize, Serialize};
-use tokio_util::io::{ReaderStream, StreamReader};
+use serde::Deserialize;
+use tokio_util::io::StreamReader;
 
 pub enum StorageType {
     Minio,
@@ -71,7 +74,6 @@ pub enum Error {
     Credentials(CredentialsError),
     S3(S3Error),
     Io(std::io::Error),
-    Codec(bincode::Error),
 }
 
 impl Display for Error {
@@ -81,7 +83,6 @@ impl Display for Error {
             Self::Credentials(e) => write!(f, "{}", e),
             Self::S3(e) => write!(f, "{}", e),
             Self::Io(e) => write!(f, "{}", e),
-            Self::Codec(e) => write!(f, "{}", e),
         }
     }
 }
@@ -106,64 +107,23 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<bincode::Error> for Error {
-    fn from(e: bincode::Error) -> Self {
-        Self::Codec(e)
+impl From<http::header::InvalidHeaderName> for Error {
+    fn from(_: http::header::InvalidHeaderName) -> Self {
+        Self::Internal
+    }
+}
+
+impl From<http::header::InvalidHeaderValue> for Error {
+    fn from(_: http::header::InvalidHeaderValue) -> Self {
+        Self::Internal
     }
 }
 
 const DATA_PATH: &str = "/data/";
 const INDEX_PATH: &str = "/index";
-const SBOM_PATH: &str = "/sbom/";
+const METADATA_PREFIX: &str = "x-amz-meta-";
 
 const VERSION: u32 = 1;
-
-#[derive(Serialize, Deserialize)]
-pub struct Object<'a> {
-    version: u32,
-    pub key: &'a str,
-    pub compressed: bool,
-    pub annotations: HashMap<&'a str, &'a str>,
-    pub data: Vec<u8>,
-}
-
-impl<'a> Object<'a> {
-    pub fn new(key: &'a str, annotations: HashMap<&'a str, &'a str>, data: Option<&'a [u8]>, compressed: bool) -> Self {
-        Self {
-            version: VERSION,
-            key,
-            compressed,
-            data: match data {
-                Some(d) => d.to_vec(),
-                None => Vec::new(),
-            },
-            annotations,
-        }
-    }
-
-    fn to_owned(self) -> OwnedObject {
-        let mut annotations = HashMap::new();
-        for (key, value) in self.annotations.iter() {
-            annotations.insert(key.to_string(), value.to_string());
-        }
-        OwnedObject {
-            version: self.version,
-            compressed: self.compressed,
-            key: self.key.to_string(),
-            annotations,
-            data: self.data,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct OwnedObject {
-    version: u32,
-    pub key: String,
-    pub compressed: bool,
-    pub annotations: HashMap<String, String>,
-    pub data: Vec<u8>,
-}
 
 impl Storage {
     pub fn new(config: Config, stype: StorageType) -> Result<Self, Error> {
@@ -186,40 +146,77 @@ impl Storage {
         key.strip_prefix(&self.prefix)
     }
 
-    pub async fn put(&self, key: &str, value: Object<'_>) -> Result<(), Error> {
-        let path = format!("{}{}", DATA_PATH, key);
-        let value = bincode::serialize(&value)?;
-        self.bucket.put_object(path, &value).await?;
-        Ok(())
+    pub async fn put_slice<'a>(
+        &self,
+        key: &'a str,
+        annotations: HashMap<&'a str, &'a str>,
+        content_type: &str,
+        data: &'a [u8],
+    ) -> Result<u16, Error> {
+        self.put_stream(key, annotations, content_type, &mut once(ok::<_, std::io::Error>(data)))
+            .await
     }
 
-    pub async fn put_stream<S, B, E>(&self, key: &str, value: Object<'_>, s: &mut S) -> Result<u16, Error>
+    pub async fn put_stream<S, B, E>(
+        &self,
+        key: &str,
+        annotations: HashMap<&str, &str>,
+        content_type: &str,
+        stream: &mut S,
+    ) -> Result<u16, Error>
     where
         S: Stream<Item = Result<B, E>> + Unpin,
         B: Buf,
         E: Into<std::io::Error>,
     {
-        let mut reader = StreamReader::new(s);
-        self.put(key, value).await?;
-        let path = format!("{}{}", SBOM_PATH, key);
-        Ok(self.bucket.put_object_stream(&mut reader, path).await?)
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-amz-meta-version", VERSION.into());
+        for (k, v) in annotations {
+            headers.insert(
+                http::HeaderName::try_from(format!("{METADATA_PREFIX}{k}"))?,
+                http::HeaderValue::from_str(v)?,
+            );
+        }
+        let bucket = self.bucket.with_extra_headers(headers);
+        let mut reader = StreamReader::new(stream);
+        let path = format!("{}{}", DATA_PATH, key);
+        Ok(bucket
+            .put_object_stream_with_content_type(&mut reader, path, content_type)
+            .await?)
     }
 
-    pub async fn get(&self, key: &str) -> Result<OwnedObject, Error> {
+    // This will load the entire S3 object into memory
+    pub async fn get(&self, key: &str) -> Result<(Vec<u8>, HashMap<String, String>), Error> {
         let path = format!("{}{}", DATA_PATH, key);
         let data = self.bucket.get_object(path).await?;
-        let value: Object<'_> = bincode::deserialize(&data.as_slice())?;
-        Ok(value.to_owned())
+        let metadata = data
+            .headers()
+            .iter()
+            .filter_map(|(k, v)| k.strip_prefix(METADATA_PREFIX).map(|k| (k.to_owned(), v.to_owned())))
+            .collect();
+        Ok((data.to_vec(), metadata))
     }
 
-    pub async fn get_stream(&self, key: &str) -> impl Stream<Item = Result<Bytes, Error>> {
-        let path = format!("{}{}", SBOM_PATH, key);
-        let (mut asyncwriter, asyncreader) = tokio::io::duplex(256 * 1024);
-        let bucket = self.bucket.clone(); // TODO: can i avoid this?
-        tokio::task::spawn(async move {
-            let _ = bucket.get_object_to_writer(path, &mut asyncwriter).await;
-        });
-        ReaderStream::new(asyncreader).err_into::<Error>()
+    // Returns a tuple of content-type and byte stream
+    pub async fn get_stream(
+        &self,
+        key: &str,
+    ) -> Result<(Option<String>, impl Stream<Item = Result<Bytes, Error>>), Error> {
+        let path = format!("{}{}", DATA_PATH, key);
+        let (head, _status) = self.bucket.head_object(&path).await?;
+        let mut s = self.bucket.get_object_stream(&path).await?;
+        let stream = try_stream! {
+            while let Some(chunk) = s.bytes().next().await {
+                yield chunk;
+            }
+        };
+        Ok((head.content_type, stream))
+    }
+
+    pub async fn get_metadata(&self, key: &str) -> Result<HashMap<String, String>, Error> {
+        let path = format!("{}{}", DATA_PATH, key);
+        let (head, _status) = self.bucket.head_object(&path).await?;
+        Ok(head.metadata.unwrap_or(HashMap::new()))
     }
 
     pub async fn put_index(&self, index: &[u8]) -> Result<(), Error> {

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -2,12 +2,13 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use actix_web::http::header::ContentType;
 use actix_web::middleware::Logger;
 use actix_web::web::{self, Bytes};
 use actix_web::{App, HttpResponse, HttpServer, Responder};
 use serde::Deserialize;
 use tokio::sync::{Mutex, RwLock};
-use trustification_storage::{Object, Storage};
+use trustification_storage::Storage;
 
 struct AppState {
     storage: RwLock<Storage>,
@@ -39,18 +40,10 @@ pub async fn run<B: Into<SocketAddr>>(storage: Storage, bind: B) -> Result<(), a
 }
 
 async fn fetch_object(storage: &Storage, key: &str) -> HttpResponse {
-    match storage.get(&key).await {
-        Ok(obj) => {
-            tracing::trace!("Retrieved object compressed: {}", obj.compressed);
-            if obj.compressed {
-                let mut out = Vec::new();
-                match ::zstd::stream::copy_decode(&obj.data[..], &mut out) {
-                    Ok(_) => HttpResponse::Ok().body(out),
-                    Err(_) => HttpResponse::InternalServerError().body("Unable to decode object"),
-                }
-            } else {
-                HttpResponse::Ok().body(obj.data)
-            }
+    match storage.get_stream(key).await {
+        Ok((ctype, stream)) => {
+            let ctype = ctype.unwrap_or(ContentType::json().to_string());
+            HttpResponse::Ok().content_type(ctype).streaming(stream)
         }
         Err(e) => {
             tracing::warn!("Unable to locate object with key {}: {:?}", key, e);
@@ -106,14 +99,11 @@ async fn publish_vex(state: web::Data<SharedState>, params: web::Query<PublishPa
     };
 
     let storage = state.storage.write().await;
-    let mut out = Vec::new();
-    let (data, compressed) = match zstd::stream::copy_encode(&data[..], &mut out, 3) {
-        Ok(_) => (&out[..], true),
-        Err(_) => (&data[..], false),
-    };
-    tracing::debug!("Storing new VEX with id: {}, compressed: {}", advisory, compressed);
-    let value = Object::new(&advisory, std::collections::HashMap::new(), Some(data), compressed);
-    match storage.put(&advisory, value).await {
+    tracing::debug!("Storing new VEX with id: {advisory}");
+    match storage
+        .put_slice(&advisory, std::collections::HashMap::new(), "application/json", &data)
+        .await
+    {
         Ok(_) => {
             let msg = format!("VEX of size {} stored successfully", &data[..].len());
             tracing::trace!(msg);

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -112,7 +112,7 @@ async fn publish_vex(state: web::Data<SharedState>, params: web::Query<PublishPa
         Err(_) => (&data[..], false),
     };
     tracing::debug!("Storing new VEX with id: {}, compressed: {}", advisory, compressed);
-    let value = Object::new(&advisory, std::collections::HashMap::new(), data, compressed);
+    let value = Object::new(&advisory, std::collections::HashMap::new(), Some(data), compressed);
     match storage.put(&advisory, value).await {
         Ok(_) => {
             let msg = format!("VEX of size {} stored successfully", &data[..].len());

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -11,7 +11,7 @@ use tantivy::collector::Count;
 use tantivy::collector::TopDocs;
 use tantivy::directory::MmapDirectory;
 use tantivy::directory::INDEX_WRITER_LOCK;
-use tantivy::query::{BooleanQuery, Occur, Query, RangeQuery, TermQuery, TermSetQuery};
+use tantivy::query::{BooleanQuery, Occur, Query, RangeQuery, TermQuery};
 use tantivy::schema::{Term, *};
 use tantivy::Directory;
 use tantivy::Index as SearchIndex;

--- a/vexination/indexer/src/indexer.rs
+++ b/vexination/indexer/src/indexer.rs
@@ -31,50 +31,35 @@ pub async fn run<E: EventBus>(
                             if data.event_type == EventType::Put {
                                 if storage.is_index(&data.key) {
                                     tracing::trace!("It's an index event, ignoring");
-                                } else {
-                                    if let Some(key) = storage.extract_key(&data.key) {
-                                        match storage.get(key).await {
-                                            Ok(obj) => {
-                                                let data = if obj.compressed {
-                                                    let mut out = Vec::new();
-                                                    match ::zstd::stream::copy_decode(&obj.data[..], &mut out) {
-                                                        Ok(_) => out,
-                                                        Err(e) => {
-                                                            tracing::warn!("Error decompressing data: {:?}", e);
-                                                            continue;
-                                                        }
+                                } else if let Some(key) = storage.extract_key(&data.key) {
+                                    match storage.get(key).await {
+                                        Ok((data, _)) => {
+                                            if let Ok(doc) = serde_json::from_slice(&data) {
+                                                match indexer.as_mut().unwrap().index(&mut index, &doc) {
+                                                    Ok(_) => {
+                                                        tracing::trace!("Inserted entry into index");
+                                                        bus.send(indexed_topic, key.as_bytes()).await?;
+                                                        events += 1;
                                                     }
-                                                } else {
-                                                    obj.data
-                                                };
-
-                                                if let Ok(doc) = serde_json::from_slice(&data) {
-                                                    match indexer.as_mut().unwrap().index(&mut index, &doc) {
-                                                        Ok(_) => {
-                                                            tracing::trace!("Inserted entry into index");
-                                                            bus.send(indexed_topic, key.as_bytes()).await?;
-                                                            events += 1;
-                                                        }
-                                                        Err(e) => {
-                                                            let failure = serde_json::json!( {
-                                                                "key": key,
-                                                                "error": e.to_string(),
-                                                            }).to_string();
-                                                            bus.send(failed_topic, failure.as_bytes()).await?;
-                                                            tracing::warn!("Error inserting entry into index: {:?}", e)
-                                                        }
+                                                    Err(e) => {
+                                                        let failure = serde_json::json!( {
+                                                            "key": key,
+                                                            "error": e.to_string(),
+                                                        }).to_string();
+                                                        bus.send(failed_topic, failure.as_bytes()).await?;
+                                                        tracing::warn!("Error inserting entry into index: {:?}", e)
                                                     }
-                                                } else {
-                                                    tracing::debug!("Error parsing object as CSAF");
                                                 }
-                                            }
-                                            Err(e) => {
-                                                tracing::debug!("Error retrieving document event data, ignoring (error: {:?})", e);
+                                            } else {
+                                                tracing::debug!("Error parsing object as CSAF");
                                             }
                                         }
-                                    } else {
-                                        tracing::warn!("Error extracting key from event: {:?}", data)
+                                        Err(e) => {
+                                            tracing::debug!("Error retrieving document event data, ignoring (error: {:?})", e);
+                                        }
                                     }
+                                } else {
+                                    tracing::warn!("Error extracting key from event: {:?}", data)
                                 }
                             }
                         } else if let Err(e) = storage.decode_event(&payload) {

--- a/vexination/walker/src/server.rs
+++ b/vexination/walker/src/server.rs
@@ -41,7 +41,7 @@ pub async fn run(storage: Storage, source: url::Url, options: ValidationOptions)
                                 annotations.insert("sha512", sha512.expected.as_str());
                             }
 
-                            let value = Object::new(&key, annotations, data, compressed);
+                            let value = Object::new(&key, annotations, Some(data), compressed);
                             match storage.put(&key, value).await {
                                 Ok(_) => {
                                     let msg = format!("VEX ({}) of size {} stored successfully", key, &data[..].len());

--- a/vexination/walker/src/server.rs
+++ b/vexination/walker/src/server.rs
@@ -11,7 +11,7 @@ use csaf_walker::{
 };
 use serde::Deserialize;
 use tokio::sync::{Mutex, RwLock};
-use trustification_storage::{Object, Storage};
+use trustification_storage::Storage;
 
 pub async fn run(storage: Storage, source: url::Url, options: ValidationOptions) -> Result<(), anyhow::Error> {
     let fetcher = Fetcher::new(Default::default()).await?;
@@ -27,11 +27,6 @@ pub async fn run(storage: Storage, source: url::Url, options: ValidationOptions)
                         Ok(doc) => {
                             let key = doc.document.tracking.id;
 
-                            let mut out = Vec::new();
-                            let (data, compressed) = match zstd::stream::copy_encode(&data[..], &mut out, 3) {
-                                Ok(_) => (&out[..], true),
-                                Err(_) => (&data[..], false),
-                            };
                             let mut annotations = std::collections::HashMap::new();
                             if let Some(sha256) = &retrieved.sha256 {
                                 annotations.insert("sha256", sha256.expected.as_str());
@@ -41,8 +36,7 @@ pub async fn run(storage: Storage, source: url::Url, options: ValidationOptions)
                                 annotations.insert("sha512", sha512.expected.as_str());
                             }
 
-                            let value = Object::new(&key, annotations, Some(data), compressed);
-                            match storage.put(&key, value).await {
+                            match storage.put_slice(&key, annotations, "application/json", &data).await {
                                 Ok(_) => {
                                     let msg = format!("VEX ({}) of size {} stored successfully", key, &data[..].len());
                                     tracing::info!(msg);


### PR DESCRIPTION
Fixes #21 

Streamed uploads are triggered by the presence of the `Transfer-Encoding: chunked` request header. No compression nor parsing of the SBOM occurs, hence the `purl` and `sha256` query params are required.

Streamed downloads are denoted by an empty `data` field in the `Object` meta struct associated with the SBOM.