### PR TITLE
fix: remove cvss from default fields for the moment

### DIFF
--- a/vexination/index/src/search.rs
+++ b/vexination/index/src/search.rs
@@ -15,7 +15,6 @@ pub enum Vulnerabilities<'a> {
     Status(Primary<'a>),
     #[search(default)]
     Severity(Primary<'a>),
-    #[search(default)]
     Cvss(PartialOrdered<f64>),
     #[search(default)]
     Package(Primary<'a>),


### PR DESCRIPTION
@ctron Temporary until we've figured out what to do with the expression parsing.