### PR TITLE
feat: refactor spog to use vexination HTTP API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5269,6 +5269,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "csaf",
  "futures",
  "hex",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4319,6 +4319,7 @@ dependencies = [
  "actix-ws",
  "anyhow",
  "bombastic-model",
+ "bytes",
  "chrono",
  "clap",
  "env_logger 0.10.0",
@@ -4338,13 +4339,10 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "trustification-index",
  "trustification-infrastructure",
- "trustification-storage",
  "urlencoding",
  "utoipa",
  "utoipa-swagger-ui",
- "vexination-index",
  "vexination-model",
  "zstd",
 ]
@@ -5237,8 +5235,11 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "trustification-index",
  "trustification-infrastructure",
  "trustification-storage",
+ "vexination-index",
+ "vexination-model",
  "zstd",
 ]
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -21,7 +21,7 @@ To run the API processes, you can use cargo:
 ```shell
 RUST_LOG=info cargo run -p trust -- vexination api --devmode -p 8081 &
 RUST_LOG=info cargo run -p trust -- bombastic api --devmode -p 8082 &
-RUST_LOG=info cargo run -p trust -- spog api --devmode -p 8083 &
+RUST_LOG=info cargo run -p trust -- spog api -p 8083 &
 ```
 
 ## Indexing

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -64,7 +64,7 @@ RUST_LOG=info cargo run -p trust -- vexination walker --devmode --source file://
 At this point, you can POST and GET SBOMs with the API using a pURL for the id. To ingest a small-ish SBOM:
 
 ```shell
-curl -X POST --json @bombastic/testdata/my-sbom.json http://localhost:8082/api/v1/sbom
+curl -X POST --json @bombastic/testdata/my-sbom.json http://localhost:8082/api/v1/sbom?id=my-sbom
 ```
 For large SBOM's, you must use a "chunked" `Transfer-Encoding` and explicitly pass the pURL:
 ```shell
@@ -110,10 +110,11 @@ The indexer will automatically sync the index to the S3 bucket, while the API wi
 
 ## Searching
 
-You can search all the data using the `spog-api` endpoint:
+You can search all the data using the `bombastic-api` or `vexination-api` endpoints:
 
 ```shell
-curl "http://localhost:8083/vuln/?q=openssl"
+curl "http://localhost:8082/api/v1/sbom/search?q=openssl"
+curl "http://localhost:8081/api/v1/vex/search?q=openssl"
 ```
 
 ## Working with local images

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ use that information to learn impact of vulnerabilities and dependency changes.
 * [Bombastic](bombastic/README.md) - Storage and archival of SBOM documents.
 * [Vexination](vexination/README.md) - Storage and archival of VEX documents.
 * [Reservoir](reservoir/README.md) - Managing product metadata and access control.
+* [Spog](spog/README.md) - Single Pane Of Glass API and frontend.
+
+
+Check the README files for individual components for more detailed information.
 
 ## Running locally
 
@@ -24,15 +28,13 @@ docker-compose -f compose.yaml -f compose-trustification.yaml -f compose-guac.ya
 
 This will start MinIO and Kafka for object storage and eventing and then run all the trustification services. It will also start to ingest data from Red Hat sources automatically via the vexination-walker and (TODO bombastic-walker) processes.
 
-## Usage
+You can also run all of the trustification services via a single binary named `trust` or using the container image `ghcr.io/trustification/trust`. 
 
-### Searching
+You can also try out the publicly hosted instance at [https://trustification.dev](https://trustification.dev).
 
-You can search all the data using the `spog-search` endpoint:
+## Developing
 
-```shell
-curl "http://localhost:8083/?q=bind"
-```
+See [DEVELOPMENT](DEVELOPMENT.md) for running the different components while developing.
 
 ## Building
 

--- a/bombastic/api/src/lib.rs
+++ b/bombastic/api/src/lib.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
-use std::{net::SocketAddr, process::ExitCode, str::FromStr, time::Duration};
+use std::{net::SocketAddr, process::ExitCode, str::FromStr, sync::Arc, time::Duration};
+
 use tokio::sync::RwLock;
 use trustification_index::IndexStore;
 use trustification_infrastructure::{Infrastructure, InfrastructureConfig};

--- a/bombastic/api/src/lib.rs
+++ b/bombastic/api/src/lib.rs
@@ -71,17 +71,17 @@ impl Run {
         tokio::task::spawn(async move {
             loop {
                 if sinker.sync_index().await.is_ok() {
-                    tracing::info!("Initial index synced");
+                    tracing::info!("Initial bombastic index synced");
                     break;
                 } else {
-                    tracing::warn!("Index not yet available");
+                    tracing::warn!("Bombastic index not yet available");
                 }
                 tokio::time::sleep(Duration::from_secs(5)).await;
             }
 
             loop {
                 if let Err(e) = sinker.sync_index().await {
-                    tracing::info!("Unable to synchronize index: {:?}", e);
+                    tracing::info!("Unable to synchronize bombastic index: {:?}", e);
                 }
                 tokio::time::sleep(sync_interval).await;
             }
@@ -108,7 +108,7 @@ impl AppState {
 
         let mut index = self.index.write().await;
         index.reload(&data[..])?;
-        tracing::info!("Index reloaded");
+        tracing::debug!("Bombastic index reloaded");
         Ok(())
     }
 }

--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -150,7 +150,7 @@ const fn default_limit() -> usize {
 async fn search_sbom(state: web::Data<SharedState>, params: web::Query<SearchParams>) -> impl Responder {
     let params = params.into_inner();
 
-    tracing::info!("Querying SBOMusing {}", params.q);
+    tracing::info!("Querying SBOM using {}", params.q);
 
     let index = state.index.read().await;
     let result = index.search(&params.q, params.offset, params.limit);

--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -18,8 +18,7 @@ use trustification_storage::Storage;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::sbom::SBOM;
-use crate::SharedState;
+use crate::{sbom::SBOM, SharedState};
 
 #[derive(OpenApi)]
 #[openapi(paths(query_sbom, publish_sbom, search_sbom))]

--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -1,5 +1,6 @@
-use bombastic_model::prelude::*;
 use core::str::FromStr;
+
+use bombastic_model::prelude::*;
 use cyclonedx_bom::models::{component::Classification, hash::HashAlgorithm};
 use search::*;
 use sikula::prelude::*;
@@ -7,9 +8,11 @@ use spdx_rs::models::Algorithm;
 use tracing::{debug, info, warn};
 use trustification_index::{
     create_boolean_query, primary2occur,
-    tantivy::doc,
-    tantivy::query::{Occur, Query},
-    tantivy::schema::{Field, Schema, Term, FAST, STORED, STRING, TEXT},
+    tantivy::{
+        doc,
+        query::{Occur, Query},
+        schema::{Field, Schema, Term, FAST, STORED, STRING, TEXT},
+    },
     term2query, Document, Error as SearchError,
 };
 

--- a/bombastic/indexer/src/indexer.rs
+++ b/bombastic/indexer/src/indexer.rs
@@ -42,9 +42,9 @@ pub async fn run<E: EventBus>(
                                     } else {
                                         let key = data.key();
                                         match storage.get_for_event(&data).await {
-                                            Ok(data) => {
+                                            Ok((k, data)) => {
                                                 if let Ok(doc) = bombastic_index::SBOM::parse(&data) {
-                                                    match indexer.as_mut().unwrap().index(index.index(), &doc) {
+                                                    match indexer.as_mut().unwrap().index(index.index(), &k, &doc) {
                                                         Ok(_) => {
                                                             tracing::trace!("Inserted entry into index");
                                                             bus.send(indexed_topic, key.as_bytes()).await?;

--- a/bombastic/model/src/search.rs
+++ b/bombastic/model/src/search.rs
@@ -1,5 +1,6 @@
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq)]
 pub struct SearchDocument {
+    pub sbom_id: String,
     pub dependent: String,
     pub name: String,
     pub purl: String,

--- a/deploy/k8s/spog/api/030-Deployment.yaml
+++ b/deploy/k8s/spog/api/030-Deployment.yaml
@@ -20,37 +20,19 @@ spec:
         app.kubernetes.io/component: api
         app.kubernetes.io/part-of: spog
     spec:
-      volumes:
-        - name: data
-          emptyDir: {}
       containers:
         - image: ghcr.io/trustification/trust:latest
           imagePullPolicy: Always
           name: service
           command: ["/trust"]
-          args: ["spog", "api", "-p", "8080"]
+          args: ["spog", "api", "-p", "8080", "--bombastic-url", "http://bombastic-api", "--vexination-url", "http://vexination-api"]
           env:
             - name: RUST_LOG
               value: info
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: vexination-credentials-secret
-                  key: access-key-id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: vexination-credentials-secret
-                  key: secret-access-key
-            - name: AWS_REGION
-              value: "eu-west-1"
             - name: INFRASTRUCTURE_ENABLED
               value: "true"
             - name: INFRASTRUCTURE_BIND
               value: "[::]:9010"
-          volumeMounts:
-            - name: data
-              mountPath: /data
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -26,7 +26,7 @@ pub trait Index {
     fn schema(&self) -> Schema;
     fn prepare_query(&self, q: &str) -> Result<Box<dyn Query>, Error>;
     fn process_hit(&self, doc: Document) -> Result<Self::MatchedDocument, Error>;
-    fn index_doc(&self, document: &Self::Document) -> Result<Vec<Document>, Error>;
+    fn index_doc(&self, id: &str, document: &Self::Document) -> Result<Vec<Document>, Error>;
 }
 
 #[derive(Debug)]
@@ -67,8 +67,8 @@ pub struct Indexer {
 }
 
 impl Indexer {
-    pub fn index<INDEX: Index>(&mut self, index: &mut INDEX, raw: &INDEX::Document) -> Result<(), Error> {
-        let docs = index.index_doc(raw)?;
+    pub fn index<INDEX: Index>(&mut self, index: &mut INDEX, id: &str, raw: &INDEX::Document) -> Result<(), Error> {
+        let docs = index.index_doc(id, raw)?;
         for doc in docs {
             self.writer.add_document(doc)?;
         }

--- a/reservoir/api/src/lib.rs
+++ b/reservoir/api/src/lib.rs
@@ -1,2 +1,4 @@
+#![allow(unused_variables)]
+#![allow(dead_code)]
 mod package;
 mod pattern;

--- a/rustfmt.nightly.toml
+++ b/rustfmt.nightly.toml
@@ -1,0 +1,3 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+max_width=120

--- a/spog/api/Cargo.toml
+++ b/spog/api/Cargo.toml
@@ -35,12 +35,10 @@ snyk = { git = "https://github.com/dejanb/snyk-rs.git", branch = "main" }
 tracing = "0.1"
 zstd = "0.12"
 rand = "0.8"
+bytes = "1"
 
 #guac = { path = "../guac-rs/lib" }
 spog-model = { path = "../model" }
-vexination-index = { path = "../../vexination/index" }
 vexination-model = { path = "../../vexination/model" }
 bombastic-model = { path = "../../bombastic/model" }
-trustification-storage = { path = "../../storage" }
-trustification-index = { path = "../../index" }
 trustification-infrastructure = { path = "../../infrastructure" }

--- a/spog/api/src/lib.rs
+++ b/spog/api/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, process::ExitCode};
+use std::process::ExitCode;
 
 use trustification_infrastructure::{Infrastructure, InfrastructureConfig};
 
@@ -27,20 +27,14 @@ pub struct Run {
     #[arg(short = 'g', long = "guac", default_value = "http://localhost:8080/query")]
     pub(crate) guac_url: String,
 
-    #[arg(short = 'i', long = "index")]
-    pub(crate) index: Option<PathBuf>,
-
     #[arg(long = "sync-interval-seconds", default_value_t = 10)]
     pub(crate) sync_interval_seconds: u64,
 
-    #[arg(long = "devmode", default_value_t = false)]
-    pub(crate) devmode: bool,
-
-    #[arg(long = "storage-endpoint", default_value = None)]
-    pub(crate) storage_endpoint: Option<String>,
-
     #[arg(long = "bombastic-url", default_value = "http://localhost:8082")]
     pub(crate) bombastic_url: reqwest::Url,
+
+    #[arg(long = "vexination-url", default_value = "http://localhost:8081")]
+    pub(crate) vexination_url: reqwest::Url,
 
     #[command(flatten)]
     pub(crate) infra: InfrastructureConfig,

--- a/spog/api/src/sbom.rs
+++ b/spog/api/src/sbom.rs
@@ -40,10 +40,14 @@ pub async fn search(state: web::Data<SharedState>, params: web::Query<search::Qu
                     if !entry.dependents.contains(&item.dependent) {
                         entry.dependents.push(item.dependent);
                     }
+                    if !entry.sboms.contains(&item.sbom_id) {
+                        entry.sboms.push(item.sbom_id);
+                    }
                 } else {
                     m.insert(
                         item.purl.clone(),
                         PackageSummary {
+                            sboms: vec![item.sbom_id],
                             purl: item.purl,
                             name: item.name,
                             sha256: item.sha256,

--- a/spog/api/src/sbom.rs
+++ b/spog/api/src/sbom.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
 use actix_web::{web, web::ServiceConfig, HttpResponse, Responder};
-use http::StatusCode;
 use spog_model::search::{PackageSummary, SearchResult};
-use tracing::{info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::{search, server::SharedState};
 
@@ -21,20 +20,8 @@ pub struct GetParams {
 
 pub async fn get(state: web::Data<SharedState>, params: web::Query<GetParams>) -> impl Responder {
     let params = params.into_inner();
-
-    let client = reqwest::Client::new();
-    let url = if let Ok(url) = state.bombastic.join("/api/v1/sbom") {
-        url
-    } else {
-        warn!("Error constructing bombastic search URL");
-        return HttpResponse::InternalServerError().finish();
-    };
-    match client.get(url).query(&[("id", &params.id)]).send().await {
-        Ok(response) => {
-            return HttpResponse::Ok()
-                .status(response.status())
-                .streaming(response.bytes_stream())
-        }
+    match state.get_sbom(&params.id).await {
+        Ok(response) => return HttpResponse::Ok().streaming(response),
         Err(e) => {
             warn!("Error lookup in bombastic: {:?}", e);
             HttpResponse::InternalServerError().finish()
@@ -45,81 +32,53 @@ pub async fn get(state: web::Data<SharedState>, params: web::Query<GetParams>) -
 pub async fn search(state: web::Data<SharedState>, params: web::Query<search::QueryParams>) -> HttpResponse {
     let params = params.into_inner();
     trace!("Querying SBOM using {}", params.q);
-    let client = reqwest::Client::new();
-
-    let url = if let Ok(url) = state.bombastic.join("/api/v1/sbom/search") {
-        url
-    } else {
-        warn!("Error constructing bombastic search URL");
-        return HttpResponse::InternalServerError().finish();
-    };
-    match client
-        .get(url)
-        .query(&[("q", &params.q)])
-        .query(&[("offset", params.offset), ("limit", params.limit)])
-        .send()
-        .await
-    {
-        Ok(response) => {
-            if response.status() == StatusCode::OK {
-                match response.json::<bombastic_model::prelude::SearchResult>().await {
-                    Ok(mut data) => {
-                        let mut m: HashMap<String, PackageSummary> = HashMap::new();
-                        for item in data.result.drain(..) {
-                            if let Some(entry) = m.get_mut(&item.purl) {
-                                if !entry.dependents.contains(&item.dependent) {
-                                    entry.dependents.push(item.dependent);
-                                }
-                            } else {
-                                m.insert(
-                                    item.purl.clone(),
-                                    PackageSummary {
-                                        purl: item.purl,
-                                        name: item.name,
-                                        sha256: item.sha256,
-                                        license: item.license,
-                                        classifier: item.classifier,
-                                        supplier: item.supplier,
-                                        description: item.description,
-                                        dependents: vec![item.dependent],
-                                        vulnerabilities: Vec::new(),
-                                    },
-                                );
-                            }
-                        }
-
-                        let mut result = SearchResult::<Vec<PackageSummary>> {
-                            total: Some(m.len()),
-                            result: m.values().cloned().collect(),
-                        };
-
-                        search_vulnerabilities(state, &mut result.result).await;
-                        info!("Search result: {:?}", result);
-                        HttpResponse::Ok().json(result)
+    match state.search_sbom(&params.q, params.offset, params.limit).await {
+        Ok(mut data) => {
+            let mut m: HashMap<String, PackageSummary> = HashMap::new();
+            for item in data.result.drain(..) {
+                if let Some(entry) = m.get_mut(&item.purl) {
+                    if !entry.dependents.contains(&item.dependent) {
+                        entry.dependents.push(item.dependent);
                     }
-                    Err(e) => {
-                        warn!("Error deserializing bombastic result: {:?}", e);
-                        HttpResponse::InternalServerError().finish()
-                    }
+                } else {
+                    m.insert(
+                        item.purl.clone(),
+                        PackageSummary {
+                            purl: item.purl,
+                            name: item.name,
+                            sha256: item.sha256,
+                            license: item.license,
+                            classifier: item.classifier,
+                            supplier: item.supplier,
+                            description: item.description,
+                            dependents: vec![item.dependent],
+                            vulnerabilities: Vec::new(),
+                        },
+                    );
                 }
-            } else {
-                return HttpResponse::Ok().status(response.status()).finish();
             }
+
+            let mut result = SearchResult::<Vec<PackageSummary>> {
+                total: Some(m.len()),
+                result: m.values().cloned().collect(),
+            };
+
+            search_vulnerabilities(state, &mut result.result).await;
+            debug!("Search result: {:?}", result);
+            HttpResponse::Ok().json(result)
         }
         Err(e) => {
-            warn!("Error searching bombastic: {:?}", e);
+            warn!("Error querying bombastic: {:?}", e);
             HttpResponse::InternalServerError().finish()
         }
     }
 }
 
 async fn search_vulnerabilities(state: web::Data<SharedState>, packages: &mut Vec<PackageSummary>) {
-    let state = &state.vex;
-    let index = state.index.read().await;
     for package in packages {
         let q = format!("affected:\"{}\"", package.purl);
-        if let Ok(result) = index.search(&q, 0, 1000) {
-            for summary in result.0 {
+        if let Ok(result) = state.search_vex(&q, 0, 1000).await {
+            for summary in result.result {
                 package.vulnerabilities.push(summary.cve);
             }
         }

--- a/spog/api/src/server.rs
+++ b/spog/api/src/server.rs
@@ -1,7 +1,8 @@
+use std::sync::Arc;
+
 use actix_cors::Cors;
 use actix_web::{middleware::Logger, web, App, HttpServer};
 use http::StatusCode;
-use std::sync::Arc;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 

--- a/spog/api/src/vulnerability.rs
+++ b/spog/api/src/vulnerability.rs
@@ -2,8 +2,6 @@ use std::collections::HashMap;
 
 use actix_web::{web, web::ServiceConfig, HttpResponse, Responder};
 use spog_model::search::{SearchResult, VulnSummary};
-use trustification_index::IndexStore;
-use vexination_model::prelude::*;
 
 use crate::{search::QueryParams, server::SharedState};
 
@@ -18,17 +16,17 @@ pub(crate) fn configure() -> impl FnOnce(&mut ServiceConfig) {
 pub async fn search(state: web::Data<SharedState>, params: web::Query<QueryParams>) -> impl Responder {
     let params = params.into_inner();
     tracing::info!("Querying VEX using {}", params.q);
-    let state = &state.vex;
 
-    let index = state.index.read().await;
-    let result = search_vex(&index, &params.q, params.offset, params.limit.min(MAX_LIMIT)).await;
+    let result = state
+        .search_vex(&params.q, params.offset, params.limit.min(MAX_LIMIT))
+        .await;
 
-    let mut result = match result {
+    let (total, mut result) = match result {
         Err(e) => {
             tracing::info!("Error searching: {:?}", e);
             return HttpResponse::InternalServerError().body(e.to_string());
         }
-        Ok(result) => result,
+        Ok(result) => (result.total, result.result),
     };
 
     // Deduplicate data
@@ -56,16 +54,7 @@ pub async fn search(state: web::Data<SharedState>, params: web::Query<QueryParam
     }
 
     HttpResponse::Ok().json(SearchResult::<Vec<VulnSummary>> {
-        total: result.total,
+        total: Some(total),
         result: m.values().cloned().collect(),
     })
-}
-
-async fn search_vex(
-    index: &IndexStore<vexination_index::Index>,
-    q: &str,
-    offset: usize,
-    limit: usize,
-) -> anyhow::Result<SearchResult<Vec<SearchDocument>>> {
-    Ok(index.search(q, offset, limit)?.into())
 }

--- a/spog/model/src/search.rs
+++ b/spog/model/src/search.rs
@@ -22,6 +22,7 @@ pub struct PackageSummary {
     pub description: String,
     pub supplier: String,
     pub dependents: Vec<String>,
+    pub sboms: Vec<String>,
     pub vulnerabilities: Vec<String>,
 }
 

--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -1560,6 +1560,7 @@ dependencies = [
  "thiserror",
  "time 0.3.20",
  "url",
+ "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-logger",

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -15,6 +15,7 @@ gloo-utils = "0.1"
 itertools = "0.10"
 log = "0.4"
 packageurl = "0.3"
+urlencoding = "2"
 patternfly-yew = { version = "0.5.0-alpha.1", features = ["icons-fab", "tree"] }
 reqwest = { version = "0.11", features = ["json"] }
 roxmltree = "0.18"

--- a/spog/ui/src/about.rs
+++ b/spog/ui/src/about.rs
@@ -1,6 +1,7 @@
-use crate::hooks::use_backend;
 use patternfly_yew::prelude::*;
 use yew::prelude::*;
+
+use crate::hooks::use_backend;
 
 #[function_component(About)]
 pub fn about() -> Html {

--- a/spog/ui/src/app.rs
+++ b/spog/ui/src/app.rs
@@ -1,7 +1,8 @@
-use crate::{components::backend::Backend, console::Console, pages::AppRoute};
 use patternfly_yew::prelude::*;
 use yew::prelude::*;
 use yew_nested_router::prelude::*;
+
+use crate::{components::backend::Backend, console::Console, pages::AppRoute};
 
 const DEFAULT_BACKEND_URL: &str = "/.well-known/chicken/backend.json";
 

--- a/spog/ui/src/backend/mod.rs
+++ b/spog/ui/src/backend/mod.rs
@@ -10,9 +10,8 @@ mod vuln;
 
 pub use pkg::*;
 pub use sbom::*;
-pub use vuln::*;
-
 use url::{ParseError, Url};
+pub use vuln::*;
 use yew::html::IntoPropValue;
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/spog/ui/src/backend/pkg.rs
+++ b/spog/ui/src/backend/pkg.rs
@@ -1,11 +1,12 @@
+use packageurl::PackageUrl;
+use serde::Deserialize;
+use spog_model::prelude::*;
+
 use super::{Backend, Error};
 use crate::backend::{
     data::{Package, PackageDependencies, PackageDependents, PackageList, PackageRef},
     Endpoint, SearchOptions,
 };
-use packageurl::PackageUrl;
-use serde::Deserialize;
-use spog_model::prelude::*;
 
 pub struct PackageService {
     backend: Backend,

--- a/spog/ui/src/backend/sbom.rs
+++ b/spog/ui/src/backend/sbom.rs
@@ -1,6 +1,7 @@
+use url::Url;
+
 use super::{Backend, Error};
 use crate::backend::Endpoint;
-use url::Url;
 
 #[allow(unused)]
 pub struct SBOMService {

--- a/spog/ui/src/backend/vuln.rs
+++ b/spog/ui/src/backend/vuln.rs
@@ -1,8 +1,8 @@
-use super::{Backend, Error};
-use crate::backend::data::Vulnerability;
-use crate::backend::Endpoint;
 use reqwest::{RequestBuilder, StatusCode};
 use spog_model::prelude::*;
+
+use super::{Backend, Error};
+use crate::backend::{data::Vulnerability, Endpoint};
 
 pub struct VexService {
     backend: Backend,

--- a/spog/ui/src/components/advisory.rs
+++ b/spog/ui/src/components/advisory.rs
@@ -1,25 +1,23 @@
-use crate::backend::{Endpoint, SearchOptions, VexService};
-use crate::hooks::use_backend;
+use std::rc::Rc;
+
 use csaf::Csaf;
 use details::CsafDetails;
 use patternfly_yew::{
     next::{
         use_table_data, Cell, CellContext, ColumnWidth, MemoizedTableModel, Table, TableColumn, TableEntryRenderer,
-        TableHeader, UseTableData,
+        TableHeader, Toolbar, ToolbarContent, UseTableData,
     },
     prelude::*,
 };
-use patternfly_yew::{
-    next::{Toolbar, ToolbarContent},
-    prelude::*,
-};
 use spog_model::prelude::*;
-use spog_model::prelude::*;
-use std::rc::Rc;
 use url::{ParseError, Url};
 use yew::prelude::*;
-use yew::prelude::*;
 use yew_more_hooks::hooks::{use_async_with_cloned_deps, UseAsyncHandleDeps};
+
+use crate::{
+    backend::{Endpoint, SearchOptions, VexService},
+    hooks::use_backend,
+};
 
 #[derive(PartialEq, Properties)]
 pub struct AdvisorySearchProperties {
@@ -290,16 +288,16 @@ pub fn vulnerability_result(props: &AdvisoryResultProperties) -> Html {
 
 mod details {
 
-    use crate::{components::cvss::CvssScore, utils::cvss::Cvss};
-    use csaf::definitions::Branch;
-    use csaf::product_tree::ProductTree;
-    use csaf::{vulnerability::Vulnerability, Csaf};
+    use std::rc::Rc;
+
+    use csaf::{definitions::Branch, product_tree::ProductTree, vulnerability::Vulnerability, Csaf};
     use patternfly_yew::{
         next::{use_table_data, MemoizedTableModel, Table, TableColumn, TableEntryRenderer, TableHeader, UseTableData},
         prelude::*,
     };
-    use std::rc::Rc;
     use yew::prelude::*;
+
+    use crate::{components::cvss::CvssScore, utils::cvss::Cvss};
 
     #[derive(Clone, Properties)]
     pub struct CsafDetailsProps {

--- a/spog/ui/src/components/backend.rs
+++ b/spog/ui/src/components/backend.rs
@@ -1,8 +1,10 @@
-use crate::{backend::Endpoints, components::error::Error};
 use std::rc::Rc;
+
 use web_sys::RequestCache;
 use yew::prelude::*;
 use yew_more_hooks::hooks::r#async::*;
+
+use crate::{backend::Endpoints, components::error::Error};
 
 #[derive(Clone, Debug, PartialEq, Properties)]
 pub struct BackendProperties {

--- a/spog/ui/src/components/cvss.rs
+++ b/spog/ui/src/components/cvss.rs
@@ -1,6 +1,7 @@
-use crate::utils::cvss::{Cvss, Severity};
 use patternfly_yew::prelude::*;
 use yew::prelude::*;
+
+use crate::utils::cvss::{Cvss, Severity};
 
 #[derive(Clone, Debug, PartialEq, Properties)]
 pub struct CvssScoreProperties {

--- a/spog/ui/src/components/mod.rs
+++ b/spog/ui/src/components/mod.rs
@@ -9,8 +9,9 @@ pub mod error;
 pub mod package;
 pub mod vulnerability;
 
-use patternfly_yew::prelude::*;
 use std::ops::Deref;
+
+use patternfly_yew::prelude::*;
 use yew::prelude::*;
 use yew_more_hooks::prelude::{UseAsyncHandleDeps, UseAsyncState};
 

--- a/spog/ui/src/components/vulnerability.rs
+++ b/spog/ui/src/components/vulnerability.rs
@@ -1,19 +1,22 @@
-use crate::backend::{SearchOptions, VexService};
-use crate::hooks::use_backend;
-use crate::pages::AppRoute;
-use patternfly_yew::next::{
-    use_table_data, Cell, CellContext, ColumnWidth, MemoizedTableModel, Table, TableColumn, TableEntryRenderer,
-    TableHeader, UseTableData,
-};
+use std::rc::Rc;
+
 use patternfly_yew::{
-    next::{Toolbar, ToolbarContent},
+    next::{
+        use_table_data, Cell, CellContext, ColumnWidth, MemoizedTableModel, Table, TableColumn, TableEntryRenderer,
+        TableHeader, Toolbar, ToolbarContent, UseTableData,
+    },
     prelude::*,
 };
 use spog_model::prelude::*;
-use std::rc::Rc;
 use yew::prelude::*;
 use yew_more_hooks::hooks::{use_async_with_cloned_deps, UseAsyncHandleDeps};
 use yew_nested_router::components::Link;
+
+use crate::{
+    backend::{SearchOptions, VexService},
+    hooks::use_backend,
+    pages::AppRoute,
+};
 
 #[derive(PartialEq, Properties)]
 pub struct VulnerabilitySearchProperties {

--- a/spog/ui/src/console.rs
+++ b/spog/ui/src/console.rs
@@ -1,13 +1,14 @@
+use patternfly_yew::prelude::*;
+use yew::prelude::*;
+use yew_more_hooks::prelude::*;
+use yew_nested_router::prelude::Switch as RouterSwitch;
+
 use crate::{
     about,
     backend::Endpoint,
     hooks::use_backend,
     pages::{self, AppRoute},
 };
-use patternfly_yew::prelude::*;
-use yew::prelude::*;
-use yew_more_hooks::prelude::*;
-use yew_nested_router::prelude::Switch as RouterSwitch;
 
 #[function_component(Console)]
 pub fn console() -> Html {

--- a/spog/ui/src/hooks.rs
+++ b/spog/ui/src/hooks.rs
@@ -1,6 +1,8 @@
-use crate::backend::Backend;
 use std::rc::Rc;
+
 use yew::prelude::*;
+
+use crate::backend::Backend;
 
 /// Get the backend instance. **Panics** if called from a component not nested somewhere under
 /// the [`crate::components::backend::Backend`] component.

--- a/spog/ui/src/pages/advisory/mod.rs
+++ b/spog/ui/src/pages/advisory/mod.rs
@@ -1,10 +1,16 @@
-use crate::components::{advisory::AdvisoryResult, advisory::AdvisorySearch, common::PageHeading, error::Error};
+use std::rc::Rc;
+
 use csaf::Csaf;
 use patternfly_yew::prelude::*;
 use spog_model::search::SearchResult;
-use std::rc::Rc;
 use yew::prelude::*;
 use yew_more_hooks::hooks::{UseAsyncHandleDeps, UseAsyncState};
+
+use crate::components::{
+    advisory::{AdvisoryResult, AdvisorySearch},
+    common::PageHeading,
+    error::Error,
+};
 
 // FIXME: use a different API and representation
 

--- a/spog/ui/src/pages/chicken.rs
+++ b/spog/ui/src/pages/chicken.rs
@@ -1,6 +1,7 @@
-use crate::components::common::PageHeading;
 use patternfly_yew::prelude::*;
 use yew::prelude::*;
+
+use crate::components::common::PageHeading;
 
 #[function_component(Chicken)]
 pub fn chicken() -> Html {

--- a/spog/ui/src/pages/index.rs
+++ b/spog/ui/src/pages/index.rs
@@ -1,9 +1,10 @@
-use crate::components::common::PageHeading;
 use patternfly_yew::{
     next::{Card, CardBody},
     prelude::*,
 };
 use yew::prelude::*;
+
+use crate::components::common::PageHeading;
 
 #[function_component(Index)]
 pub fn index() -> Html {

--- a/spog/ui/src/pages/mod.rs
+++ b/spog/ui/src/pages/mod.rs
@@ -12,9 +12,9 @@ mod vulnerability;
 pub use advisory::*;
 pub use chicken::*;
 pub use index::*;
-pub use package::*;
 // pub use sbom::*;
 pub use package::Package;
+pub use package::*;
 pub use vulnerability::Vulnerability;
 
 #[derive(Clone, Debug, PartialEq, Eq, Target)]

--- a/spog/ui/src/pages/package/mod.rs
+++ b/spog/ui/src/pages/package/mod.rs
@@ -1,12 +1,5 @@
-use crate::backend::{data::PackageRef, VexService};
-use crate::components::{
-    common::PageHeading,
-    cvss::CvssScore,
-    error::Error,
-    package::{PackageResult, PackageSearch},
-};
-use crate::hooks::use_backend;
-use crate::pages::AppRoute;
+use std::{rc::Rc, str::FromStr};
+
 use csaf::Csaf;
 use packageurl::PackageUrl;
 use patternfly_yew::{
@@ -14,10 +7,20 @@ use patternfly_yew::{
     prelude::*,
 };
 use spog_model::prelude::*;
-use std::rc::Rc;
-use std::str::FromStr;
 use yew::prelude::*;
 use yew_more_hooks::hooks::r#async::*;
+
+use crate::{
+    backend::{data::PackageRef, VexService},
+    components::{
+        common::PageHeading,
+        cvss::CvssScore,
+        error::Error,
+        package::{PackageResult, PackageSearch},
+    },
+    hooks::use_backend,
+    pages::AppRoute,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Properties)]
 pub struct PackageProps {

--- a/spog/ui/src/pages/vulnerability/mod.rs
+++ b/spog/ui/src/pages/vulnerability/mod.rs
@@ -1,12 +1,5 @@
-use crate::backend::{data::PackageRef, VexService};
-use crate::components::{
-    common::PageHeading,
-    cvss::CvssScore,
-    error::Error,
-    vulnerability::{VulnerabilityResult, VulnerabilitySearch},
-};
-use crate::hooks::use_backend;
-use crate::pages::AppRoute;
+use std::{rc::Rc, str::FromStr};
+
 use csaf::Csaf;
 use packageurl::PackageUrl;
 use patternfly_yew::{
@@ -14,10 +7,20 @@ use patternfly_yew::{
     prelude::*,
 };
 use spog_model::prelude::*;
-use std::rc::Rc;
-use std::str::FromStr;
 use yew::prelude::*;
 use yew_more_hooks::hooks::r#async::*;
+
+use crate::{
+    backend::{data::PackageRef, VexService},
+    components::{
+        common::PageHeading,
+        cvss::CvssScore,
+        error::Error,
+        vulnerability::{VulnerabilityResult, VulnerabilitySearch},
+    },
+    hooks::use_backend,
+    pages::AppRoute,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Properties)]
 pub struct VulnerabilityProps {

--- a/spog/ui/src/utils/cvss.rs
+++ b/spog/ui/src/utils/cvss.rs
@@ -1,5 +1,6 @@
-use spog_model::vuln::Cvss3;
 use std::str::FromStr;
+
+use spog_model::vuln::Cvss3;
 use yew::html::IntoPropValue;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/vexination/api/Cargo.toml
+++ b/vexination/api/Cargo.toml
@@ -12,6 +12,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 trustification-infrastructure = { path = "../../infrastructure" }
 trustification-storage = { path = "../../storage" }
+trustification-index = { path = "../../index" }
+vexination-index = { path = "../index" }
+vexination-model = { path = "../model" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 zstd = "0.12"

--- a/vexination/api/src/lib.rs
+++ b/vexination/api/src/lib.rs
@@ -1,9 +1,12 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+use std::sync::Arc;
 use std::{net::SocketAddr, path::PathBuf, process::ExitCode, str::FromStr, time::Duration};
-
+use tokio::sync::RwLock;
+use trustification_index::IndexStore;
 use trustification_infrastructure::{Infrastructure, InfrastructureConfig};
+use trustification_storage::Storage;
 
 mod server;
 
@@ -15,6 +18,12 @@ pub struct Run {
 
     #[arg(short = 'p', long = "port", default_value_t = 8080)]
     pub(crate) port: u16,
+
+    #[arg(short = 'i', long = "index")]
+    pub(crate) index: Option<std::path::PathBuf>,
+
+    #[arg(long = "sync-interval-seconds", default_value_t = 10)]
+    pub(crate) sync_interval_seconds: u64,
 
     #[arg(long = "devmode", default_value_t = false)]
     pub(crate) devmode: bool,
@@ -28,15 +37,80 @@ pub struct Run {
 
 impl Run {
     pub async fn run(self) -> anyhow::Result<ExitCode> {
+        let state = self.configure()?;
         Infrastructure::from(self.infra)
             .run(|| async {
-                let storage = trustification_storage::create("vexination", self.devmode, self.storage_endpoint)?;
                 let addr = SocketAddr::from_str(&format!("{}:{}", self.bind, self.port))?;
 
-                server::run(storage, addr).await
+                server::run(state, addr).await
             })
             .await?;
 
         Ok(ExitCode::SUCCESS)
+    }
+
+    fn configure(&self) -> anyhow::Result<Arc<AppState>> {
+        let vexination_dir = self.index.clone().unwrap_or_else(|| {
+            use rand::RngCore;
+            let r = rand::thread_rng().next_u32();
+            std::env::temp_dir().join(format!("vexination-index.{}", r))
+        });
+
+        std::fs::create_dir(&vexination_dir)?;
+
+        let vexination_index = IndexStore::new(&vexination_dir, vexination_index::Index::new())?;
+        let vexination_storage =
+            trustification_storage::create("vexination", self.devmode, self.storage_endpoint.clone())?;
+
+        let state = Arc::new(AppState {
+            storage: RwLock::new(vexination_storage),
+            index: RwLock::new(vexination_index),
+        });
+
+        let sync_interval = Duration::from_secs(self.sync_interval_seconds);
+
+        let sinker = state.clone();
+        tokio::task::spawn(async move {
+            loop {
+                if sinker.sync_index().await.is_ok() {
+                    tracing::info!("Initial vexination index synced");
+                    break;
+                } else {
+                    tracing::warn!("Vexination index not yet available");
+                }
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+
+            loop {
+                if let Err(e) = sinker.sync_index().await {
+                    tracing::info!("Unable to synchronize vexination index: {:?}", e);
+                }
+                tokio::time::sleep(sync_interval).await;
+            }
+        });
+
+        Ok(state)
+    }
+}
+
+pub(crate) type Index = IndexStore<vexination_index::Index>;
+pub struct AppState {
+    storage: RwLock<Storage>,
+    index: RwLock<Index>,
+}
+
+pub(crate) type SharedState = Arc<AppState>;
+
+impl AppState {
+    async fn sync_index(&self) -> Result<(), anyhow::Error> {
+        let data = {
+            let storage = self.storage.read().await;
+            storage.get_index().await?
+        };
+
+        let mut index = self.index.write().await;
+        index.reload(&data[..])?;
+        tracing::debug!("Vexination index reloaded");
+        Ok(())
     }
 }

--- a/vexination/api/src/lib.rs
+++ b/vexination/api/src/lib.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
-use std::sync::Arc;
-use std::{net::SocketAddr, path::PathBuf, process::ExitCode, str::FromStr, time::Duration};
+use std::{net::SocketAddr, path::PathBuf, process::ExitCode, str::FromStr, sync::Arc, time::Duration};
+
 use tokio::sync::RwLock;
 use trustification_index::IndexStore;
 use trustification_infrastructure::{Infrastructure, InfrastructureConfig};

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -1,6 +1,5 @@
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
-use crate::SharedState;
 use actix_web::{
     http::header::{self, ContentType},
     middleware::{Compress, Logger},
@@ -11,6 +10,8 @@ use serde::Deserialize;
 use tokio::sync::{Mutex, RwLock};
 use trustification_storage::Storage;
 use vexination_model::prelude::*;
+
+use crate::SharedState;
 
 pub async fn run<B: Into<SocketAddr>>(state: SharedState, bind: B) -> Result<(), anyhow::Error> {
     let addr = bind.into();

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -425,7 +425,7 @@ mod tests {
         let index = Index::new();
         let mut store = IndexStore::new_in_memory(index).unwrap();
         let mut writer = store.indexer().unwrap();
-        writer.index(store.index(), &csaf).unwrap();
+        writer.index(store.index(), &csaf.document.tracking.id, &csaf).unwrap();
         writer.commit().unwrap();
         f(store);
     }

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -53,9 +53,8 @@ impl trustification_index::Index for Index {
     type MatchedDocument = SearchDocument;
     type Document = Csaf;
 
-    fn index_doc(&self, csaf: &Csaf) -> Result<Vec<Document>, SearchError> {
+    fn index_doc(&self, id: &str, csaf: &Csaf) -> Result<Vec<Document>, SearchError> {
         let mut documents = Vec::new();
-        let id = &csaf.document.tracking.id;
         let document_status = match &csaf.document.tracking.status {
             csaf::document::Status::Draft => "draft",
             csaf::document::Status::Interim => "interim",
@@ -65,7 +64,7 @@ impl trustification_index::Index for Index {
         if let Some(vulns) = &csaf.vulnerabilities {
             for vuln in vulns {
                 let mut document = doc!(
-                    self.fields.id => id.as_str(),
+                    self.fields.id => id,
                     self.fields.document_status => document_status,
                 );
 

--- a/vexination/indexer/Cargo.toml
+++ b/vexination/indexer/Cargo.toml
@@ -17,6 +17,7 @@ trustification-event-bus = { path = "../../event-bus", features = ["kafka"] }
 trustification-infrastructure = { path = "../../infrastructure" }
 trustification-storage = { path = "../../storage" }
 trustification-index = { path = "../../index" }
+csaf = "0.5"
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 futures = "0.3"

--- a/vexination/indexer/src/indexer.rs
+++ b/vexination/indexer/src/indexer.rs
@@ -42,9 +42,9 @@ pub async fn run<E: EventBus>(
                                     } else {
                                         let key = data.key();
                                         match storage.get_for_event(&data).await {
-                                            Ok(data) => {
-                                                if let Ok(doc) = serde_json::from_slice(&data) {
-                                                    match indexer.as_mut().unwrap().index(index.index(), &doc) {
+                                            Ok((_, data)) => {
+                                                if let Ok(doc) = serde_json::from_slice::<csaf::Csaf>(&data) {
+                                                    match indexer.as_mut().unwrap().index(index.index(), &doc.document.tracking.id, &doc) {
                                                         Ok(_) => {
                                                             tracing::debug!("Inserted entry into index");
                                                             bus.send(indexed_topic, key.as_bytes()).await?;

--- a/vexination/model/src/search.rs
+++ b/vexination/model/src/search.rs
@@ -9,3 +9,9 @@ pub struct SearchDocument {
     pub affected: Vec<String>,
     pub fixed: Vec<String>,
 }
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq)]
+pub struct SearchResult {
+    pub total: usize,
+    pub result: Vec<SearchDocument>,
+}


### PR DESCRIPTION
This removes the strong coupling between spog and S3 + index, and allows evolving the storage and index for bombastic and vexination independently of spog.
