### PR TITLE
feat: add advisory summary to use in frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4655,6 +4655,7 @@ dependencies = [
  "serde",
  "serde_json",
  "time 0.3.21",
+ "url",
  "urlencoding",
  "utoipa",
  "vexination-model",

--- a/bombastic/model/src/search.rs
+++ b/bombastic/model/src/search.rs
@@ -9,6 +9,7 @@ pub struct SearchDocument {
     pub supplier: String,
     pub classifier: String,
     pub description: String,
+    pub snippet: String,
     pub created: time::OffsetDateTime,
 }
 

--- a/spog/api/src/advisory.rs
+++ b/spog/api/src/advisory.rs
@@ -70,11 +70,13 @@ pub async fn search(state: web::Data<SharedState>, params: web::Query<QueryParam
 
     // Dedup data
     let mut m: HashMap<String, AdvisorySummary> = HashMap::new();
+    let mut collapsed = 0;
 
     for item in result.result.drain(..) {
         if let Some(entry) = m.get_mut(&item.advisory_id) {
             if !entry.cves.contains(&item.cve_id) {
                 entry.cves.push(item.cve_id);
+                collapsed += 1;
             }
         } else {
             m.insert(
@@ -93,7 +95,7 @@ pub async fn search(state: web::Data<SharedState>, params: web::Query<QueryParam
     }
 
     HttpResponse::Ok().json(SearchResult::<Vec<AdvisorySummary>> {
-        total: Some(result.total),
+        total: Some(result.total - collapsed),
         result: m.values().cloned().collect(),
     })
 }

--- a/spog/api/src/sbom.rs
+++ b/spog/api/src/sbom.rs
@@ -76,6 +76,7 @@ pub async fn search(state: web::Data<SharedState>, params: web::Query<search::Qu
                             sha256: item.sha256,
                             license: item.license,
                             classifier: item.classifier,
+                            snippet: item.snippet,
                             supplier: item.supplier.trim_start_matches("Organization: ").to_string(),
                             description: item.description,
                             dependents: vec![item.dependent],
@@ -90,6 +91,7 @@ pub async fn search(state: web::Data<SharedState>, params: web::Query<search::Qu
                 result: m.values().cloned().collect(),
             };
 
+            // TODO: Use guac to lookup vulnerabilities for each package!
             search_vulnerabilities(state, &mut result.result).await;
             debug!("Search result: {:?}", result);
             HttpResponse::Ok().json(result)
@@ -106,7 +108,7 @@ async fn search_vulnerabilities(state: web::Data<SharedState>, packages: &mut Ve
         let q = format!("affected:\"{}\"", package.purl);
         if let Ok(result) = state.search_vex(&q, 0, 1000).await {
             for summary in result.result {
-                package.vulnerabilities.push(summary.cve);
+                package.vulnerabilities.push(summary.cve_id);
             }
         }
 

--- a/spog/api/src/vulnerability.rs
+++ b/spog/api/src/vulnerability.rs
@@ -17,7 +17,7 @@ pub(crate) fn configure() -> impl FnOnce(&mut ServiceConfig) {
     get,
     path = "/api/v1/vulnerability/search",
     responses(
-        (status = 200, description = "Search was performed successfully", body = Pet),
+        (status = 200, description = "Search was performed successfully", body = SearchResult<Vec<VulnSummary>>),
     ),
     params(
         ("q" = String, Path, description = "Search query"),
@@ -44,22 +44,22 @@ pub async fn search(state: web::Data<SharedState>, params: web::Query<QueryParam
     // Deduplicate data
     let mut m: HashMap<String, VulnSummary> = HashMap::new();
     for item in result.drain(..) {
-        if let Some(entry) = m.get_mut(&item.cve) {
-            if !entry.advisories.contains(&item.advisory) {
-                entry.advisories.push(item.advisory);
+        if let Some(entry) = m.get_mut(&item.cve_id) {
+            if !entry.advisories.contains(&item.advisory_id) {
+                entry.advisories.push(item.advisory_id);
             }
         } else {
             m.insert(
-                item.cve.clone(),
+                item.cve_id.clone(),
                 VulnSummary {
-                    cve: item.cve,
-                    advisories: vec![item.advisory],
-                    title: item.title,
-                    description: item.description,
-                    release: item.release,
-                    cvss: item.cvss,
-                    affected: item.affected,
-                    fixed: item.fixed,
+                    id: item.cve_id,
+                    desc: item.cve_desc,
+                    advisories: vec![item.advisory_id],
+                    title: item.cve_title,
+                    snippet: item.cve_snippet,
+                    release: item.cve_release,
+                    cvss: item.cve_cvss,
+                    // TODO: Fetch packages affected by this advisory from guac?
                 },
             );
         }

--- a/spog/model/Cargo.toml
+++ b/spog/model/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1", features = ["derive"] }
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 vexination-model = { path = "../../vexination/model" }
 time = { version = "0.3" }
+url = "2"
 
 # required by ToSchema utopia
 serde_json = "1"

--- a/spog/model/src/search.rs
+++ b/spog/model/src/search.rs
@@ -1,14 +1,24 @@
 use std::ops::{Deref, DerefMut};
 
 #[derive(utoipa::ToSchema, serde::Deserialize, serde::Serialize, Debug, PartialEq, Clone)]
-pub struct VulnSummary {
-    pub cve: String,
+pub struct AdvisorySummary {
+    pub id: String,
     pub title: String,
+    pub snippet: String,
+    pub desc: String,
+    pub date: time::OffsetDateTime,
+    pub cves: Vec<String>,
+    pub href: String,
+}
+
+#[derive(utoipa::ToSchema, serde::Deserialize, serde::Serialize, Debug, PartialEq, Clone)]
+pub struct VulnSummary {
+    pub id: String,
+    pub title: String,
+    pub desc: String,
     pub release: time::OffsetDateTime,
-    pub description: String,
-    pub cvss: f64,
-    pub affected: Vec<String>,
-    pub fixed: Vec<String>,
+    pub cvss: Option<f64>,
+    pub snippet: String,
     pub advisories: Vec<String>,
 }
 
@@ -18,6 +28,7 @@ pub struct PackageSummary {
     pub name: String,
     pub sha256: String,
     pub license: String,
+    pub snippet: String,
     pub classifier: String,
     pub description: String,
     pub supplier: String,

--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -1532,6 +1532,7 @@ dependencies = [
  "serde",
  "serde_json",
  "time 0.3.20",
+ "url",
  "urlencoding",
  "utoipa",
  "vexination-model",

--- a/spog/ui/src/backend/vuln.rs
+++ b/spog/ui/src/backend/vuln.rs
@@ -2,7 +2,7 @@ use reqwest::{RequestBuilder, StatusCode};
 use spog_model::prelude::*;
 
 use super::{Backend, Error};
-use crate::backend::{data::Vulnerability, Endpoint};
+use crate::backend::Endpoint;
 
 pub struct VexService {
     backend: Backend,
@@ -37,11 +37,10 @@ impl VexService {
         }
     }
 
-    pub async fn lookup(&self, advisory: &String) -> Result<Option<csaf::Csaf>, Error> {
+    pub async fn lookup(&self, advisory: &AdvisorySummary) -> Result<Option<csaf::Csaf>, Error> {
         let response = self
             .client
-            .get(self.backend.join(Endpoint::Api, "/api/v1/advisory")?)
-            .query(&[("advisory", advisory.to_string())])
+            .get(self.backend.join(Endpoint::Api, &advisory.href)?)
             .send()
             .await?;
 
@@ -74,7 +73,7 @@ impl VexService {
         &self,
         q: &str,
         options: &SearchOptions,
-    ) -> Result<SearchResult<Vec<csaf::Csaf>>, Error> {
+    ) -> Result<SearchResult<Vec<AdvisorySummary>>, Error> {
         let request = self
             .client
             .get(self.backend.join(Endpoint::Api, "/api/v1/advisory/search")?)

--- a/spog/ui/src/components/common.rs
+++ b/spog/ui/src/components/common.rs
@@ -21,3 +21,16 @@ pub fn page_heading(props: &PageHeadingProperties) -> Html {
         </PageSection>
     )
 }
+
+#[derive(Properties, PartialEq)]
+pub struct Props {
+    pub html: String,
+}
+
+#[function_component(SafeHtml)]
+pub fn safe_html(props: &Props) -> Html {
+    let div = gloo_utils::document().create_element("div").unwrap();
+    div.set_inner_html(&props.html.clone());
+
+    Html::VRef(div.into())
+}

--- a/spog/ui/src/components/package.rs
+++ b/spog/ui/src/components/package.rs
@@ -16,6 +16,7 @@ use yew_nested_router::components::Link;
 
 use crate::{
     backend::{Endpoint, PackageService, SearchOptions},
+    components::common::SafeHtml,
     hooks::use_backend,
     pages::AppRoute,
     utils::last_weeks_date,
@@ -41,7 +42,7 @@ pub fn package_search(props: &PackageSearchProperties) -> Html {
     let limit = use_state_eq(|| 10);
 
     // Default is SBOM created past weeks
-    let default_query = format!("created:>{}", last_weeks_date());
+    let _default_query = format!("created:>{}", last_weeks_date());
 
     // the active query
     let state = use_state_eq(|| {
@@ -206,7 +207,6 @@ pub enum Column {
     Name,
     Supplier,
     Products,
-    Description,
     Vulnerabilities,
     Version,
 }
@@ -223,7 +223,6 @@ impl TableEntryRenderer<Column> for PackageEntry {
             Column::Name => html!(&self.package.name).into(),
             Column::Supplier => html!(&self.package.supplier).into(),
             Column::Products => html!(&self.package.dependents.len()).into(),
-            Column::Description => html!(&self.package.description).into(),
             Column::Vulnerabilities => {
                 html!(<Link<AppRoute> target={AppRoute::Vulnerability { query: format!("affected:\"{}\"", self.package.purl)}}>{self.package.vulnerabilities.len()}</Link<AppRoute>>).into()
             }
@@ -271,12 +270,11 @@ pub fn package_result(props: &PackageResultProperties) -> Html {
 
     let header = html_nested! {
         <TableHeader<Column>>
-            <TableColumn<Column> label="Name" index={Column::Name} width={ColumnWidth::Percent(10)}/>
-            <TableColumn<Column> label="Version" index={Column::Version} width={ColumnWidth::Percent(15)}/>
-            <TableColumn<Column> label="Supplier" index={Column::Supplier} width={ColumnWidth::Percent(10)}/>
-            <TableColumn<Column> label="Products" index={Column::Products} width={ColumnWidth::Percent(10)}/>
-            <TableColumn<Column> label="Description" index={Column::Description} width={ColumnWidth::Percent(40)}/>
-            <TableColumn<Column> label="Vulnerabilities" index={Column::Vulnerabilities} width={ColumnWidth::Percent(15)}/>
+            <TableColumn<Column> label="Name" index={Column::Name} width={ColumnWidth::Percent(15)}/>
+            <TableColumn<Column> label="Version" index={Column::Version} width={ColumnWidth::Percent(20)}/>
+            <TableColumn<Column> label="Supplier" index={Column::Supplier} width={ColumnWidth::Percent(20)}/>
+            <TableColumn<Column> label="Products" index={Column::Products} width={ColumnWidth::Percent(20)}/>
+            <TableColumn<Column> label="Vulnerabilities" index={Column::Vulnerabilities} width={ColumnWidth::Percent(25)}/>
         </TableHeader<Column>>
     };
 
@@ -289,8 +287,6 @@ pub fn package_result(props: &PackageResultProperties) -> Html {
          />
     )
 }
-
-use yew::prelude::*;
 
 #[derive(Clone, Properties)]
 pub struct PackageDetailsProps {
@@ -322,10 +318,13 @@ pub fn package_details(props: &PackageDetailsProps) -> Html {
         })
         .collect::<Vec<sboms::SbomTableEntry>>();
     let sboms = Rc::new(sboms);
+    let snippet = package.package.snippet.clone();
     html!(
         <Panel>
             <PanelMain>
-            <PanelMainBody>{&package.package.description}</PanelMainBody>
+            <PanelMainBody>
+            <SafeHtml html={snippet} />
+            </PanelMainBody>
             </PanelMain>
             <PanelFooter>
             <h3>{"Related SBOMs"}</h3>
@@ -344,8 +343,6 @@ mod sboms {
     };
     use url::Url;
     use yew::prelude::*;
-
-    use super::*;
 
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum Column {

--- a/spog/ui/src/components/vulnerability.rs
+++ b/spog/ui/src/components/vulnerability.rs
@@ -14,6 +14,7 @@ use yew_nested_router::components::Link;
 
 use crate::{
     backend::{SearchOptions, VexService},
+    components::common::SafeHtml,
     components::cvss::CvssScore,
     hooks::use_backend,
     pages::AppRoute,
@@ -212,7 +213,7 @@ pub enum Column {
 impl TableEntryRenderer<Column> for VulnSummary {
     fn render_cell(&self, context: &CellContext<'_, Column>) -> Cell {
         match context.column {
-            Column::Cve => html!(&self.cve).into(),
+            Column::Cve => html!(&self.id).into(),
             Column::Title => html!(&self.title).into(),
             Column::Released => {
                 let format = time::macros::format_description!("[year]-[month]-[day]");
@@ -224,11 +225,15 @@ impl TableEntryRenderer<Column> for VulnSummary {
                 html!(s).into()
             }
             Column::Cvss => {
-                let cvss = Cvss {
-                    score: self.cvss as f32,
-                    status: String::new(),
-                };
-                html!(<CvssScore {cvss}/>).into()
+                if let Some(cvss) = self.cvss {
+                    let cvss = Cvss {
+                        score: cvss as f32,
+                        status: String::new(),
+                    };
+                    html!(<CvssScore {cvss}/>).into()
+                } else {
+                    html!({ "N/A" }).into()
+                }
             }
         }
     }
@@ -266,8 +271,6 @@ pub fn vulnerability_result(props: &VulnResultProperties) -> Html {
     )
 }
 
-use yew::prelude::*;
-
 #[derive(Clone, Properties)]
 pub struct VulnDetailsProps {
     pub vuln: Rc<VulnSummary>,
@@ -292,10 +295,13 @@ pub fn vuln_details(props: &VulnDetailsProps) -> Html {
             )
         })
         .collect::<Vec<Html>>();
+    let snippet = summary.snippet.clone();
     html!(
         <Panel>
             <PanelMain>
-            <PanelMainBody>{&summary.description}</PanelMainBody>
+            <PanelMainBody>
+            <SafeHtml html={snippet} />
+            </PanelMainBody>
             </PanelMain>
             <PanelFooter>
             <h3>{"Related Advisories"}</h3>

--- a/spog/ui/src/pages/advisory/mod.rs
+++ b/spog/ui/src/pages/advisory/mod.rs
@@ -1,8 +1,7 @@
 use std::rc::Rc;
 
-use csaf::Csaf;
 use patternfly_yew::prelude::*;
-use spog_model::search::SearchResult;
+use spog_model::prelude::*;
 use yew::prelude::*;
 use yew_more_hooks::hooks::{UseAsyncHandleDeps, UseAsyncState};
 
@@ -25,9 +24,11 @@ pub fn advisory(props: &AdvisoryProps) -> Html {
     let search = use_state_eq(UseAsyncState::default);
     let callback = {
         let search = search.clone();
-        Callback::from(move |state: UseAsyncHandleDeps<SearchResult<Rc<Vec<Csaf>>>, String>| {
-            search.set((*state).clone());
-        })
+        Callback::from(
+            move |state: UseAsyncHandleDeps<SearchResult<Rc<Vec<AdvisorySummary>>>, String>| {
+                search.set((*state).clone());
+            },
+        )
     };
     let query = if let Some(props) = &props.query {
         if props.is_empty() {

--- a/spog/ui/src/pages/package/mod.rs
+++ b/spog/ui/src/pages/package/mod.rs
@@ -1,25 +1,14 @@
-use std::{rc::Rc, str::FromStr};
+use std::rc::Rc;
 
-use csaf::Csaf;
-use packageurl::PackageUrl;
-use patternfly_yew::{
-    next::{Card, CardBody, CardDivider},
-    prelude::*,
-};
+use patternfly_yew::prelude::*;
 use spog_model::prelude::*;
 use yew::prelude::*;
 use yew_more_hooks::hooks::r#async::*;
 
-use crate::{
-    backend::{data::PackageRef, VexService},
-    components::{
-        common::PageHeading,
-        cvss::CvssScore,
-        error::Error,
-        package::{PackageResult, PackageSearch},
-    },
-    hooks::use_backend,
-    pages::AppRoute,
+use crate::components::{
+    common::PageHeading,
+    error::Error,
+    package::{PackageResult, PackageSearch},
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Properties)]

--- a/spog/ui/src/pages/vulnerability/mod.rs
+++ b/spog/ui/src/pages/vulnerability/mod.rs
@@ -1,25 +1,14 @@
-use std::{rc::Rc, str::FromStr};
+use std::rc::Rc;
 
-use csaf::Csaf;
-use packageurl::PackageUrl;
-use patternfly_yew::{
-    next::{Card, CardBody, CardDivider},
-    prelude::*,
-};
+use patternfly_yew::prelude::*;
 use spog_model::prelude::*;
 use yew::prelude::*;
 use yew_more_hooks::hooks::r#async::*;
 
-use crate::{
-    backend::{data::PackageRef, VexService},
-    components::{
-        common::PageHeading,
-        cvss::CvssScore,
-        error::Error,
-        vulnerability::{VulnerabilityResult, VulnerabilitySearch},
-    },
-    hooks::use_backend,
-    pages::AppRoute,
+use crate::components::{
+    common::PageHeading,
+    error::Error,
+    vulnerability::{VulnerabilityResult, VulnerabilitySearch},
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Properties)]

--- a/vexination/model/src/search.rs
+++ b/vexination/model/src/search.rs
@@ -1,13 +1,17 @@
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq)]
 pub struct SearchDocument {
-    pub advisory: String,
-    pub cve: String,
-    pub title: String,
-    pub release: time::OffsetDateTime,
-    pub description: String,
-    pub cvss: f64,
-    pub affected: Vec<String>,
-    pub fixed: Vec<String>,
+    pub advisory_id: String,
+    pub advisory_title: String,
+    pub advisory_date: time::OffsetDateTime,
+    pub advisory_snippet: String,
+    pub advisory_desc: String,
+
+    pub cve_id: String,
+    pub cve_title: String,
+    pub cve_release: time::OffsetDateTime,
+    pub cve_snippet: String,
+    pub cve_desc: String,
+    pub cve_cvss: Option<f64>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq)]


### PR DESCRIPTION
    * add separate type for advisory summary to speed up fetching
    * fetch CSAF document on-demand when rendering details
    * generate snippets of description to highlight parts that matches a query
    * add more fields to index and refactor how field data is retrieved