### PR TITLE
refactor: consolidate handlers and use response-from-error feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ dependencies = [
  "bombastic-index",
  "bombastic-model",
  "clap",
+ "derive_more",
  "futures",
  "hex",
  "packageurl",

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -64,9 +64,9 @@ RUST_LOG=info cargo run -p trust -- vexination walker --devmode --source file://
 At this point, you can POST and GET SBOMs with the API using a unique identifier for the id. To ingest a small-ish SBOM:
 
 ```shell
-curl -X POST --json @bombastic/testdata/my-sbom.json http://localhost:8082/api/v1/sbom?id=my-sbom
+curl --json @bombastic/testdata/my-sbom.json http://localhost:8082/api/v1/sbom?id=my-sbom
 ```
-For large SBOM's, you must use a "chunked" `Transfer-Encoding`:
+For large SBOM's, you may use a "chunked" `Transfer-Encoding`:
 ```shell
 curl -H "transfer-encoding: chunked" --json @bombastic/testdata/ubi9-sbom.json http://localhost:8082/api/v1/sbom?id=ubi9
 ```

--- a/bombastic/api/Cargo.toml
+++ b/bombastic/api/Cargo.toml
@@ -24,6 +24,7 @@ hex = "0.4.3"
 packageurl = "0.3"
 rand = "0.8"
 futures = "0.3"
+derive_more = "0.99"
 
 utoipa = { version = "3", features = ["actix_extras"] }
 utoipa-swagger-ui = { version = "3", features = ["actix-web"] }

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -36,7 +36,7 @@ pub async fn run<B: Into<SocketAddr>>(state: SharedState, bind: B) -> Result<(),
 }
 
 async fn fetch_object(storage: &Storage, key: &str) -> HttpResponse {
-    match storage.get_stream(key).await {
+    match storage.get_decoded_stream(key).await {
         Ok(stream) => HttpResponse::Ok().content_type(ContentType::json()).streaming(stream),
         Err(e) => {
             tracing::warn!("Unable to locate object with key {}: {:?}", key, e);


### PR DESCRIPTION
We create a general purpose `Error` enum for the bombastic server, which enables us to exploit `?` in the handlers to simplify their logic.