### PR TITLE
feat: refactor to facilitate non-json SBOM's

### DIFF
--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -200,7 +200,7 @@ async fn publish_sbom(
     payload: web::Payload,
     content_type: Option<web::Header<ContentType>>,
 ) -> actix_web::Result<impl Responder> {
-    let _ = verify_type(content_type)?;
+    let typ = verify_type(content_type)?;
     let enc = verify_encoding(req.headers().get(CONTENT_ENCODING))?;
     let id = &params.id;
     let storage = state.storage.write().await;
@@ -209,7 +209,7 @@ async fn publish_sbom(
         _ => io::Error::new(io::ErrorKind::Other, e),
     });
     let status = storage
-        .put_stream(id, enc, &mut payload)
+        .put_stream(id, typ.as_ref(), enc, &mut payload)
         .await
         .map_err(Error::Storage)?;
     tracing::trace!("SBOM stored with status code: {status}");

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -80,7 +80,7 @@ async fn publish_vex(state: web::Data<SharedState>, params: web::Query<PublishPa
 
     let storage = state.storage.write().await;
     tracing::debug!("Storing new VEX with id: {advisory}");
-    match storage.put_slice(&advisory, &data).await {
+    match storage.put_json_slice(&advisory, &data).await {
         Ok(_) => {
             let msg = format!("VEX of size {} stored successfully", &data[..].len());
             tracing::trace!(msg);

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -10,7 +10,7 @@ use csaf::{
 use search::*;
 use sikula::prelude::*;
 use tantivy::{Searcher, SnippetGenerator};
-use tracing::{debug, info};
+use tracing::debug;
 use trustification_index::{
     create_boolean_query, create_date_query, field2date, field2float, field2str, primary2occur,
     tantivy::{

--- a/vexination/walker/src/server.rs
+++ b/vexination/walker/src/server.rs
@@ -24,7 +24,7 @@ pub async fn run(storage: Storage, source: url::Url, options: ValidationOptions)
                     match serde_json::from_slice::<csaf::Csaf>(&data) {
                         Ok(doc) => {
                             let key = doc.document.tracking.id;
-                            match storage.put_slice(&key, &data).await {
+                            match storage.put_json_slice(&key, &data).await {
                                 Ok(_) => {
                                     let msg = format!("VEX ({}) of size {} stored successfully", key, &data[..].len());
                                     tracing::info!(msg);


### PR DESCRIPTION
Removes some of the hard-coded assumptions (or makes them explicit) in the storage api.