### PR TITLE
UI: pollish visual styles of components

### DIFF
--- a/spog/ui/src/components/common.rs
+++ b/spog/ui/src/components/common.rs
@@ -19,7 +19,7 @@ pub fn page_heading(props: &PageHeadingProperties) -> Html {
     html!(
         <PageSection {sticky} variant={PageSectionVariant::Light} >
             <Content>
-                <Title size={Size::XXXXLarge}>{ for props.children.iter() }</Title>
+                <Title>{ for props.children.iter() }</Title>
                 if let Some(subtitle) = &props.subtitle {
                     <p>{ &subtitle }</p>
                 }

--- a/spog/ui/src/components/mod.rs
+++ b/spog/ui/src/components/mod.rs
@@ -12,6 +12,7 @@ pub mod package;
 pub mod async_state_renderer;
 pub mod simple_pagination;
 pub mod spdx;
+pub mod table_wrapper;
 
 use std::ops::Deref;
 

--- a/spog/ui/src/components/simple_pagination.rs
+++ b/spog/ui/src/components/simple_pagination.rs
@@ -3,6 +3,9 @@ use yew::prelude::*;
 
 #[derive(Clone, PartialEq, Properties)]
 pub struct SimplePaginationProps {
+    #[prop_or(PaginationPosition::Top)]
+    pub position: PaginationPosition,
+
     pub total_items: Option<usize>,
     pub page: usize,
     pub per_page: usize,
@@ -12,6 +15,25 @@ pub struct SimplePaginationProps {
 
 #[function_component(SimplePagination)]
 pub fn simple_pagination(props: &SimplePaginationProps) -> Html {
+    // Custom total_entries to avoid "Unknown" values in the Pagination
+    let total_entries = use_state_eq(|| Some(0));
+
+    {
+        let total_entries = total_entries.clone();
+        use_effect_with_deps(
+            {
+                move |total_items| match total_items {
+                    Some(val) => {
+                        total_entries.set(Some(*val));
+                    }
+                    None => {}
+                }
+            },
+            props.total_items,
+        );
+    }
+
+    // On page change
     let onnavigation = {
         if let Some(total) = props.total_items {
             let on_page_change = props.on_page_change.clone();
@@ -25,7 +47,8 @@ pub fn simple_pagination(props: &SimplePaginationProps) -> Html {
 
     html!(
         <Pagination
-            total_entries={props.total_items}
+            position={props.position}
+            total_entries={*total_entries}
             offset={(props.page - 1) * props.per_page}
             selected_choice={props.per_page}
             entries_per_page_choices={vec![10, 25, 50]}

--- a/spog/ui/src/components/table_wrapper.rs
+++ b/spog/ui/src/components/table_wrapper.rs
@@ -1,0 +1,140 @@
+use patternfly_yew::prelude::*;
+use std::rc::Rc;
+use yew::prelude::*;
+
+#[derive(PartialEq, Properties, Clone)]
+struct SkeletonEntry {}
+
+impl TableEntryRenderer<usize> for SkeletonEntry {
+    fn render_cell(&self, _: CellContext<'_, usize>) -> Cell {
+        html!(<Skeleton />).into()
+    }
+}
+
+//
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct SimpleTableProps<C, M>
+where
+    C: Clone + Eq + 'static,
+    M: PartialEq + TableModel<C> + 'static,
+{
+    #[prop_or_default]
+    pub loading: bool,
+
+    #[prop_or_default]
+    pub error: Option<String>,
+
+    #[prop_or_default]
+    pub header: Vec<TableColumnProperties<C>>,
+
+    #[prop_or_default]
+    pub empty: bool,
+
+    #[prop_or_default]
+    pub children: ChildrenWithProps<Table<C, M>>,
+}
+
+#[function_component(TableWrapper)]
+pub fn table_wrapper<C, M>(props: &SimpleTableProps<C, M>) -> Html
+where
+    C: Clone + Eq + 'static,
+    M: Clone + PartialEq + TableModel<C> + 'static,
+{
+    let header = html_nested!(
+        <TableHeader<usize>>
+            {
+                for props.header.iter().enumerate()
+                    .map(|(index, column)| {
+                        yew::props!(TableColumnProperties<usize> {
+                            index: index,
+                            label: column.label.clone(),
+                            width: column.width
+                        })
+                    })
+                    .map(|column| html_nested!(<TableColumn<usize> ..column.clone() />))
+            }
+        </TableHeader<usize>>
+    );
+
+    let (empty_entries, _) = use_table_data(MemoizedTableModel::new(Rc::new(
+        (0..0).map(|_| SkeletonEntry {}).collect(),
+    )));
+    let (skeleton_entries, _) = use_table_data(MemoizedTableModel::new(Rc::new(
+        (0..10).map(|_| SkeletonEntry {}).collect(),
+    )));
+
+    // Loading view
+    if props.loading == true {
+        html!(
+            <Table<usize, UseTableData<usize, MemoizedTableModel<SkeletonEntry>>>
+                header={header}
+                entries={skeleton_entries}
+            />
+        )
+    } else if props.error.is_some() {
+        let error = match &props.error {
+            Some(val) => &val,
+            None => "",
+        };
+
+        html!(
+            <>
+                <Table<usize, UseTableData<usize, MemoizedTableModel<SkeletonEntry>>>
+                    header={header}
+                    entries={empty_entries}
+                />
+
+                <Card>
+                    <CardBody>
+                        <Grid gutter=true>
+                            <GridItem offset={[2]} cols={[2]}>
+                                <img src="assets/images/chicken-svgrepo-com.svg" style="transform: scaleY(-1);"/>
+                            </GridItem>
+                            <GridItem cols={[6]}>
+                                <Title>{"Error"}</Title>
+                                { error }
+                            </GridItem>
+                        </Grid>
+                    </CardBody>
+                </Card>
+            </>
+        )
+    } else if props.empty {
+        html!(
+            <>
+                <Table<usize, UseTableData<usize, MemoizedTableModel<SkeletonEntry>>>
+                    header={header}
+                    entries={empty_entries}
+                />
+                <div style="background-color: var(--pf-v5-global--BackgroundColor--100);">
+                    <EmptyState
+                        title="No results"
+                        icon={Icon::Search}
+                        size={Size::Small}
+                    >
+                        { "Try a different search expression." }
+                    </EmptyState>
+                </div>
+            </>
+        )
+    } else {
+        html!(
+            <>
+                {
+                    for props.children.iter().map(|mut item| {
+                        let header = html_nested!(
+                            <TableHeader<C>>
+                                { for props.header.iter().map(|column| html_nested!(<TableColumn<C> ..column.clone() />)) }
+                            </TableHeader<C>>
+                        );
+
+                        let mut item_props = Rc::make_mut(&mut item.props);
+                        item_props.header = Some(header);
+                        item
+                    })
+                }
+            </>
+        )
+    }
+}

--- a/spog/ui/src/components/vulnerability.rs
+++ b/spog/ui/src/components/vulnerability.rs
@@ -236,7 +236,6 @@ pub fn vulnerability_result(props: &VulnResultProperties) -> Html {
 
     html!(
         <Table<Column, UseTableData<Column, MemoizedTableModel<VulnSummary>>>
-            mode={TableMode::CompactExpandable}
             {header}
             {entries}
             {onexpand}

--- a/spog/ui/src/console.rs
+++ b/spog/ui/src/console.rs
@@ -86,10 +86,6 @@ pub fn console() -> Html {
     html!(
         <Page {brand} {sidebar} {tools}>
             <RouterSwitch<AppRoute> {render}/>
-
-            <PageSection variant={PageSectionVariant::Darker} fill={PageSectionFill::NoFill}>
-                {"Copyright © 2023 Red Hat, Inc. and "} <a href="https://github.com/trustification" target="_blank"> {"The chickens"} </a> {"."}
-            </PageSection>
         </Page>
     )
 }

--- a/spog/ui/src/hooks/use_pagination_state.rs
+++ b/spog/ui/src/hooks/use_pagination_state.rs
@@ -6,6 +6,7 @@ pub struct UsePaginationStateArgs {
     pub initial_items_per_page: usize,
 }
 
+#[derive(PartialEq, Clone)]
 pub struct PaginationState {
     pub page: usize,
     pub per_page: usize,

--- a/spog/ui/src/pages/advisory/mod.rs
+++ b/spog/ui/src/pages/advisory/mod.rs
@@ -5,10 +5,13 @@ use spog_model::prelude::*;
 use yew::prelude::*;
 use yew_more_hooks::hooks::{UseAsyncHandleDeps, UseAsyncState};
 
-use crate::components::{
-    advisory::{AdvisoryResult, AdvisorySearch},
-    async_state_renderer::AsyncStateRenderer,
-    common::PageHeading,
+use crate::{
+    components::{
+        advisory::{AdvisoryResult, AdvisorySearch},
+        common::PageHeading,
+        simple_pagination::*,
+    },
+    hooks::use_pagination_state::*,
 };
 
 // FIXME: use a different API and representation
@@ -32,19 +35,29 @@ pub fn advisory(props: &AdvisoryProps) -> Html {
     };
     let query = props.query.clone();
 
+    // Pagination
+    let total = search.data().and_then(|d| d.total);
+    let pagination_state = use_pagination_state(|| UsePaginationStateArgs {
+        initial_items_per_page: 10,
+    });
+
     html!(
         <>
             <PageHeading subtitle="Search security advisories">{"Advisories"}</PageHeading>
 
             // We need to set the main section to fill, as we have a footer section
-            <PageSection variant={PageSectionVariant::Default} fill={PageSectionFill::Fill}>
-                <AdvisorySearch {callback} {query}/>
+            <PageSection variant={PageSectionVariant::Default}>
+                <AdvisorySearch {callback} {query} pagination={pagination_state.clone()}/>
 
-                <AsyncStateRenderer<AdvisorySummary>
-                    state={(*search).clone()}
-                    on_ready={Callback::from(move |result| {
-                        html!(<AdvisoryResult {result} />)
-                    })}
+                <AdvisoryResult state={(*search).clone()} />
+
+                <SimplePagination
+                    position={PaginationPosition::Bottom}
+                    total_items={total}
+                    page={pagination_state.page}
+                    per_page={pagination_state.per_page}
+                    on_page_change={pagination_state.on_page_change}
+                    on_per_page_change={pagination_state.on_per_page_change}
                 />
             </PageSection>
         </>

--- a/spog/ui/src/pages/catalog/mod.rs
+++ b/spog/ui/src/pages/catalog/mod.rs
@@ -5,9 +5,7 @@ use spog_model::prelude::*;
 use yew::prelude::*;
 use yew_more_hooks::hooks::r#async::*;
 
-use crate::components::{
-    async_state_renderer::AsyncStateRenderer, catalog::CatalogSearch, common::PageHeading, package::PackageResult,
-};
+use crate::components::{catalog::CatalogSearch, common::PageHeading, package::PackageResult};
 
 #[derive(Clone, Debug, PartialEq, Eq, Properties)]
 pub struct CatalogProps {
@@ -35,12 +33,7 @@ pub fn catalog(props: &CatalogProps) -> Html {
             // We need to set the main section to fill, as we have a footer section
             <PageSection variant={PageSectionVariant::Light} fill={PageSectionFill::Fill}>
                 <CatalogSearch {callback} {query}>
-                    <AsyncStateRenderer<PackageSummary>
-                        state={(*search).clone()}
-                        on_ready={Callback::from(move |result| {
-                            html!(<PackageResult {result} />)
-                        })}
-                    />
+                    <PackageResult state={(*search).clone()} />
                 </CatalogSearch>
             </PageSection>
         </>

--- a/spog/ui/src/pages/package/mod.rs
+++ b/spog/ui/src/pages/package/mod.rs
@@ -5,10 +5,13 @@ use spog_model::prelude::*;
 use yew::prelude::*;
 use yew_more_hooks::hooks::r#async::*;
 
-use crate::components::{
-    async_state_renderer::AsyncStateRenderer,
-    common::PageHeading,
-    package::{PackageResult, PackageSearch},
+use crate::{
+    components::{
+        common::PageHeading,
+        package::{PackageResult, PackageSearch},
+        simple_pagination::SimplePagination,
+    },
+    hooks::use_pagination_state::*,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Properties)]
@@ -30,19 +33,29 @@ pub fn package(props: &PackageProps) -> Html {
     };
     let query = props.query.clone().filter(|s| !s.is_empty());
 
+    // Pagination
+    let total = search.data().and_then(|d| d.total);
+    let pagination_state = use_pagination_state(|| UsePaginationStateArgs {
+        initial_items_per_page: 10,
+    });
+
     html!(
         <>
             <PageHeading subtitle="Search packages">{"Packages"}</PageHeading>
 
             // We need to set the main section to fill, as we have a footer section
-            <PageSection variant={PageSectionVariant::Default} fill={PageSectionFill::Fill}>
-                <PackageSearch {callback} {query} />
+            <PageSection variant={PageSectionVariant::Default}>
+                <PackageSearch {callback} {query} pagination={pagination_state.clone()}/>
 
-                <AsyncStateRenderer<PackageSummary>
-                    state={(*search).clone()}
-                    on_ready={Callback::from(move |result| {
-                        html!(<PackageResult {result} />)
-                    })}
+                <PackageResult state={(*search).clone()} />
+
+                <SimplePagination
+                    position={PaginationPosition::Bottom}
+                    total_items={total}
+                    page={pagination_state.page}
+                    per_page={pagination_state.per_page}
+                    on_page_change={pagination_state.on_page_change}
+                    on_per_page_change={pagination_state.on_per_page_change}
                 />
             </PageSection>
         </>


### PR DESCRIPTION
- [x] Page titles are too big and they should be aligned with https://www.patternfly.org/v4/demos/dashboard/html-demos/basic/
- [x] Main tables should not be compacted. There is no need to fix all elements of the table in the screen, we can use the browser scroll for it and in any case everyone has different sizes of screen.
- [X] Pagination component should be located at both TOP and BOTTOM.
- [x] The change page is showing `unknown`; it should either not show anything of keep the previous value until the next page becomes available

[Screencast from 2023-06-23 11-37-40.webm](https://github.com/trustification/trustification/assets/2582866/40c685e8-ce83-47b9-9c3c-2b740e97caff)
  
- [x] The loading of a new page completely removes the whole table and puts a "Spinner". The transition to a new page should be smoother, potentially using https://www.patternfly.org/v4/components/skeleton

[Screencast from 2023-06-23 11-42-09.webm](https://github.com/trustification/trustification/assets/2582866/e6eb709d-578d-456d-acdb-b72d97d896c3)

- [ ] Remove the "Copyright" section from the bottom of each page, this kind of information should be written in the "About" modal component. This is just a suggestion though.