### PR TITLE
fix: metadata can now be attached to large, multipart SBOM's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3916,8 +3916,7 @@ dependencies = [
 [[package]]
 name = "rust-s3"
 version = "0.34.0-beta3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d7eaca94ee4a4b18c676637d2b29946a4adb373c84d0933ed46981f27e825d"
+source = "git+https://github.com/jcrossley3/rust-s3.git?branch=issue-352#158e587e1b33039e292eb4fca9005b63d99e582c"
 dependencies = [
  "async-trait",
  "aws-creds",

--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -234,12 +234,13 @@ async fn publish_sbom(
         PayloadError::Io(e) => e,
         _ => io::Error::new(io::ErrorKind::Other, e),
     });
-    let status = storage
+    let size = storage
         .put_stream(id, typ.as_ref(), enc, &mut payload)
         .await
         .map_err(Error::Storage)?;
-    tracing::trace!("SBOM stored with status code: {status}");
-    Ok(HttpResponse::Created().finish())
+    let msg = format!("Successfully uploaded SBOM: id={id}, size={size}");
+    tracing::info!(msg);
+    Ok(HttpResponse::Created().body(msg))
 }
 
 fn verify_type(content_type: Option<web::Header<ContentType>>) -> Result<ContentType, Error> {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rust-s3 = "0.34.0-beta3"
+rust-s3 = { git = "https://github.com/jcrossley3/rust-s3.git", branch = "issue-352" }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 anyhow = "1"

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -170,7 +170,7 @@ impl Storage {
         content_type: &'a str,
         encoding: Option<&str>,
         data: &mut S,
-    ) -> Result<u16, Error>
+    ) -> Result<usize, Error>
     where
         S: Stream<Item = Result<B, E>> + Unpin,
         B: Buf + 'a,
@@ -187,10 +187,11 @@ impl Storage {
         let mut rdr = stream::encode(encoding, data)?;
         Ok(bucket
             .put_object_stream_with_content_type(&mut rdr, path, content_type)
-            .await?)
+            .await?
+            .uploaded_bytes())
     }
 
-    pub async fn put_json_slice<'a>(&self, key: &'a str, json: &'a [u8]) -> Result<u16, Error> {
+    pub async fn put_json_slice<'a>(&self, key: &'a str, json: &'a [u8]) -> Result<usize, Error> {
         let mut stream = once(ok::<_, std::io::Error>(json));
         self.put_stream(key, "application/json", None, &mut stream).await
     }


### PR DESCRIPTION
Fixes #161

This required [a fix in the rust-s3 crate](https://github.com/durch/rust-s3/pull/353) so we're now depending on a branch of a fork of that repo.

The fork's API differs slightly from the version we were previously using: we can now report the size of the upload instead of just the status code.

And while I was at it, I removed a confusing debug println that should clean up our server log a bit.