### PR TITLE
feat: use crate version in S3 metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5371,6 +5371,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "trustification-version",
  "urlencoding",
 ]
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -19,3 +19,8 @@ urlencoding = "2.1.2"
 thiserror = "1"
 async-compression = { version = "0.4", features = ["tokio", "zstd", "bzip2"] }
 clap = { version = "4", features = ["derive", "env"] }
+
+trustification-version = { path = "../version" }
+
+[build-dependencies]
+trustification-version = { path = "../version", features = ["build"] }

--- a/storage/build.rs
+++ b/storage/build.rs
@@ -1,0 +1,6 @@
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    trustification_version::build::generate()?;
+    Ok(())
+}


### PR DESCRIPTION
Currently using `full` but could see using only `major` or `minor` to distinguish API changes, maybe.