### PR TITLE
fix: change date queries to match on day instead of millisecond

### DIFF
--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -618,6 +618,15 @@ mod tests {
         assert_search(|index| {
             let result = search(&index, "created:>2022-01-01");
             assert_eq!(result.0.len(), 2);
+
+            let result = search(&index, "created:2023-03-30");
+            assert_eq!(result.0.len(), 1);
+
+            let result = search(&index, "created:2023-03-29");
+            assert_eq!(result.0.len(), 0);
+
+            let result = search(&index, "created:2023-03-31");
+            assert_eq!(result.0.len(), 0);
         });
     }
 

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -637,6 +637,15 @@ mod tests {
 
             let result = search(&index, "release:2022-01-01..2024-01-01");
             assert_eq!(result.0.len(), 1);
+
+            let result = search(&index, "release:2023-03-23");
+            assert_eq!(result.0.len(), 1);
+
+            let result = search(&index, "release:2023-03-24");
+            assert_eq!(result.0.len(), 0);
+
+            let result = search(&index, "release:2023-03-22");
+            assert_eq!(result.0.len(), 0);
         });
     }
 


### PR DESCRIPTION
This changes a query for a specific date to a range query matching the
entire day, rather than at millisecond granularity. For finer
granularity, specifying a restricted range will still work.

Fixes #176
