### PR TITLE
feat: add option to explain why a document matched

### DIFF
--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -158,6 +158,9 @@ pub struct SearchParams {
     /// Max number of documents to return
     #[serde(default = "default_limit")]
     pub limit: usize,
+    /// Provide a detailed explanation of query matches
+    #[serde(default = "default_explain")]
+    pub explain: bool,
 }
 
 const fn default_offset() -> usize {
@@ -166,6 +169,10 @@ const fn default_offset() -> usize {
 
 const fn default_limit() -> usize {
     10
+}
+
+const fn default_explain() -> bool {
+    false
 }
 
 /// Search for an SBOM using a free form search query.
@@ -194,7 +201,7 @@ async fn search_sbom(
 
     let index = state.index.read().await;
     let result = index
-        .search(&params.q, params.offset, params.limit)
+        .search(&params.q, params.offset, params.limit, params.explain)
         .map_err(Error::Index)?;
 
     Ok(HttpResponse::Ok().json(SearchResult {

--- a/bombastic/model/src/search.rs
+++ b/bombastic/model/src/search.rs
@@ -1,3 +1,5 @@
+use serde_json::Value;
+
 /// A document returned from the search index for every match.
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, utoipa::ToSchema)]
 pub struct SearchDocument {
@@ -30,11 +32,22 @@ pub struct SearchDocument {
     pub dependencies: Vec<String>,
 }
 
+/// The hit describes the document, its score and optionally an explanation of why that score was given.
+#[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, utoipa::ToSchema)]
+pub struct SearchHit {
+    /// The document that was matched.
+    pub document: SearchDocument,
+    /// Score as evaluated by the search engine.
+    pub score: f32,
+    /// Explanation of the score if enabled,
+    pub explanation: Option<Value>,
+}
+
 /// The payload returned describing how many results matched and the matching documents (within offset and limit requested).
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, utoipa::ToSchema)]
 pub struct SearchResult {
     /// Total number of matching documents
     pub total: usize,
     /// Documents matched up to max requested
-    pub result: Vec<SearchDocument>,
+    pub result: Vec<SearchHit>,
 }

--- a/spog/api/src/advisory.rs
+++ b/spog/api/src/advisory.rs
@@ -68,6 +68,7 @@ pub async fn search(state: web::Data<SharedState>, params: web::Query<QueryParam
 
     let mut m: Vec<AdvisorySummary> = Vec::new();
     for item in result.result.drain(..) {
+        let item = item.document;
         m.push(AdvisorySummary {
             id: item.advisory_id.clone(),
             title: item.advisory_title,

--- a/spog/api/src/sbom.rs
+++ b/spog/api/src/sbom.rs
@@ -57,6 +57,7 @@ pub async fn search(state: web::Data<SharedState>, params: web::Query<search::Qu
         Ok(mut data) => {
             let mut m: Vec<PackageSummary> = Vec::new();
             for item in data.result.drain(..) {
+                let item = item.document;
                 m.push(PackageSummary {
                     id: item.id.clone(),
                     purl: item.purl,
@@ -97,6 +98,7 @@ async fn search_advisories(state: web::Data<SharedState>, packages: &mut Vec<Pac
         let q = format!("fixed:\"{}\"", package.name);
         if let Ok(result) = state.search_vex(&q, 0, 1000).await {
             for summary in result.result {
+                let summary = summary.document;
                 package.advisories.push(summary.advisory_id);
             }
         }

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -149,6 +149,9 @@ pub struct SearchParams {
     /// Max number of documents to return
     #[serde(default = "default_limit")]
     pub limit: usize,
+    /// Provide a detailed explanation of query matches
+    #[serde(default = "default_explain")]
+    pub explain: bool,
 }
 
 const fn default_offset() -> usize {
@@ -157,6 +160,10 @@ const fn default_offset() -> usize {
 
 const fn default_limit() -> usize {
     10
+}
+
+const fn default_explain() -> bool {
+    false
 }
 
 /// Search for a VEX using a free form search query.
@@ -181,7 +188,7 @@ async fn search_vex(state: web::Data<SharedState>, params: web::Query<SearchPara
     tracing::info!("Querying VEX using {}", params.q);
 
     let index = state.index.read().await;
-    let result = index.search(&params.q, params.offset, params.limit);
+    let result = index.search(&params.q, params.offset, params.limit, params.explain);
 
     let result = match result {
         Err(e) => {

--- a/vexination/model/src/search.rs
+++ b/vexination/model/src/search.rs
@@ -1,3 +1,4 @@
+use serde_json::Value;
 use utoipa::ToSchema;
 
 /// A document returned from the search index for every match.
@@ -20,11 +21,22 @@ pub struct SearchDocument {
     pub cvss_max: Option<f64>,
 }
 
+/// The hit describes the document, its score and optionally an explanation of why that score was given.
+#[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, utoipa::ToSchema)]
+pub struct SearchHit {
+    /// The document that was matched.
+    pub document: SearchDocument,
+    /// Score as evaluated by the search engine.
+    pub score: f32,
+    /// Explanation of the score if enabled,
+    pub explanation: Option<Value>,
+}
+
 /// The payload returned describing how many results matched and the matching documents (within offset and limit requested).
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, ToSchema)]
 pub struct SearchResult {
     /// Total number of matching documents
     pub total: usize,
     /// Documents matched up to max requested
-    pub result: Vec<SearchDocument>,
+    pub result: Vec<SearchHit>,
 }


### PR DESCRIPTION
Provide a JSON tantivy explanation if a flag enabling it is passed during
the search. This flag can set as a query parameter in bombastic and
vexination.
