### PR TITLE
refactor: integs

### DIFF
--- a/integration-tests/tests/bombastic.rs
+++ b/integration-tests/tests/bombastic.rs
@@ -1,53 +1,90 @@
 use integration_tests::{assert_within_timeout, run_test};
 use reqwest::StatusCode;
-use serde_json::{Map, Value};
+use serde_json::Value;
 use std::time::Duration;
 
 #[test]
 fn test_bombastic() {
     run_test(Duration::from_secs(60), async move {
-        let client = reqwest::Client::new();
-        let input = serde_json::from_str::<Map<String, Value>>(include_str!("../../bombastic/testdata/ubi9-sbom.json"))
-            .unwrap();
-        let response = client
-            .post("http://localhost:8082/api/v1/sbom?id=ubi9")
-            .json(&input)
-            .send()
-            .await?;
-        assert_eq!(response.status(), StatusCode::CREATED);
-
-        assert_within_timeout(Duration::from_secs(30), async move {
-            loop {
-                // 1. Check that we can get the SBOM back
-                let response = client
-                    .get("http://localhost:8082/api/v1/sbom?id=ubi9")
-                    .header("Accept", "application/json")
-                    .send()
-                    .await
-                    .unwrap();
-
-                if response.status() == StatusCode::OK {
-                    let body: Map<String, Value> = response.json().await.unwrap();
-                    assert_eq!(body, input);
-
-                    // 2. Make sure we can search for the SBOM (takes some time)
-                    let response = client
-                        .get("http://localhost:8082/api/v1/sbom/search?q=")
-                        .send()
-                        .await
-                        .unwrap();
-
-                    assert_eq!(response.status(), StatusCode::OK);
-                    let response: Map<String, Value> = response.json().await.unwrap();
-
-                    if let Some(Some(1)) = response.get("total").map(|t| t.as_i64()) {
-                        break;
-                    }
-                }
-                tokio::time::sleep(Duration::from_secs(4)).await;
-            }
-        })
-        .await;
+        let input = serde_json::from_str(include_str!("../../bombastic/testdata/ubi9-sbom.json")).unwrap();
+        upload("ubi9", &input).await;
+        assert_eq!(fetch("ubi9").await, input);
+        search().await;
+        upload_invalid_type().await;
+        upload_invalid_encoding().await;
         Ok(())
     })
+}
+
+async fn upload(key: &str, input: &Value) {
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("http://localhost:8082/api/v1/sbom?id={key}"))
+        .json(input)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
+async fn fetch(key: &str) -> Value {
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://localhost:8082/api/v1/sbom?id={key}"))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    response.json().await.unwrap()
+}
+
+async fn search() {
+    assert_within_timeout(Duration::from_secs(30), async move {
+        let client = reqwest::Client::new();
+        // Ensure we can search for the SBOM. We want to allow the
+        // indexer time to do its thing, so might need to retry
+        loop {
+            let response = client
+                .get("http://localhost:8082/api/v1/sbom/search?q=")
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let response: Value = response.json().await.unwrap();
+            if let Some(Some(1)) = response.get("total").map(|t| t.as_i64()) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    })
+    .await;
+}
+
+async fn upload_invalid_type() {
+    let client = reqwest::Client::new();
+    let response = client
+        .post("http://localhost:8082/api/v1/sbom?id=foo")
+        .body("<foo/>")
+        .header("Content-Type", "application/xml")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.headers().get("accept").unwrap(), &"application/json");
+}
+
+async fn upload_invalid_encoding() {
+    let client = reqwest::Client::new();
+    let response = client
+        .post("http://localhost:8082/api/v1/sbom?id=foo")
+        .body("{}")
+        .header("Content-Type", "application/json")
+        .header("Content-Encoding", "braille")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.headers().get("accept-encoding").unwrap(), &"bzip2, zstd");
 }


### PR DESCRIPTION
I don't love this. I'd like to break each test out into its own fn, but I don't like that I only have one `#[test]` fn that calls all the rest in the correct order. 

I'd like for each test to be annotated with `#[test]` so we can see our test counts increase over time. :smile: 