### PR TITLE
fix: add positive term for not queries

### DIFF
--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -661,6 +661,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_not() {
+        assert_search(|index| {
+            let result = search(&index, "type:oci");
+            assert_eq!(result.0.len(), 1);
+            let result = search(&index, "NOT type:oci");
+            assert_eq!(result.0.len(), 2);
+
+            let result = search(&index, "NOT ubi9");
+            assert_eq!(result.0.len(), 2);
+
+            let result = search(&index, "type:oci NOT ubi9");
+            assert_eq!(result.0.len(), 0);
+
+            let result = search(&index, "type:oci NOT ubi8");
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
+    #[tokio::test]
     async fn test_quarkus() {
         assert_search(|index| {
             let result = search(&index, "dependency:quarkus-arc");

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -12,7 +12,7 @@ pub use tantivy::schema::Document;
 use tantivy::{
     collector::{Count, TopDocs},
     directory::{MmapDirectory, INDEX_WRITER_LOCK},
-    query::{BooleanQuery, BoostQuery, Occur, Query, RangeQuery, RegexQuery, TermQuery},
+    query::{AllQuery, BooleanQuery, BoostQuery, Occur, Query, RangeQuery, RegexQuery, TermQuery},
     schema::*,
     DateTime, Directory, DocAddress, Index as SearchIndex, IndexSettings, Searcher,
 };
@@ -332,7 +332,8 @@ pub fn term2query<'m, R: Search<'m>, F: Fn(&R::Parsed) -> Box<dyn Query>>(
     match term {
         sikula::prelude::Term::Match(resource) => f(resource),
         sikula::prelude::Term::Not(term) => {
-            let query_terms = vec![(Occur::MustNot, term2query(term, f))];
+            let all: Box<dyn Query> = Box::new(AllQuery);
+            let query_terms = vec![(Occur::Should, all), (Occur::MustNot, term2query(term, f))];
             let query = BooleanQuery::new(query_terms);
             Box::new(query)
         }


### PR DESCRIPTION
A positive term is required for a not query to have some results to act
match. Adding a AllQuery term in union with the not term ensures the not
term has candidate hits to match against.

Fixes #215
