### PR TITLE
feat: add basic authentication support for write APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-httpauth"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dda62cf04bc3a9ad2ea8f314f721951cfdb4cdacec4e984d20e77c7bb170991"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "base64 0.13.1",
+ "futures-core",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "actix-web-opentelemetry"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1062,7 @@ name = "bombastic-api"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "actix-web-httpauth",
  "anyhow",
  "bombastic-index",
  "bombastic-model",
@@ -6012,6 +6028,7 @@ name = "vexination-api"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "actix-web-httpauth",
  "anyhow",
  "clap",
  "csaf",

--- a/bombastic/api/Cargo.toml
+++ b/bombastic/api/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.8"
 futures = "0.3"
 derive_more = "0.99"
 prometheus = "0.13.3"
+actix-web-httpauth = "0.8.0"
 
 utoipa = { version = "3", features = ["actix_extras"] }
 utoipa-swagger-ui = { version = "3", features = ["actix-web"] }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -182,6 +182,7 @@ fn bombastic_api(storage_endpoint: &str) -> bombastic_api::Run {
             infrastructure_workers: 1,
             enable_tracing: false,
         },
+        publish_secret_token: None,
     }
 }
 
@@ -238,5 +239,6 @@ fn vexination_api(storage_endpoint: &str) -> vexination_api::Run {
             infrastructure_workers: 1,
             enable_tracing: false,
         },
+        publish_secret_token: None,
     }
 }

--- a/vexination/api/Cargo.toml
+++ b/vexination/api/Cargo.toml
@@ -25,6 +25,7 @@ packageurl = "0.3"
 rand = "0.8"
 csaf = "0.5.0"
 prometheus = "0.13.3"
+actix-web-httpauth = "0.8.0"
 
 utoipa = { version = "3", features = ["actix_extras"] }
 utoipa-swagger-ui = { version = "3", features = ["actix-web"] }

--- a/vexination/api/src/lib.rs
+++ b/vexination/api/src/lib.rs
@@ -6,7 +6,12 @@ use std::{
     time::Duration,
 };
 
-use actix_web::{web, App, HttpServer};
+use actix_web::{dev::Service, error::ErrorUnauthorized};
+use actix_web::{
+    http::{header::Header, Method},
+    web, App, HttpServer,
+};
+use actix_web_httpauth::headers::authorization::{Authorization, Bearer};
 use prometheus::Registry;
 use tokio::sync::RwLock;
 use trustification_index::{IndexConfig, IndexStore};
@@ -27,6 +32,10 @@ pub struct Run {
     #[arg(long = "devmode", default_value_t = false)]
     pub devmode: bool,
 
+    /// Require a secret token for publishing publishing SBOMs.
+    #[arg(long = "publish-secret")]
+    pub publish_secret_token: Option<String>,
+
     #[command(flatten)]
     pub index: IndexConfig,
 
@@ -45,7 +54,40 @@ impl Run {
             .run("vexination-api", |metrics| async move {
                 let state = Self::configure(index, storage, metrics.registry(), self.devmode)?;
                 let mut srv = HttpServer::new(move || {
+                    let secret = self.publish_secret_token.clone();
                     App::new()
+                        // NOTE: Workaround until we have an authentication and authorization scheme
+                        .wrap_fn(move |req, srv| {
+                            let secret = secret.clone();
+                            let mut auth = Err(ErrorUnauthorized("Not authorized to write"));
+                            if req.method() == Method::POST
+                                || req.method() == Method::PUT
+                                || req.method() == Method::DELETE
+                            {
+                                if let Some(secret) = secret {
+                                    if let Ok(r) = Authorization::<Bearer>::parse(&req) {
+                                        if r.as_ref().token() == secret {
+                                            auth = Ok(())
+                                        }
+                                    }
+                                } else {
+                                    auth = Ok(())
+                                }
+                            } else {
+                                auth = Ok(())
+                            }
+
+                            let fut = srv.call(req);
+                            async move {
+                                match auth {
+                                    Ok(_) => {
+                                        let res = fut.await?;
+                                        Ok(res)
+                                    }
+                                    Err(e) => Err(e),
+                                }
+                            }
+                        })
                         .app_data(web::Data::new(state.clone()))
                         .configure(server::config)
                 });


### PR DESCRIPTION
This is a temporary change that will be replaced by proper
authentication and authorization, but is useful in order to keep the
public instances of trustification protected.
