### PR TITLE
feat: increase concurrency of VEX walker

### DIFF
--- a/deploy/compose/compose-walkers.yaml
+++ b/deploy/compose/compose-walkers.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   vexination-walker:
     image: $TRUST_IMAGE:${TRUST_VERSION:?TRUST_VERSION is required}
-    command: vexination walker --devmode --source https://www.redhat.com/.well-known/csaf/provider-metadata.json -3 --storage-endpoint http://minio:9000
+    command: vexination walker --devmode --workers 3 --source https://www.redhat.com/.well-known/csaf/provider-metadata.json -3 --storage-endpoint http://minio:9000
     depends_on:
       minio:
         condition: service_healthy

--- a/vexination/walker/src/lib.rs
+++ b/vexination/walker/src/lib.rs
@@ -34,6 +34,10 @@ pub struct Run {
     #[arg(long = "devmode", default_value_t = false)]
     pub(crate) devmode: bool,
 
+    /// Number of workers, too many might get you rate-limited
+    #[arg(short, long, default_value = "1")]
+    pub(crate) workers: usize,
+
     #[command(flatten)]
     pub(crate) storage: StorageConfig,
 
@@ -61,7 +65,7 @@ impl Run {
 
                 let options = ValidationOptions { validation_date };
 
-                server::run(storage, self.source, options).await
+                server::run(self.workers, storage, self.source, options).await
             })
             .await?;
         Ok(ExitCode::SUCCESS)


### PR DESCRIPTION
At 5 threads, I start getting rate-limited, i.e. 403 Access Denied errors. With 4 threads, I don't, so just to be on the safe side, let's go with 3 in the compose file.

This speeds up the walker considerably: less than 30 minutes instead of the 2+ hours with a single thread.