### PR TITLE
Allow returning index document when searching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,6 +1247,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.7",
  "tokio",
+ "trustification-api",
  "trustification-index",
  "trustification-infrastructure",
  "trustification-storage",
@@ -1271,6 +1272,7 @@ dependencies = [
  "tar",
  "time 0.3.22",
  "tokio",
+ "trustification-api",
  "trustification-index",
  "zstd",
 ]
@@ -5378,6 +5380,7 @@ dependencies = [
  "spog-model",
  "thiserror",
  "tokio",
+ "trustification-api",
  "trustification-infrastructure",
  "trustification-version",
  "urlencoding",
@@ -6125,6 +6128,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustification-api"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde",
+]
+
+[[package]]
 name = "trustification-event-bus"
 version = "0.1.0"
 dependencies = [
@@ -6157,6 +6168,7 @@ dependencies = [
  "tar",
  "time 0.3.22",
  "tokio",
+ "trustification-api",
  "zstd",
 ]
 
@@ -6444,6 +6456,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.7",
  "tokio",
+ "trustification-api",
  "trustification-index",
  "trustification-infrastructure",
  "trustification-storage",
@@ -6470,6 +6483,7 @@ dependencies = [
  "tar",
  "time 0.3.22",
  "tokio",
+ "trustification-api",
  "trustification-index",
  "vexination-model",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "api",
     "bombastic/bombastic",
     "bombastic/api",
     "bombastic/model",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "trustification-api"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Common API definitions"
+
+[dependencies]
+reqwest = { version = "0.11", default-features = false}
+serde = { version = "1", features = ["derive"] }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod search;
+
+pub trait Apply<T> {
+    fn apply(self, value: &T) -> Self;
+}

--- a/api/src/search.rs
+++ b/api/src/search.rs
@@ -1,0 +1,23 @@
+use crate::Apply;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct SearchOptions {
+    #[serde(default)]
+    pub explain: bool,
+    #[serde(default)]
+    pub metadata: bool,
+}
+
+impl Apply<SearchOptions> for reqwest::RequestBuilder {
+    fn apply(mut self, options: &SearchOptions) -> Self {
+        if options.explain {
+            self = self.query(&[("explain", "true")]);
+        }
+
+        if options.metadata {
+            self = self.query(&[("metadata", "true")]);
+        }
+
+        self
+    }
+}

--- a/bombastic/api/Cargo.toml
+++ b/bombastic/api/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1.0", features = ["full"] }
 log = "0.4"
 bombastic-index = { path = "../index" }
 bombastic-model = { path = "../model" }
+trustification-api = { path = "../../api" }
 trustification-infrastructure = { path = "../../infrastructure" }
 trustification-storage = { path = "../../storage" }
 trustification-index = { path = "../../index" }

--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -185,14 +185,11 @@ async fn search_sbom(
     log::info!("Querying SBOM using {}", params.q);
 
     let index = state.index.read().await;
-    let result = index
+    let (result, total) = index
         .search(&params.q, params.offset, params.limit, params.explain)
         .map_err(Error::Index)?;
 
-    Ok(HttpResponse::Ok().json(SearchResult {
-        total: result.1,
-        result: result.0,
-    }))
+    Ok(HttpResponse::Ok().json(SearchResult { total, result }))
 }
 
 /// Upload an SBOM with an identifier.

--- a/bombastic/index/Cargo.toml
+++ b/bombastic/index/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4"
 time = "0.3"
 tar = "0.4"
 trustification-index = { path = "../../index" }
+trustification-api = { path = "../../api" }
 bombastic-model = { path = "../model" }
 cyclonedx-bom = "0.4.0"
 spdx-rs = "0.5.2"

--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -590,7 +590,17 @@ mod tests {
     }
 
     fn search(index: &IndexStore<Index>, query: &str) -> (Vec<SearchHit>, usize) {
-        index.search(query, 0, 10000, false).unwrap()
+        index
+            .search(
+                query,
+                0,
+                10000,
+                SearchOptions {
+                    metadata: false,
+                    explain: false,
+                },
+            )
+            .unwrap()
     }
 
     #[tokio::test]
@@ -716,7 +726,17 @@ mod tests {
     #[tokio::test]
     async fn test_explain() {
         assert_search(|index| {
-            let result = index.search("dependency:openssl", 0, 10000, true).unwrap();
+            let result = index
+                .search(
+                    "dependency:openssl",
+                    0,
+                    10000,
+                    SearchOptions {
+                        explain: true,
+                        metadata: false,
+                    },
+                )
+                .unwrap();
             assert_eq!(result.0.len(), 1);
             assert!(result.0[0].explanation.is_some());
             println!(

--- a/bombastic/model/src/search.rs
+++ b/bombastic/model/src/search.rs
@@ -74,8 +74,12 @@ pub struct SearchHit {
     pub document: SearchDocument,
     /// Score as evaluated by the search engine.
     pub score: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Explanation of the score if enabled,
     pub explanation: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Additional metadata, if enabled
+    pub metadata: Option<Value>,
 }
 
 /// The payload returned describing how many results matched and the matching documents (within offset and limit requested).

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -4,19 +4,21 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tantivy = "0.19.2"
-log = "0.4"
-zstd = "0.12"
-tar = "0.4"
-sikula = { version = "0.4.0-alpha", features = ["time"] }
-time = "0.3"
 clap = { version = "4", features = ["derive", "env"] }
 humantime = "2.1.0"
-rand = "0.8"
+log = "0.4"
 prometheus = "0.13.3"
+rand = "0.8"
+serde_json = "1.0.68"
+sikula = { version = "0.4.0-alpha", features = ["time"] }
+tantivy = "0.19.2"
+tar = "0.4"
+time = "0.3"
+zstd = "0.12"
+
+trustification-api = { path = "../api"}
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.68"
 env_logger = "0.10"

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -562,7 +562,21 @@ mod tests {
 
         writer.commit().unwrap();
 
-        assert_eq!(store.search("is", 0, 10, false).unwrap().1, 1);
+        assert_eq!(
+            store
+                .search(
+                    "is",
+                    0,
+                    10,
+                    SearchOptions {
+                        explain: false,
+                        metadata: false
+                    }
+                )
+                .unwrap()
+                .1,
+            1
+        );
     }
 
     #[tokio::test]
@@ -577,13 +591,41 @@ mod tests {
 
         writer.commit().unwrap();
 
-        assert_eq!(store.search("is", 0, 10, false).unwrap().1, 1);
+        assert_eq!(
+            store
+                .search(
+                    "is",
+                    0,
+                    10,
+                    SearchOptions {
+                        explain: false,
+                        metadata: false
+                    }
+                )
+                .unwrap()
+                .1,
+            1
+        );
 
         let writer = store.writer().unwrap();
         writer.delete_document(store.index_as_mut(), "foo");
         writer.commit().unwrap();
 
-        assert_eq!(store.search("is", 0, 10, false).unwrap().1, 0);
+        assert_eq!(
+            store
+                .search(
+                    "is",
+                    0,
+                    10,
+                    SearchOptions {
+                        explain: false,
+                        metadata: false
+                    }
+                )
+                .unwrap()
+                .1,
+            0
+        );
     }
 
     #[tokio::test]
@@ -602,7 +644,21 @@ mod tests {
 
         writer.commit().unwrap();
 
-        assert_eq!(store.search("is", 0, 10, false).unwrap().1, 1);
+        assert_eq!(
+            store
+                .search(
+                    "is",
+                    0,
+                    10,
+                    SearchOptions {
+                        explain: false,
+                        metadata: false
+                    }
+                )
+                .unwrap()
+                .1,
+            1
+        );
 
         // Duplicates also removed if separate commits.
         let mut writer = store.writer().unwrap();
@@ -612,6 +668,20 @@ mod tests {
 
         writer.commit().unwrap();
 
-        assert_eq!(store.search("is", 0, 10, false).unwrap().1, 1);
+        assert_eq!(
+            store
+                .search(
+                    "is",
+                    0,
+                    10,
+                    SearchOptions {
+                        explain: false,
+                        metadata: false
+                    }
+                )
+                .unwrap()
+                .1,
+            1
+        );
     }
 }

--- a/index/src/metadata.rs
+++ b/index/src/metadata.rs
@@ -1,0 +1,14 @@
+use serde_json::Value;
+use tantivy::schema::Schema;
+use tantivy::Document;
+
+/// generated the search metadata from an index document
+pub fn doc2metadata(schema: &Schema, doc: &Document) -> Value {
+    let data = doc
+        .get_sorted_field_values()
+        .into_iter()
+        .map(|(field, values)| (schema.get_field_entry(field), values))
+        .collect::<Vec<_>>();
+
+    serde_json::to_value(&data).unwrap_or_default()
+}

--- a/index/src/metadata.rs
+++ b/index/src/metadata.rs
@@ -10,5 +10,5 @@ pub fn doc2metadata(schema: &Schema, doc: &Document) -> Value {
         .map(|(field, values)| (schema.get_field_entry(field), values))
         .collect::<Vec<_>>();
 
-    serde_json::to_value(&data).unwrap_or_default()
+    serde_json::to_value(data).unwrap_or_default()
 }

--- a/spog/api/Cargo.toml
+++ b/spog/api/Cargo.toml
@@ -44,6 +44,7 @@ spog-model = { path = "../model" }
 vexination-model = { path = "../../vexination/model" }
 bombastic-model = { path = "../../bombastic/model" }
 
+trustification-api = { path = "../../api" }
 trustification-infrastructure = { path = "../../infrastructure" }
 trustification-version = { path = "../../version", features = ["actix-web"] }
 

--- a/spog/api/src/advisory.rs
+++ b/spog/api/src/advisory.rs
@@ -2,6 +2,7 @@ use actix_web::{web, web::ServiceConfig, HttpResponse, Responder};
 use http::header;
 use log::{info, trace, warn};
 use spog_model::search::{AdvisorySummary, SearchResult};
+use trustification_api::search::SearchOptions;
 
 use crate::{search::QueryParams, server::SharedState};
 
@@ -58,11 +59,20 @@ pub async fn get(state: web::Data<SharedState>, params: web::Query<GetParams>) -
         ("limit" = u64, Path, description = "Max entries returned in the search results"),
     )
 )]
-pub async fn search(state: web::Data<SharedState>, params: web::Query<QueryParams>) -> impl Responder {
+pub async fn search(
+    state: web::Data<SharedState>,
+    params: web::Query<QueryParams>,
+    options: web::Query<SearchOptions>,
+) -> impl Responder {
     let params = params.into_inner();
     trace!("Querying VEX using {}", params.q);
     let result = state
-        .search_vex(&params.q, params.offset, params.limit.min(MAX_LIMIT))
+        .search_vex(
+            &params.q,
+            params.offset,
+            params.limit.min(MAX_LIMIT),
+            options.into_inner(),
+        )
         .await;
 
     let result = match result {

--- a/spog/api/src/sbom.rs
+++ b/spog/api/src/sbom.rs
@@ -1,6 +1,6 @@
 use actix_web::{web, web::ServiceConfig, HttpResponse, Responder};
 use http::header;
-use log::{debug, info, trace, warn};
+use log::{debug, trace, warn};
 use spog_model::search::{PackageSummary, SearchResult};
 
 use crate::{search, server::SharedState};
@@ -104,13 +104,13 @@ pub async fn search(state: web::Data<SharedState>, params: web::Query<search::Qu
 async fn search_advisories(state: web::Data<SharedState>, packages: &mut Vec<PackageSummary>) {
     for package in packages {
         let q = format!("fixed:\"{}\"", package.name);
-        if let Ok(result) = state.search_vex(&q, 0, 1000).await {
+        if let Ok(result) = state.search_vex(&q, 0, 1000, Default::default()).await {
             for summary in result.result {
                 let summary = summary.document;
                 package.advisories.push(summary.advisory_id);
             }
         }
-        info!(
+        debug!(
             "Found {} advisories related to {}",
             package.advisories.len(),
             package.purl

--- a/spog/api/src/server.rs
+++ b/spog/api/src/server.rs
@@ -7,6 +7,7 @@ use anyhow::anyhow;
 use http::StatusCode;
 use prometheus::Registry;
 use spog_model::search;
+use trustification_api::{search::SearchOptions, Apply};
 use trustification_version::version;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -161,6 +162,7 @@ impl AppState {
         q: &str,
         offset: usize,
         limit: usize,
+        options: SearchOptions,
     ) -> Result<vexination_model::search::SearchResult, anyhow::Error> {
         let url = self.vexination.join("/api/v1/vex/search")?;
         let response = self
@@ -168,6 +170,7 @@ impl AppState {
             .get(url)
             .query(&[("q", q)])
             .query(&[("offset", offset), ("limit", limit)])
+            .apply(&options)
             .send()
             .await?;
         if response.status() == StatusCode::OK {

--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -1690,6 +1690,7 @@ dependencies = [
  "strum 0.25.0",
  "thiserror",
  "time 0.3.22",
+ "trustification-api",
  "trustification-version",
  "url",
  "urlencoding",
@@ -1974,6 +1975,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trustification-api"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde",
 ]
 
 [[package]]

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -43,6 +43,7 @@ spog-model = "0.1.0"
 
 bombastic-model = { path = "../../bombastic/model" }
 vexination-model = { path = "../../vexination/model" }
+trustification-api = { path = "../../api" }
 trustification-version = { path = "../../version" }
 
 [build-dependencies]

--- a/spog/ui/src/backend/mod.rs
+++ b/spog/ui/src/backend/mod.rs
@@ -7,13 +7,17 @@ pub mod data {
 mod config;
 mod pkg;
 mod sbom;
+mod search;
 mod version;
 mod vuln;
 
 pub use config::*;
 pub use pkg::*;
 pub use sbom::*;
+pub use search::*;
 pub use version::*;
+pub use version::*;
+pub use vuln::*;
 pub use vuln::*;
 
 use url::{ParseError, Url};

--- a/spog/ui/src/backend/pkg.rs
+++ b/spog/ui/src/backend/pkg.rs
@@ -2,11 +2,12 @@ use packageurl::PackageUrl;
 use serde::Deserialize;
 use spog_model::prelude::*;
 use std::rc::Rc;
+use trustification_api::Apply;
 
 use super::{Backend, Error};
 use crate::backend::{
     data::{Package, PackageDependencies, PackageDependents, PackageList, PackageRef},
-    Endpoint, SearchOptions,
+    Endpoint, SearchParameters,
 };
 
 pub struct PackageService {
@@ -59,16 +60,15 @@ impl PackageService {
     pub async fn search_packages(
         &self,
         q: &str,
-        options: &SearchOptions,
+        options: &SearchParameters,
     ) -> Result<SearchResult<Vec<PackageSummary>>, Error> {
-        let request = self
+        let response = self
             .client
             .get(self.backend.join(Endpoint::Api, "/api/v1/package/search")?)
-            .query(&[("q", q)]);
-
-        let request = options.apply(request);
-
-        let response = request.send().await?;
+            .query(&[("q", q)])
+            .apply(options)
+            .send()
+            .await?;
 
         Ok(response.error_for_status()?.json().await?)
     }

--- a/spog/ui/src/backend/search.rs
+++ b/spog/ui/src/backend/search.rs
@@ -1,0 +1,49 @@
+use reqwest::RequestBuilder;
+use trustification_api::{search::SearchOptions, Apply};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SearchParameters {
+    pub offset: Option<usize>,
+    pub limit: Option<usize>,
+    pub options: SearchOptions,
+}
+
+impl Default for SearchParameters {
+    fn default() -> Self {
+        Self {
+            offset: None,
+            limit: None,
+            options: SearchOptions {
+                // in debug mode, we ask for metadata by default
+                metadata: default_metadata(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+#[cfg(not(debug_assertions))]
+const fn default_metadata() -> bool {
+    false
+}
+
+#[cfg(debug_assertions)]
+const fn default_metadata() -> bool {
+    true
+}
+
+impl Apply<SearchParameters> for RequestBuilder {
+    fn apply(mut self, value: &SearchParameters) -> Self {
+        if let Some(limit) = value.limit {
+            self = self.query(&[("limit", limit)]);
+        }
+
+        if let Some(offset) = value.offset {
+            self = self.query(&[("offset", offset)]);
+        }
+
+        self = self.apply(&value.options);
+
+        self
+    }
+}

--- a/spog/ui/src/components/advisory/search.rs
+++ b/spog/ui/src/components/advisory/search.rs
@@ -77,10 +77,6 @@ pub fn advisory_search(props: &AdvisorySearchProperties) -> Html {
         (props.callback.clone(), search.clone()),
     );
 
-    // pagination
-
-    let total = search.data().and_then(|d| d.total);
-
     // render
 
     let hidden = text.is_empty();
@@ -138,7 +134,7 @@ pub fn advisory_search(props: &AdvisorySearchProperties) -> Html {
                             <ToolbarItem r#type={ToolbarItemType::Pagination}>
                                 <SimplePagination
                                     pagination={pagination.clone()}
-                                    total={total}
+                                    total={*total}
                                 />
                             </ToolbarItem>
 
@@ -159,7 +155,7 @@ pub fn advisory_search(props: &AdvisorySearchProperties) -> Html {
 
             <SimplePagination
                 {pagination}
-                total={total}
+                total={*total}
                 position={PaginationPosition::Bottom}
             />
 

--- a/spog/ui/src/components/advisory/search.rs
+++ b/spog/ui/src/components/advisory/search.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::{SearchOptions, VexService},
+    backend::{self, VexService},
     components::search::*,
     hooks::{use_backend::use_backend, use_config, use_standard_search, UseStandardSearch},
     utils::pagination_to_offset,
@@ -54,9 +54,10 @@ pub fn advisory_search(props: &AdvisorySearchProperties) -> Html {
                 service
                     .search_advisories(
                         &search_params.as_str(&filters),
-                        &SearchOptions {
+                        &backend::SearchParameters {
                             offset: Some(pagination_to_offset(page, per_page)),
                             limit: Some(per_page),
+                            ..Default::default()
                         },
                     )
                     .await

--- a/spog/ui/src/components/advisory/search.rs
+++ b/spog/ui/src/components/advisory/search.rs
@@ -74,7 +74,7 @@ pub fn advisory_search(props: &AdvisorySearchProperties) -> Html {
         |(callback, search)| {
             callback.emit(search.clone());
         },
-        (props.callback.clone(), search.clone()),
+        (props.callback.clone(), search),
     );
 
     // pagination

--- a/spog/ui/src/components/advisory/search.rs
+++ b/spog/ui/src/components/advisory/search.rs
@@ -74,7 +74,7 @@ pub fn advisory_search(props: &AdvisorySearchProperties) -> Html {
         |(callback, search)| {
             callback.emit(search.clone());
         },
-        (props.callback.clone(), search),
+        (props.callback.clone(), search.clone()),
     );
 
     // pagination

--- a/spog/ui/src/components/sbom/mod.rs
+++ b/spog/ui/src/components/sbom/mod.rs
@@ -77,10 +77,6 @@ pub fn catalog_search(props: &CatalogSearchProperties) -> Html {
         (props.callback.clone(), search.clone()),
     );
 
-    // pagination
-
-    let total = search.data().and_then(|d| d.total);
-
     // render
 
     let hidden = text.is_empty();
@@ -142,7 +138,7 @@ pub fn catalog_search(props: &CatalogSearchProperties) -> Html {
                             <ToolbarItem r#type={ToolbarItemType::Pagination}>
                                 <SimplePagination
                                     pagination={pagination.clone()}
-                                    total={total}
+                                    total={*total}
                                 />
                             </ToolbarItem>
 
@@ -163,7 +159,7 @@ pub fn catalog_search(props: &CatalogSearchProperties) -> Html {
 
             <SimplePagination
                 {pagination}
-                total={total}
+                total={*total}
                 position={PaginationPosition::Bottom}
             />
 

--- a/spog/ui/src/components/sbom/mod.rs
+++ b/spog/ui/src/components/sbom/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::{PackageService, SearchOptions},
+    backend::{self, PackageService},
     components::search::*,
     hooks::{use_backend::use_backend, use_config, use_standard_search, UseStandardSearch},
     utils::pagination_to_offset,
@@ -54,9 +54,10 @@ pub fn catalog_search(props: &CatalogSearchProperties) -> Html {
                 service
                     .search_packages(
                         &search_params.as_str(&filters),
-                        &SearchOptions {
+                        &backend::SearchParameters {
                             offset: Some(pagination_to_offset(page, per_page)),
                             limit: Some(per_page),
+                            ..Default::default()
                         },
                     )
                     .await

--- a/vexination/api/Cargo.toml
+++ b/vexination/api/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
 tokio = { version = "1.0", features = ["full"] }
 log = "0.4"
+trustification-api = { path = "../../api" }
 trustification-infrastructure = { path = "../../infrastructure" }
 trustification-storage = { path = "../../storage" }
 trustification-index = { path = "../../index" }

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -177,7 +177,7 @@ async fn search_vex(state: web::Data<SharedState>, params: web::Query<SearchPara
     let index = state.index.read().await;
     let result = index.search(&params.q, params.offset, params.limit, params.explain);
 
-    let result = match result {
+    let (result, total) = match result {
         Err(e) => {
             log::info!("Error searching: {:?}", e);
             return HttpResponse::InternalServerError().body(e.to_string());
@@ -185,8 +185,5 @@ async fn search_vex(state: web::Data<SharedState>, params: web::Query<SearchPara
         Ok(result) => result,
     };
 
-    HttpResponse::Ok().json(SearchResult {
-        total: result.1,
-        result: result.0,
-    })
+    HttpResponse::Ok().json(SearchResult { total, result })
 }

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -7,6 +7,7 @@ use actix_web::{
     HttpResponse, Responder,
 };
 use serde::Deserialize;
+use trustification_api::search::SearchOptions;
 use trustification_storage::Storage;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -139,6 +140,9 @@ pub struct SearchParams {
     /// Provide a detailed explanation of query matches
     #[serde(default = "default_explain")]
     pub explain: bool,
+    /// Provide additional metadata from the index
+    #[serde(default = "default_metadata")]
+    pub metadata: bool,
 }
 
 const fn default_offset() -> usize {
@@ -151,6 +155,19 @@ const fn default_limit() -> usize {
 
 const fn default_explain() -> bool {
     false
+}
+
+const fn default_metadata() -> bool {
+    false
+}
+
+impl From<&SearchParams> for SearchOptions {
+    fn from(value: &SearchParams) -> Self {
+        Self {
+            explain: value.explain,
+            metadata: value.metadata,
+        }
+    }
 }
 
 /// Search for a VEX using a free form search query.
@@ -175,7 +192,7 @@ async fn search_vex(state: web::Data<SharedState>, params: web::Query<SearchPara
     log::info!("Querying VEX using {}", params.q);
 
     let index = state.index.read().await;
-    let result = index.search(&params.q, params.offset, params.limit, params.explain);
+    let result = index.search(&params.q, params.offset, params.limit, (&params).into());
 
     let (result, total) = match result {
         Err(e) => {

--- a/vexination/index/Cargo.toml
+++ b/vexination/index/Cargo.toml
@@ -13,6 +13,7 @@ tar = "0.4"
 sikula = { version = "0.4.0-alpha.3", features = ["time"] }
 chumsky = "1.0.0-alpha.4"
 time = "0.3"
+trustification-api = { path = "../../api" }
 trustification-index = { path = "../../index" }
 vexination-model = { path = "../model" }
 serde_json = "1"

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -591,7 +591,17 @@ mod tests {
     }
 
     fn search(index: &IndexStore<Index>, query: &str) -> (Vec<SearchHit>, usize) {
-        index.search(query, 0, 10000, false).unwrap()
+        index
+            .search(
+                query,
+                0,
+                10000,
+                SearchOptions {
+                    explain: false,
+                    metadata: false,
+                },
+            )
+            .unwrap()
     }
 
     #[tokio::test]

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -12,6 +12,7 @@ use tantivy::{
     store::ZstdCompressor,
     DocAddress, IndexSettings, Searcher, SnippetGenerator,
 };
+use trustification_api::search::SearchOptions;
 use trustification_index::{
     boost, create_date_query, create_string_query, create_text_query, field2date, field2f64vec, field2str,
     field2strvec,
@@ -248,7 +249,7 @@ impl trustification_index::Index for Index {
         score: f32,
         searcher: &Searcher,
         query: &dyn Query,
-        explain: bool,
+        options: &SearchOptions,
     ) -> Result<Self::MatchedDocument, SearchError> {
         let doc = searcher.doc(doc_address)?;
         let snippet_generator = SnippetGenerator::create(searcher, query, self.fields.advisory_description)?;
@@ -290,7 +291,7 @@ impl trustification_index::Index for Index {
             cvss_max,
         };
 
-        let explanation: Option<serde_json::Value> = if explain {
+        let explanation: Option<serde_json::Value> = if options.explain {
             match query.explain(searcher, doc_address) {
                 Ok(explanation) => Some(serde_json::to_value(explanation).ok()).unwrap_or(None),
                 Err(e) => {
@@ -302,10 +303,13 @@ impl trustification_index::Index for Index {
             None
         };
 
+        let metadata = options.metadata.then(|| doc2metadata(&self.schema, &doc));
+
         Ok(SearchHit {
             document,
             score,
             explanation,
+            metadata,
         })
     }
 }
@@ -475,6 +479,8 @@ impl Index {
 }
 
 use csaf::definitions::{BranchesT, ProductIdentificationHelper};
+use trustification_index::metadata::doc2metadata;
+
 fn find_product_identifier<'m, F: Fn(&'m ProductIdentificationHelper) -> Option<R>, R>(
     branches: &'m BranchesT,
     product_id: &'m ProductIdT,

--- a/vexination/model/src/search.rs
+++ b/vexination/model/src/search.rs
@@ -65,7 +65,11 @@ pub struct SearchHit {
     /// Score as evaluated by the search engine.
     pub score: f32,
     /// Explanation of the score if enabled,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub explanation: Option<Value>,
+    /// Additional metadata, if enabled
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
 }
 
 /// The payload returned describing how many results matched and the matching documents (within offset and limit requested).


### PR DESCRIPTION
When searching the index it is not always clear to me "why" a document matched or didn't. I also want to understand what additional information is stored in the index in order to understand what I can search for.

This change adds the ability to request the raw index document content alongside the actual search document as returned on the API.

For example:

```
http -v localhost:8082/api/v1/sbom/search q=="ubi" metadata==true
```

Results in: https://gist.github.com/ctron/6978595544d7b15fd9ceb76cf3ba4804

By default no metadata is returned. When the frontend is compiled in debug mode, it is requested by default.

Also: `explain` seems to be broken at the moment #283 