### PR TITLE
fix: clean up the search model for package as well

### DIFF
--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -9,6 +9,7 @@ use cyclonedx_bom::models::{
 use log::{debug, info, warn};
 use sikula::prelude::*;
 use spdx_rs::models::Algorithm;
+use tantivy::query::TermSetQuery;
 use tantivy::{
     query::{AllQuery, BooleanQuery},
     schema::INDEXED,
@@ -325,7 +326,10 @@ impl Index {
                 PACKAGE_WEIGHT,
             ),
 
-            Packages::Type(primary) => self.create_string_query(&[self.fields.sbom.purl_type], primary),
+            Packages::Type(value) => Box::new(TermSetQuery::new(vec![Term::from_field_text(
+                self.fields.sbom.purl_type,
+                value,
+            )])),
 
             Packages::Namespace(primary) => self.create_string_query(&[self.fields.sbom.purl_namespace], primary),
 
@@ -337,7 +341,10 @@ impl Index {
 
             Packages::Description(primary) => self.create_text_query(&[self.fields.sbom.desc], primary),
 
-            Packages::Digest(primary) => self.create_string_query(&[self.fields.sbom.sha256], primary),
+            Packages::Digest(value) => Box::new(TermSetQuery::new(vec![Term::from_field_text(
+                self.fields.sbom.sha256,
+                value,
+            )])),
 
             Packages::License(primary) => self.create_string_query(&[self.fields.sbom.license], primary),
 

--- a/bombastic/model/src/search.rs
+++ b/bombastic/model/src/search.rs
@@ -5,25 +5,21 @@ use sikula::prelude::*;
 pub enum Packages<'a> {
     #[search(default)]
     Package(Primary<'a>),
-    #[search]
-    Type(Primary<'a>),
-    #[search]
+    Type(&'a str),
+    #[search(scope)]
     Namespace(Primary<'a>),
     #[search(default)]
     Version(Primary<'a>),
     #[search(default)]
     Description(Primary<'a>),
-    #[search]
     Created(Ordered<time::OffsetDateTime>),
-    #[search]
-    Digest(Primary<'a>),
-    #[search]
+    Digest(&'a str),
+    #[search(scope)]
     License(Primary<'a>),
     #[search(scope)]
     Supplier(Primary<'a>),
-    #[search]
     Qualifier(Qualified<'a, &'a str>),
-    #[search]
+    #[search(scope)]
     Dependency(Primary<'a>),
     Application,
     Library,

--- a/vexination/model/src/search.rs
+++ b/vexination/model/src/search.rs
@@ -13,7 +13,6 @@ pub enum Vulnerabilities<'a> {
     #[search(default)]
     Description(Primary<'a>),
     Status(&'a str),
-    #[search]
     Severity(&'a str),
     Cvss(PartialOrdered<f64>),
     #[search(scope)]


### PR DESCRIPTION
We did re-iterate over the search model for vulnerabilities, but it looks like this hasn't happened for packages.

This is a proposal to remove unnecessary annotations, and use scope or default for cases where primary is used, or use &str instead.