### PR TITLE
fix: show alert when product id is invalid

### DIFF
--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 [[package]]
 name = "patternfly-yew"
 version = "0.5.0-alpha.2"
-source = "git+https://github.com/ctron/patternfly-yew?rev=b13c34c00fce5da61cbfa7a6a36d30e03d7420ed#b13c34c00fce5da61cbfa7a6a36d30e03d7420ed"
+source = "git+https://github.com/ctron/patternfly-yew?rev=46486afd82f9f449fd11727e64b59b97bdd7fc60#46486afd82f9f449fd11727e64b59b97bdd7fc60"
 dependencies = [
  "chrono",
  "gloo-events",

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -63,7 +63,7 @@ features = [
 #yew-nested-router = { git = "https://github.com/ctron/yew-nested-router", rev = "9689db446dee7030325884df768d0c2e84f353d6" }
 yew-more-hooks = { git = "https://github.com/ctron/yew-more-hooks", rev = "3c943759287c59a22256a4748993d2407b9a9e9b" }
 #yew-more-hooks = { path = "../yew-more-hooks" }
-patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "b13c34c00fce5da61cbfa7a6a36d30e03d7420ed" } # FIXME: awaiting release
+patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "46486afd82f9f449fd11727e64b59b97bdd7fc60" } # FIXME: awaiting release
 #patternfly-yew = { path = "../../../patternfly-yew" }
 
 csaf = { git = "https://github.com/voteblake/csaf-rs", rev = "76cb9ede10adb1fbb495b17e5fd8d95c5cf6c900" } # FIXME: waiting for release


### PR DESCRIPTION
Quarkus SBOMs are using an invalid product ID. This get flagged now:

![image](https://github.com/trustification/trustification/assets/202474/c66c7574-463d-402d-9670-df81c88e7904)
