### PR TITLE
feat: allow overriding the landing page content

### DIFF
--- a/spog/api/src/config/default.yaml
+++ b/spog/api/src/config/default.yaml
@@ -140,3 +140,23 @@ vexination:
             label: OpenShift Container Platform 4
             terms:
               - '( "cpe:/a:redhat:openshift:4" in:package )'
+
+landingPage:
+  content: |
+    <section
+      class="pf-v5-c-page__main-section pf-m-light pf-m-shadow-bottom"
+    >
+      <div class="pf-v5-l-grid pf-m-gutter">
+        <div class="pf-v5-l-grid__item pf-m-8-col">
+          <div class="pf-v5-c-content">
+            <h1 class="pf-v5-c-title pf-m-2xl">Trusted Content</h1>
+            <p class="pf-v5-u-color-200">A service for software supply chain security</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    
+    <section
+      class="pf-v5-c-page__main-section"
+    >
+    </section>

--- a/spog/api/src/config/mod.rs
+++ b/spog/api/src/config/mod.rs
@@ -16,7 +16,7 @@ impl Config {
     async fn retrieve(&self) -> anyhow::Result<Cow<'_, Configuration>> {
         Ok(match &self.source {
             Some(config) => {
-                // FIXME: need to cache instead reparsing every time
+                // FIXME: need to cache instead re-parsing every time
                 // TODO: when we cache the result, attach a probe to it which fails if loading fails
                 let content = tokio::fs::read(config).await?;
                 Cow::Owned(serde_yaml::from_slice(&content)?)

--- a/spog/api/src/config/schema.yaml
+++ b/spog/api/src/config/schema.yaml
@@ -11,6 +11,16 @@ properties:
   "$schema":
     type: string
 
+  landingPage:
+    type: object
+    additionalProperties: false
+    properties:
+      content:
+        type: string
+        description: |
+          HTML content which will be used as the main content of the page. This is only the main page content,
+          without navigation controls. It is possible to use PatternFly styles.
+
   bombastic:
     type: object
     additionalProperties: false

--- a/spog/api/src/lib.rs
+++ b/spog/api/src/lib.rs
@@ -38,7 +38,8 @@ pub struct Run {
     #[arg(long = "vexination-url", default_value = "http://localhost:8081")]
     pub(crate) vexination_url: reqwest::Url,
 
-    #[arg(short, long = "config")]
+    /// Path to the UI configuration file, overriding the default configuration file.
+    #[arg(short, long = "config", env = "SPOG_UI_CONFIG")]
     pub(crate) config: Option<PathBuf>,
 
     #[command(flatten)]

--- a/spog/model/src/config.rs
+++ b/spog/model/src/config.rs
@@ -1,14 +1,21 @@
-use serde::de::Error;
-use serde::ser::SerializeMap;
-use serde::{Deserializer, Serialize, Serializer};
+use serde::{de::Error, ser::SerializeMap, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Configuration {
+    #[serde(default)]
+    pub landing_page: LandingPage,
     #[serde(default)]
     pub bombastic: Bombastic,
     #[serde(default)]
     pub vexination: Vexination,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LandingPage {
+    #[serde(default)]
+    pub content: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/spog/ui/src/pages/index.rs
+++ b/spog/ui/src/pages/index.rs
@@ -1,5 +1,4 @@
 use crate::hooks::use_config;
-use patternfly_yew::prelude::*;
 use yew::prelude::*;
 
 #[function_component(Index)]

--- a/spog/ui/src/pages/index.rs
+++ b/spog/ui/src/pages/index.rs
@@ -1,47 +1,14 @@
+use crate::hooks::use_config;
 use patternfly_yew::prelude::*;
 use yew::prelude::*;
 
-use crate::components::common::PageHeading;
-
 #[function_component(Index)]
 pub fn index() -> Html {
+    let config = use_config();
+
     html!(
         <>
-            <PageHeading subtitle="Fully hosted and managed service" >{"Trusted Content"}</PageHeading>
-
-            <PageSection variant={PageSectionVariant::Default} fill=true>
-                <Grid gutter={true}>
-                    <GridItem cols={[12.all()]}>
-                        <Card title={html!("Search")}>
-                            <CardBody>
-                                {"Search!"}
-                            </CardBody>
-                        </Card>
-                    </GridItem>
-                    <GridItem cols={[6.lg(), 12.all()]}>
-                        <Card title={html!("Get Started")}>
-                            <CardBody>
-                                {"Get Started"}
-                            </CardBody>
-                        </Card>
-                    </GridItem>
-                    <GridItem cols={[6.lg(), 12.all()]} rows={[2.lg(), 1.all()]}>
-                        <Card title={html!("Why Trust Red Hat?")}>
-                            <CardBody>
-                                {"Why trust Red Hat?"}
-                            </CardBody>
-                        </Card>
-                    </GridItem>
-                    <GridItem cols={[6.lg(), 12.all()]}>
-                        <Card title={html!("Subscribe")}>
-                            <CardBody>
-                                {"Subscribe"}
-                            </CardBody>
-                        </Card>
-                    </GridItem>
-                </Grid>
-            </PageSection>
-
+            { Html::from_html_unchecked(config.landing_page.content.clone().into()) }
         </>
     )
 }


### PR DESCRIPTION
This allows to override the content section of the landing page through the SPoG UI config.

The idea is to provide a reasonable default, allowing to override the content in a custom deployment without the need to patch the actual source code.