### PR TITLE
correlate advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3266,6 +3266,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spog-api",
+ "spog-model",
  "test-context",
  "test-with",
  "tokio",

--- a/auth/src/authenticator/mod.rs
+++ b/auth/src/authenticator/mod.rs
@@ -149,7 +149,7 @@ async fn create_client<P: CompactJson + Claims>(
     )
     .await?;
 
-    log::info!("Discovered OpenID: {:#?}", client.config());
+    log::debug!("Discovered OpenID: {:#?}", client.config());
 
     Ok(AuthenticatorClient {
         client,

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -36,3 +36,4 @@ trustification-index = { path = "../index" }
 [dev-dependencies]
 env_logger = "0.10"
 urlencoding = "2.1.2"
+spog-model = { path = "../spog/model" }

--- a/integration-tests/src/bom.rs
+++ b/integration-tests/src/bom.rs
@@ -72,6 +72,19 @@ pub async fn start_bombastic(provider: ProviderContext) -> BombasticContext {
     context
 }
 
+pub async fn upload_sbom(port: u16, key: &str, input: &serde_json::Value, context: &ProviderContext) {
+    let response = reqwest::Client::new()
+        .post(format!("http://localhost:{port}/api/v1/sbom?id={key}"))
+        .json(input)
+        .inject_token(&context.provider_manager)
+        .await
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
 #[async_trait]
 impl AsyncTestContext for BombasticContext {
     async fn setup() -> Self {

--- a/integration-tests/src/vex.rs
+++ b/integration-tests/src/vex.rs
@@ -73,6 +73,19 @@ pub async fn start_vexination(provider: ProviderContext) -> VexinationContext {
     context
 }
 
+pub async fn upload_vex(port: u16, input: &serde_json::Value, context: &ProviderContext) {
+    let response = reqwest::Client::new()
+        .post(format!("http://localhost:{port}/api/v1/vex"))
+        .json(input)
+        .inject_token(&context.provider_manager)
+        .await
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
 #[async_trait]
 impl AsyncTestContext for VexinationContext {
     async fn setup() -> Self {

--- a/integration-tests/tests/bombastic.rs
+++ b/integration-tests/tests/bombastic.rs
@@ -1,4 +1,4 @@
-use integration_tests::{assert_within_timeout, BombasticContext, upload_sbom};
+use integration_tests::{assert_within_timeout, upload_sbom, BombasticContext};
 use reqwest::StatusCode;
 use serde_json::{json, Value};
 use std::time::Duration;

--- a/integration-tests/tests/spog.rs
+++ b/integration-tests/tests/spog.rs
@@ -150,9 +150,11 @@ async fn test_search_correlation(context: &mut SpogContext) {
 
                 let data: spog_model::search::PackageSummary =
                     serde_json::from_value(payload["result"][0].clone()).unwrap();
-                println!("Data: {:?}", data);
-                assert_eq!(1, data.advisories.len());
-                break;
+                // println!("Data: {:?}", data);
+                // Data might not be available until vex index is synced
+                if data.advisories.len() >= 1 {
+                    break;
+                }
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
         }

--- a/integration-tests/tests/spog.rs
+++ b/integration-tests/tests/spog.rs
@@ -1,6 +1,8 @@
-use integration_tests::SpogContext;
+use std::time::Duration;
+
+use integration_tests::{SpogContext, upload_sbom, upload_vex, assert_within_timeout};
 use reqwest::StatusCode;
-use serde_json::Value;
+use serde_json::{json, Value};
 use test_context::test_context;
 use trustification_auth::client::TokenInjector;
 
@@ -104,4 +106,52 @@ async fn test_crda_integration(context: &mut SpogContext) {
     println!("{html:#?}");
 
     assert_eq!(status, StatusCode::OK);
+}
+
+/// SPoG API might enrich results from package search with related vulnerabilities. This test checks that this
+/// is working as expected for the test data.
+#[test_context(SpogContext)]
+#[tokio::test]
+#[ntest::timeout(30_000)]
+async fn test_search_correlation(context: &mut SpogContext) {
+    let input = serde_json::from_str(include_str!("../../bombastic/testdata/ubi9-sbom.json")).unwrap();
+    upload_sbom(context.bombastic.port, "ubi9-container", &input, &context.bombastic.provider).await;
+
+    let input =
+        serde_json::from_str(include_str!("../../vexination/testdata/rhsa-2023_1441.json"))
+            .unwrap();
+    upload_vex(context.vexination.port, &input, &context.vexination.provider).await;
+
+    let client = reqwest::Client::new();
+
+
+    assert_within_timeout(Duration::from_secs(30), async move {
+        // Ensure we can search for the data. We want to allow the
+        // indexer time to do its thing, so might need to retry
+        loop {
+            let response = client
+                .get(format!(
+                    "http://localhost:{port}/api/v1/package/search?q=package%3Aubi9-container",
+                    port = context.port
+                ))
+                .inject_token(&context.provider.provider_user)
+                .await
+                .unwrap()
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let payload: Value = response.json().await.unwrap();
+            if payload["total"].as_u64().unwrap() >= 1 {
+                assert_eq!(payload["result"][0]["name"], json!("ubi9-container"));
+
+                let data: spog_model::search::PackageSummary = serde_json::from_value(payload["result"][0].clone()).unwrap();
+                println!("Data: {:?}", data);
+                assert_eq!(1, data.advisories.len());
+                break;
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await;
 }

--- a/integration-tests/tests/vexination.rs
+++ b/integration-tests/tests/vexination.rs
@@ -1,4 +1,4 @@
-use integration_tests::{assert_within_timeout, VexinationContext, upload_vex};
+use integration_tests::{assert_within_timeout, upload_vex, VexinationContext};
 use reqwest::StatusCode;
 use serde_json::Value;
 use std::time::Duration;
@@ -10,9 +10,7 @@ use trustification_auth::client::TokenInjector;
 #[ntest::timeout(60_000)]
 async fn test_vexination(vexination: &mut VexinationContext) {
     let client = reqwest::Client::new();
-    let input =
-        serde_json::from_str(include_str!("../../vexination/testdata/rhsa-2023_1441.json"))
-            .unwrap();
+    let input = serde_json::from_str(include_str!("../../vexination/testdata/rhsa-2023_1441.json")).unwrap();
     upload_vex(vexination.port, &input, &vexination.provider).await;
 
     assert_within_timeout(Duration::from_secs(30), async move {

--- a/spog/api/src/sbom.rs
+++ b/spog/api/src/sbom.rs
@@ -131,7 +131,12 @@ async fn search_advisories(
     provider: &dyn TokenProvider,
 ) {
     for package in packages {
-        let q = format!("fixed:\"{}\"", package.name);
+        let mut terms = Vec::new();
+        for field in &[&package.cpe, &package.purl] {
+            terms.push(format!("fixed:\"{}\" OR affected:\"{}\"", field, field));
+        }
+
+        let q = terms.join(" OR ");
         if let Ok(result) = state.search_vex(&q, 0, 1000, Default::default(), provider).await {
             for summary in result.result {
                 let summary = summary.document;
@@ -143,5 +148,20 @@ async fn search_advisories(
             package.advisories.len(),
             package.purl
         );
+
+        for dep in package.dependencies.iter() {
+            let q = format!("fixed:\"{}\" OR affected:\"{}\"", dep, dep);
+            if let Ok(result) = state.search_vex(&q, 0, 1000, Default::default(), provider).await {
+                for summary in result.result {
+                    let summary = summary.document;
+                    package.advisories.push(summary.advisory_id);
+                }
+            }
+            debug!(
+                "Found {} advisories related to dependency {}",
+                package.advisories.len(),
+                dep
+            );
+        }
     }
 }


### PR DESCRIPTION
- chore: make test upload fn available to all tests
- fix: query associated advisories using cpe OR purl
- fix: cargo fmt
