### PR TITLE
fix: wrap the backdrop viewer with the oauth2 context

### DIFF
--- a/spog/ui/src/app.rs
+++ b/spog/ui/src/app.rs
@@ -48,16 +48,18 @@ fn application_with_backend() -> Html {
         // as the backdrop viewer might host content which makes use of the router, the
         // router must also wrap the backdrop viewer
         <Router<AppRoute>>
-            <BackdropViewer>
-                <OAuth2
-                    {config}
-                    scopes={backend.endpoints.oidc.scopes.clone()}
-                >
+            // as the backdrop viewer might actually make use of the access token, the
+            // oauth2 context must also wrap the backdrop viewer
+            <OAuth2
+                {config}
+                scopes={backend.endpoints.oidc.scopes.clone()}
+            >
+                <BackdropViewer>
                     <OAuth2Configured>
                         <Console />
                     </OAuth2Configured>
-                </OAuth2>
-            </BackdropViewer>
+                </BackdropViewer>
+            </OAuth2>
         </Router<AppRoute>>
     )
 }


### PR DESCRIPTION
Backdrop content might require the access token too. So the backdrop viewer needs to be wrapped by the oauth2 context.

closes #329