### PR TITLE
Improve the compose deployment

### DIFF
--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -1,5 +1,5 @@
 TRUST_IMAGE=ghcr.io/trustification/trust
-TRUST_VERSION=0.1.0-nightly.97fc55cc
+TRUST_VERSION=0.1.0-nightly.c925a710
 TRUST_UI_IMAGE=ghcr.io/trustification/trust-ui
 VEXINATION_API_PORT=8081
 BOMBASTIC_API_PORT=8082

--- a/deploy/compose/compose-trustification.yaml
+++ b/deploy/compose/compose-trustification.yaml
@@ -1,4 +1,5 @@
 version: '3'
+
 services:
   vexination-api:
     image: $TRUST_IMAGE:${TRUST_VERSION:?TRUST_VERSION is required}
@@ -9,12 +10,17 @@ services:
     ports:
       - "$VEXINATION_API_PORT:8080"
     command: vexination api --devmode --storage-endpoint http://minio:9000
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9010" ]
+    restart: on-failure
     environment:
       ISSUER_URL: http://keycloak:8080/realms/chicken
+      INFRASTRUCTURE_ENABLED: "true"
 
   vexination-indexer:
     image: $TRUST_IMAGE:${TRUST_VERSION:?}
     command: vexination indexer --devmode --storage-endpoint http://minio:9000 --kafka-bootstrap-servers kafka:9094
+    restart: on-failure
 
   bombastic-api:
     image: $TRUST_IMAGE:${TRUST_VERSION:?}
@@ -25,24 +31,35 @@ services:
     ports:
       - "$BOMBASTIC_API_PORT:8080"
     command: bombastic api --devmode --storage-endpoint http://minio:9000
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9010" ]
     environment:
       ISSUER_URL: http://keycloak:8080/realms/chicken
+      INFRASTRUCTURE_ENABLED: "true"
 
   bombastic-indexer:
     image: $TRUST_IMAGE:${TRUST_VERSION:?}
     command: bombastic indexer --devmode --storage-endpoint http://minio:9000 --kafka-bootstrap-servers kafka:9094
+    restart: on-failure
 
   spog-api:
     image: $TRUST_IMAGE:${TRUST_VERSION:?}
     depends_on:
       - keycloak
+      - bombastic-api
+      - vexination-api
     expose:
       - "$SPOG_API_PORT"
     ports:
       - "$SPOG_API_PORT:8080"
     command: spog api --devmode --bombastic-url http://bombastic-api:8080 --vexination-url http://vexination-api:8080
+    restart: on-failure
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9010" ]
     environment:
       ISSUER_URL: http://keycloak:8080/realms/chicken
+      INFRASTRUCTURE_ENABLED: "true"
 
   spog-ui:
     image: $TRUST_UI_IMAGE:${TRUST_VERSION:?}
@@ -53,6 +70,9 @@ services:
       # the issuer URL is passed to the browser, which is running on the host, not insider the container, so the
       # URL is "localhost"
       - ISSUER_URL=http://localhost:8090/realms/chicken
+    depends_on:
+      - spog-api
+    restart: on-failure
     expose:
       - "$SPOG_UI_PORT"
     ports:

--- a/deploy/compose/compose-walkers.yaml
+++ b/deploy/compose/compose-walkers.yaml
@@ -10,3 +10,6 @@ services:
   bombastic-walker:
     image: $TRUST_IMAGE:${TRUST_VERSION:?}
     command: bombastic walker --bombastic-url http://bombastic-api:8080 --scripts-path /usr/bin
+    depends_on:
+      bombastic-api:
+        condition: service_healthy

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -85,9 +85,9 @@ services:
     # FIXME: unable to define a health check: https://github.com/keycloak/keycloak/issues/21941
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080"]
-      interval: 10s
+      interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 20
 
   init-keycloak:
     image: quay.io/keycloak/keycloak:20.0.0

--- a/infrastructure/Cargo.toml
+++ b/infrastructure/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1.0"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["time", "signal"] }
 opentelemetry = { version = "0.19.0", features = ["rt-tokio"] }
 tracing-bunyan-formatter = "0.3.7"
 actix-web-opentelemetry = "0.13.0"


### PR DESCRIPTION
Also: add a sigterm handler to all processes using `Infrastructure` to enable shutdown without the need for `SIGKILL`.