### PR TITLE
issue 348

### DIFF
--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -6,10 +6,10 @@ use cyclonedx_bom::models::{
     hash::HashAlgorithm,
     license::{LicenseChoice, LicenseIdentifier},
 };
-use tantivy::collector::TopDocs;
 use log::{debug, info, warn};
 use sikula::prelude::*;
 use spdx_rs::models::Algorithm;
+use tantivy::collector::TopDocs;
 use tantivy::query::TermSetQuery;
 use tantivy::{
     query::{AllQuery, BooleanQuery},
@@ -443,8 +443,17 @@ impl trustification_index::Index for Index {
         Ok(query)
     }
 
-    fn search(&self, searcher: &Searcher, query: &dyn Query, offset: usize, limit: usize) -> Result<(Vec<(f32, DocAddress)>, usize), SearchError> {
-        Ok(searcher.search(query, &(TopDocs::with_limit(limit).and_offset(offset), tantivy::collector::Count))?)
+    fn search(
+        &self,
+        searcher: &Searcher,
+        query: &dyn Query,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(f32, DocAddress)>, usize), SearchError> {
+        Ok(searcher.search(
+            query,
+            &(TopDocs::with_limit(limit).and_offset(offset), tantivy::collector::Count),
+        )?)
     }
 
     fn process_hit(

--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -6,6 +6,7 @@ use cyclonedx_bom::models::{
     hash::HashAlgorithm,
     license::{LicenseChoice, LicenseIdentifier},
 };
+use tantivy::collector::TopDocs;
 use log::{debug, info, warn};
 use sikula::prelude::*;
 use spdx_rs::models::Algorithm;
@@ -440,6 +441,10 @@ impl trustification_index::Index for Index {
 
         debug!("Processed query: {:?}", query);
         Ok(query)
+    }
+
+    fn search(&self, searcher: &Searcher, query: &dyn Query, offset: usize, limit: usize) -> Result<(Vec<(f32, DocAddress)>, usize), SearchError> {
+        Ok(searcher.search(query, &(TopDocs::with_limit(limit).and_offset(offset), tantivy::collector::Count))?)
     }
 
     fn process_hit(

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -107,7 +107,13 @@ pub trait Index {
     fn settings(&self) -> IndexSettings;
     fn schema(&self) -> Schema;
     fn prepare_query(&self, q: &str) -> Result<Box<dyn Query>, Error>;
-    fn search(&self, searcher: &Searcher, query: &dyn Query, offset: usize, limit: usize) -> Result<(Vec<(f32, DocAddress)>, usize), Error>;
+    fn search(
+        &self,
+        searcher: &Searcher,
+        query: &dyn Query,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(f32, DocAddress)>, usize), Error>;
     fn process_hit(
         &self,
         doc: DocAddress,
@@ -550,8 +556,17 @@ mod tests {
             Ok(id.unwrap_or("").to_string())
         }
 
-        fn search(&self, searcher: &Searcher, query: &dyn Query, offset: usize, limit: usize) -> Result<(Vec<(f32, DocAddress)>, usize), Error> {
-            Ok(searcher.search(query, &(TopDocs::with_limit(limit).and_offset(offset), tantivy::collector::Count))?)
+        fn search(
+            &self,
+            searcher: &Searcher,
+            query: &dyn Query,
+            offset: usize,
+            limit: usize,
+        ) -> Result<(Vec<(f32, DocAddress)>, usize), Error> {
+            Ok(searcher.search(
+                query,
+                &(TopDocs::with_limit(limit).and_offset(offset), tantivy::collector::Count),
+            )?)
         }
 
         fn index_doc(&self, id: &str, document: &Self::Document) -> Result<Vec<Document>, Error> {

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -309,7 +309,7 @@ impl trustification_index::Index for Index {
                                     }
                                 }
                                 log::trace!("CVSS score impact {} -> {}", tweaked, (score as f32) * tweaked);
-                                tweaked = (score as f32) * tweaked;
+                                tweaked *= score as f32;
 
                                 // Now look at the date, normalize score between 0 and 1 (baseline 1970)
                                 if let Ok(date_reader) = &date_reader {
@@ -326,7 +326,7 @@ impl trustification_index::Index for Index {
                                             tweaked,
                                             tweaked * (normalized as f32)
                                         );
-                                        tweaked = tweaked * (normalized as f32);
+                                        tweaked *= normalized as f32;
                                     }
                                 }
                             }

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -14,7 +14,7 @@ use sikula::prelude::*;
 use tantivy::{
     query::{AllQuery, TermSetQuery},
     store::ZstdCompressor,
-    DocAddress, IndexSettings, Searcher, SnippetGenerator,
+    DocAddress, IndexSettings, Searcher, SnippetGenerator, collector::TopDocs,
 };
 use trustification_api::search::SearchOptions;
 use trustification_index::{
@@ -262,6 +262,10 @@ impl trustification_index::Index for Index {
 
         debug!("Processed query: {:?}", query);
         Ok(query)
+    }
+
+    fn search(&self, searcher: &Searcher, query: &dyn Query, offset: usize, limit: usize) -> Result<(Vec<(f32, DocAddress)>, usize), SearchError> {
+        Ok(searcher.search(query, &(TopDocs::with_limit(limit).and_offset(offset), tantivy::collector::Count))?)
     }
 
     fn process_hit(


### PR DESCRIPTION
 * Use CVSS score to boost documents that are more important
 * Use time since advisory release to boost documents that are more recent. For docs that are more recent than 1 month, boost them more.

This is likely to need further tuning as we get more experience in using search.