### PR TITLE
Allow disabling authorization

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -53,7 +53,7 @@ The default credentials for single sign on are:
 * **Username:** `admin`
 * **Password:** `admin123456`
 
-When running with `--devmode`, you can request an access token using:
+When running with `--devmode` and authentication enabled, you can request an access token using:
 
 ```shell
 curl -s -d "client_id=walker" -d "client_secret=ZVzq9AMOVUdMY1lSohpx1jI3aW56QDPS" -d 'grant_type=client_credentials' \
@@ -72,6 +72,7 @@ echo "Access Token: $TOKEN"
 
 You can then add `$CURL_OPTS` to all `curl` calls in order to use the token.
 
+
 ## APIs
 
 To run the API processes, you can use cargo:
@@ -81,6 +82,8 @@ RUST_LOG=info cargo run -p trust -- vexination api --devmode -p 8081 &
 RUST_LOG=info cargo run -p trust -- bombastic api --devmode -p 8082 &
 RUST_LOG=info cargo run -p trust -- spog api --devmode -p 8083  &
 ```
+
+If you want to disable authentication (not recommended unless you are not exposing any services outside localhost), you can pass the `--authentication-disabled` flag to the above commands.
 
 ## Indexing
 

--- a/auth/src/authenticator/config.rs
+++ b/auth/src/authenticator/config.rs
@@ -21,9 +21,9 @@ pub struct AuthenticatorConfig {
 
 impl AuthenticatorConfig {
     /// Create "devmode" configuration
-    pub fn devmode() -> Self {
+    pub fn devmode(disabled: bool) -> Self {
         AuthenticatorConfig {
-            disabled: false,
+            disabled,
             clients: SingleAuthenticatorClientConfig {
                 client_ids: devmode::CLIENT_IDS.iter().map(|s| s.to_string()).collect(),
                 issuer_url: devmode::issuer_url(),

--- a/auth/src/authenticator/mod.rs
+++ b/auth/src/authenticator/mod.rs
@@ -31,7 +31,7 @@ impl Authenticator {
 
     pub async fn from_devmode_or_config(devmode: bool, config: AuthenticatorConfig) -> anyhow::Result<Option<Self>> {
         match devmode {
-            true => Self::from_config(AuthenticatorConfig::devmode()).await,
+            true => Self::from_config(AuthenticatorConfig::devmode(config.disabled)).await,
             false => Self::from_config(config).await,
         }
     }

--- a/auth/src/authorizer/mod.rs
+++ b/auth/src/authorizer/mod.rs
@@ -1,0 +1,31 @@
+use crate::authenticator::{error::AuthorizationError, user::UserDetails};
+
+#[derive(Debug, Clone, Copy)]
+pub enum Authorizer {
+    Enabled,
+    Disabled,
+}
+
+impl Default for Authorizer {
+    fn default() -> Self {
+        Self::Enabled
+    }
+}
+
+impl Authorizer {
+    pub fn require_role(&self, user: Option<UserDetails>, role: impl AsRef<str>) -> Result<(), AuthorizationError> {
+        match self {
+            Self::Enabled => {
+                if let Some(user) = user {
+                    user.require_role(role)
+                } else {
+                    Err(AuthorizationError::Failed)
+                }
+            }
+            Self::Disabled => {
+                log::warn!("WARNING: Authorization disabled, all permissions granted");
+                Ok(())
+            }
+        }
+    }
+}

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod authenticator;
+pub mod authorizer;
 pub mod client;
 pub mod devmode;
 

--- a/bombastic/api/src/lib.rs
+++ b/bombastic/api/src/lib.rs
@@ -12,9 +12,9 @@ use actix_web_prom::PrometheusMetricsBuilder;
 use anyhow::anyhow;
 use prometheus::Registry;
 use tokio::sync::RwLock;
-use trustification_auth::authenticator::config::AuthenticatorConfig;
 use trustification_auth::authenticator::Authenticator;
 use trustification_auth::swagger_ui::{SwaggerUiOidc, SwaggerUiOidcConfig};
+use trustification_auth::{authenticator::config::AuthenticatorConfig, authorizer::Authorizer};
 use trustification_index::{IndexConfig, IndexStore};
 use trustification_infrastructure::app::{new_app, AppOptions};
 use trustification_infrastructure::{Infrastructure, InfrastructureConfig};
@@ -87,6 +87,11 @@ impl Run {
                         cors: Some(cors),
                         metrics: Some(http_metrics),
                         authenticator: None,
+                        authorizer: if self.devmode {
+                            Authorizer::Disabled
+                        } else {
+                            Authorizer::Enabled
+                        },
                     })
                     .app_data(web::Data::new(state.clone()))
                     .configure(move |svc| server::config(svc, authenticator.clone(), swagger_oidc.clone()))

--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -20,6 +20,7 @@ use serde::Deserialize;
 use trustification_api::search::SearchOptions;
 use trustification_auth::{
     authenticator::{user::UserDetails, Authenticator},
+    authorizer::Authorizer,
     swagger_ui::SwaggerUiOidc,
     ROLE_MANAGER,
 };
@@ -255,9 +256,10 @@ async fn publish_sbom(
     params: web::Query<IdentifierParams>,
     payload: web::Payload,
     content_type: Option<web::Header<ContentType>>,
-    user: UserDetails,
+    authorizer: web::Data<Authorizer>,
+    user: Option<UserDetails>,
 ) -> actix_web::Result<impl Responder> {
-    user.require_role(ROLE_MANAGER)?;
+    authorizer.require_role(user, ROLE_MANAGER)?;
 
     let typ = verify_type(content_type)?;
     let enc = verify_encoding(req.headers().get(CONTENT_ENCODING))?;
@@ -316,9 +318,10 @@ fn verify_encoding(content_encoding: Option<&HeaderValue>) -> Result<Option<&str
 async fn delete_sbom(
     state: web::Data<SharedState>,
     params: web::Query<IdentifierParams>,
-    user: UserDetails,
+    authorizer: web::Data<Authorizer>,
+    user: Option<UserDetails>,
 ) -> actix_web::Result<impl Responder> {
-    user.require_role(ROLE_MANAGER)?;
+    authorizer.require_role(user, ROLE_MANAGER)?;
 
     let params = params.into_inner();
     let id = &params.id;

--- a/infrastructure/src/app.rs
+++ b/infrastructure/src/app.rs
@@ -10,12 +10,14 @@ use actix_web_extras::middleware::Condition;
 use actix_web_prom::PrometheusMetrics;
 use std::sync::Arc;
 use trustification_auth::authenticator::Authenticator;
+use trustification_auth::authorizer::Authorizer;
 
 #[derive(Default)]
 pub struct AppOptions {
     pub cors: Option<Cors>,
     pub metrics: Option<PrometheusMetrics>,
     pub authenticator: Option<Arc<Authenticator>>,
+    pub authorizer: Authorizer,
 }
 
 #[macro_export]
@@ -51,6 +53,8 @@ pub fn new_app(
     App::new()
         // Handle authentication, might fail and return early
         .wrap(new_auth!(options.authenticator))
+        // Handle authorization
+        .app_data(actix_web::web::Data::new(options.authorizer))
         // Handle CORS requests, this might finish early and not pass requests to the next entry
         .wrap(Condition::from_option(options.cors))
         // Next, record metrics for the request (should never fail)

--- a/spog/api/src/server.rs
+++ b/spog/api/src/server.rs
@@ -10,6 +10,7 @@ use spog_model::search;
 use trustification_api::{search::SearchOptions, Apply};
 use trustification_auth::{
     authenticator::Authenticator,
+    authorizer::Authorizer,
     client::{TokenInjector, TokenProvider},
     swagger_ui::SwaggerUiOidc,
 };
@@ -98,6 +99,11 @@ impl Server {
                 cors: Some(cors),
                 metrics: Some(http_metrics),
                 authenticator: None, // we map this explicitly
+                authorizer: if self.run.devmode {
+                    Authorizer::Disabled
+                } else {
+                    Authorizer::Enabled
+                },
             })
             .app_data(web::Data::new(state))
             .configure(index::configure())

--- a/vexination/api/src/lib.rs
+++ b/vexination/api/src/lib.rs
@@ -12,10 +12,9 @@ use actix_web_prom::PrometheusMetricsBuilder;
 use anyhow::anyhow;
 use prometheus::Registry;
 use tokio::sync::RwLock;
-use trustification_auth::{
-    authenticator::{config::AuthenticatorConfig, Authenticator},
-    swagger_ui::{SwaggerUiOidc, SwaggerUiOidcConfig},
-};
+use trustification_auth::authenticator::Authenticator;
+use trustification_auth::swagger_ui::{SwaggerUiOidc, SwaggerUiOidcConfig};
+use trustification_auth::{authenticator::config::AuthenticatorConfig, authorizer::Authorizer};
 use trustification_index::{IndexConfig, IndexStore};
 use trustification_infrastructure::{
     app::{new_app, AppOptions},
@@ -88,6 +87,11 @@ impl Run {
                         cors: Some(cors),
                         metrics: Some(http_metrics),
                         authenticator: None,
+                        authorizer: if self.devmode {
+                            Authorizer::Disabled
+                        } else {
+                            Authorizer::Enabled
+                        },
                     })
                     .app_data(web::Data::new(state.clone()))
                     .configure(move |svc| server::config(svc, authenticator.clone(), swagger_oidc.clone()))

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use trustification_api::search::SearchOptions;
 use trustification_auth::{
     authenticator::{user::UserDetails, Authenticator},
+    authorizer::Authorizer,
     swagger_ui::SwaggerUiOidc,
     ROLE_MANAGER,
 };
@@ -118,9 +119,10 @@ async fn publish_vex(
     state: web::Data<SharedState>,
     params: web::Query<PublishParams>,
     data: Bytes,
-    user: UserDetails,
+    authorizer: web::Data<Authorizer>,
+    user: Option<UserDetails>,
 ) -> actix_web::Result<HttpResponse> {
-    user.require_role(ROLE_MANAGER)?;
+    authorizer.require_role(user, ROLE_MANAGER)?;
 
     let params = params.into_inner();
     let advisory = if let Some(advisory) = params.advisory {


### PR DESCRIPTION
Add an authorizer to APIs that controls if a request should be authorized based on user details.  When --devmode is enabled, authorization is disabled (authentication still enabled), otherwise it is always enabled.