### PR TITLE
Enable integs to assert certain events occur

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [registries.crates-io]
 protocol = "sparse"
+
+[env]
+RUST_TEST_THREADS = "10"

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Test
         run: |
-          RUST_LOG=info cargo test -p integration-tests -- --nocapture
+          RUST_LOG=tantivy=off,info cargo test -p integration-tests -- --nocapture --test-threads=3
           docker-compose -f deploy/compose/compose.yaml ps
 
       - name: Print logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,6 +3276,7 @@ dependencies = [
  "log",
  "ntest",
  "openid",
+ "prometheus",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,6 +3291,7 @@ dependencies = [
  "trustification-infrastructure",
  "trustification-storage",
  "urlencoding",
+ "uuid",
  "vexination-api",
  "vexination-indexer",
 ]

--- a/bombastic/testdata/ubi9-sbom.json
+++ b/bombastic/testdata/ubi9-sbom.json
@@ -13608,7 +13608,7 @@
       "originator": "NOASSERTION",
       "packageFileName": "NOASSERTION",
       "supplier": "Organization: Red Hat",
-      "versionInfo": "ubi9-container-9.1.0-1782.testdata"
+      "versionInfo": "ubi9-container-9.1.0-1782.noarch"
     }
   ],
   "relationships": [

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -37,3 +37,4 @@ trustification-index = { path = "../index" }
 env_logger = "0.10"
 urlencoding = "2.1.2"
 spog-model = { path = "../spog/model" }
+prometheus = "0.13.3"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -34,6 +34,7 @@ trustification-storage = { path = "../storage" }
 trustification-index = { path = "../index" }
 
 prometheus = "0.13.3"
+uuid = "1"
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -33,8 +33,9 @@ trustification-infrastructure = { path = "../infrastructure" }
 trustification-storage = { path = "../storage" }
 trustification-index = { path = "../index" }
 
+prometheus = "0.13.3"
+
 [dev-dependencies]
 env_logger = "0.10"
 urlencoding = "2.1.2"
 spog-model = { path = "../spog/model" }
-prometheus = "0.13.3"

--- a/integration-tests/src/bom.rs
+++ b/integration-tests/src/bom.rs
@@ -85,6 +85,18 @@ pub async fn upload_sbom(port: u16, key: &str, input: &serde_json::Value, contex
     assert_eq!(response.status(), StatusCode::CREATED);
 }
 
+pub async fn delete_sbom(port: u16, key: &str, context: &ProviderContext) {
+    let response = reqwest::Client::new()
+        .delete(format!("http://localhost:{port}/api/v1/sbom?id={key}"))
+        .inject_token(&context.provider_manager)
+        .await
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
 #[async_trait]
 impl AsyncTestContext for BombasticContext {
     async fn setup() -> Self {

--- a/integration-tests/src/bom.rs
+++ b/integration-tests/src/bom.rs
@@ -6,7 +6,7 @@ use test_context::AsyncTestContext;
 pub struct BombasticContext {
     pub provider: ProviderContext,
     pub port: u16,
-
+    pub config: EventBusConfig,
     _runner: Runner,
 }
 
@@ -15,12 +15,14 @@ pub async fn start_bombastic(provider: ProviderContext) -> BombasticContext {
 
     let listener = TcpListener::bind("localhost:0").unwrap();
     let port = listener.local_addr().unwrap().port();
+    let indexer = bombastic_indexer();
+    let config = indexer.bus.clone();
 
     let runner = Runner::spawn(|| async {
         select! {
             biased;
 
-            bindexer = bombastic_indexer().run() => match bindexer {
+            bindexer = indexer.run() => match bindexer {
                 Err(e) => {
                     panic!("Error running bombastic indexer: {e:?}");
                 }
@@ -46,6 +48,7 @@ pub async fn start_bombastic(provider: ProviderContext) -> BombasticContext {
     let context = BombasticContext {
         port,
         provider,
+        config,
         _runner: runner,
     };
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -265,3 +265,9 @@ pub async fn get_response(
         response.json().await.unwrap()
     }
 }
+
+// Return a unique ID
+pub fn id(prefix: &str) -> String {
+    let uuid = uuid::Uuid::new_v4();
+    format!("{prefix}-{uuid}")
+}

--- a/integration-tests/src/provider.rs
+++ b/integration-tests/src/provider.rs
@@ -27,7 +27,5 @@ async fn create_provider(client_id: &str) -> Arc<OpenIdTokenProvider> {
 
     let provider = trustification_auth::client::OpenIdTokenProvider::new(client_user, chrono::Duration::seconds(10));
 
-    println!("Initial access token: {:?}", provider.provide_access_token().await);
-
     Arc::new(provider)
 }

--- a/integration-tests/src/vex.rs
+++ b/integration-tests/src/vex.rs
@@ -6,7 +6,7 @@ use test_context::AsyncTestContext;
 pub struct VexinationContext {
     pub provider: ProviderContext,
     pub port: u16,
-
+    pub config: EventBusConfig,
     _runner: Runner,
 }
 
@@ -15,12 +15,14 @@ pub async fn start_vexination(provider: ProviderContext) -> VexinationContext {
 
     let listener = TcpListener::bind("localhost:0").unwrap();
     let port = listener.local_addr().unwrap().port();
+    let indexer = vexination_indexer();
+    let config = indexer.bus.clone();
 
     let runner = Runner::spawn(|| async {
         select! {
             biased;
 
-            vindexer = vexination_indexer().run() => match vindexer {
+            vindexer = indexer.run() => match vindexer {
                 Err(e) => {
                     panic!("Error running vexination indexer: {e:?}");
                 }
@@ -47,6 +49,7 @@ pub async fn start_vexination(provider: ProviderContext) -> VexinationContext {
     let context = VexinationContext {
         port,
         provider,
+        config,
         _runner: runner,
     };
 

--- a/integration-tests/tests/bombastic.rs
+++ b/integration-tests/tests/bombastic.rs
@@ -352,7 +352,6 @@ async fn test_upload_user_not_allowed(context: &mut BombasticContext) {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    println!("{:?}", response);
 }
 
 #[test_context(BombasticContext)]
@@ -369,7 +368,6 @@ async fn test_upload_unauthorized(context: &mut BombasticContext) {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    println!("{:?}", response);
 }
 
 #[test_context(BombasticContext)]
@@ -390,7 +388,6 @@ async fn test_delete_user_not_allowed(context: &mut BombasticContext) {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    println!("{:?}", response);
 }
 
 #[test_context(BombasticContext)]
@@ -408,7 +405,6 @@ async fn test_delete_unauthorized(context: &mut BombasticContext) {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    println!("{:?}", response);
 }
 
 #[test_context(BombasticContext)]

--- a/integration-tests/tests/spog.rs
+++ b/integration-tests/tests/spog.rs
@@ -90,8 +90,6 @@ async fn test_search_forward_vexination(context: &mut SpogContext) {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
-    let data: Value = response.json().await.unwrap();
-    println!("{data:#?}");
 }
 
 #[test_with::env(CRDA_URL)]

--- a/integration-tests/tests/vexination.rs
+++ b/integration-tests/tests/vexination.rs
@@ -187,7 +187,6 @@ async fn test_upload_vex_empty_json(context: &mut VexinationContext) {
             .send()
             .await
             .unwrap();
-        println!("{:?}", response);
         assert_eq!(response.status(), StatusCode::CREATED);
     })
     .await;
@@ -212,7 +211,6 @@ async fn test_upload_vex_empty_file(vexination: &mut VexinationContext) {
             .await
             .unwrap();
         remove_file(&file_path).await.unwrap();
-        println!("{:?}", response);
         assert_eq!(response.status(), StatusCode::CREATED);
     })
     .await;


### PR DESCRIPTION
Fixes #363 

Includes a new `wait_for_event` helper and demonstrates how unique id's can help mitigate test confusion stemming from stale data persisting in local stores (minio/kafka) across test runs.