### PR TITLE
feat: support using s3 directly as index backing store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "block_on_proc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b872f3528eeeb4370ee73b51194dc1cd93680c2d0eb6c7a223889038d2c1a167"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "blocking"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5058,6 +5068,7 @@ dependencies = [
  "aws-creds",
  "aws-region",
  "base64 0.21.2",
+ "block_on_proc",
  "bytes",
  "cfg-if",
  "futures",
@@ -6970,20 +6981,25 @@ dependencies = [
 name = "trustification-index"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "clap",
+ "crc32fast",
  "env_logger",
  "humantime",
  "log",
  "prometheus",
  "rand 0.8.5",
+ "rust-s3",
  "serde",
  "serde_json",
  "sikula",
  "tantivy",
  "tar",
+ "thiserror",
  "time 0.3.23",
  "tokio",
  "trustification-api",
+ "trustification-storage",
  "zstd",
 ]
 

--- a/bombastic/api/src/lib.rs
+++ b/bombastic/api/src/lib.rs
@@ -12,6 +12,7 @@ use actix_web_prom::PrometheusMetricsBuilder;
 use anyhow::anyhow;
 use prometheus::Registry;
 use tokio::sync::RwLock;
+use tokio::task::block_in_place;
 use trustification_auth::authenticator::Authenticator;
 use trustification_auth::swagger_ui::{SwaggerUiOidc, SwaggerUiOidcConfig};
 use trustification_auth::{authenticator::config::AuthenticatorConfig, authorizer::Authorizer};
@@ -111,13 +112,13 @@ impl Run {
     }
 
     fn configure(
-        index: IndexConfig,
+        index_config: IndexConfig,
         mut storage: StorageConfig,
         registry: &Registry,
         devmode: bool,
     ) -> anyhow::Result<Arc<AppState>> {
-        let sync_interval: Duration = index.sync_interval.into();
-        let index = IndexStore::new(&index, bombastic_index::Index::new(), registry)?;
+        let index =
+            block_in_place(|| IndexStore::new(&storage, &index_config, bombastic_index::Index::new(), registry))?;
         let storage = storage.create("bombastic", devmode, registry)?;
 
         let state = Arc::new(AppState {
@@ -126,6 +127,7 @@ impl Run {
         });
 
         let sinker = state.clone();
+        let sync_interval = index_config.sync_interval.into();
         tokio::task::spawn(async move {
             loop {
                 if sinker.sync_index().await.is_ok() {
@@ -159,14 +161,9 @@ pub(crate) type SharedState = Arc<AppState>;
 
 impl AppState {
     async fn sync_index(&self) -> Result<(), anyhow::Error> {
-        let data = {
-            let storage = self.storage.read().await;
-            storage.get_index().await?
-        };
-
+        let storage = self.storage.read().await;
         let mut index = self.index.write().await;
-        index.reload(&data[..])?;
-        log::debug!("Bombastic index reloaded");
+        index.sync(&storage).await?;
         Ok(())
     }
 }

--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -453,7 +453,7 @@ impl trustification_index::Index for Index {
             });
         }
 
-        let mut query = Packages::parse(q).map_err(|err| SearchError::Parser(err.to_string()))?;
+        let mut query = Packages::parse(q).map_err(|err| SearchError::QueryParser(err.to_string()))?;
 
         query.term = query.term.compact();
 

--- a/bombastic/indexer/src/lib.rs
+++ b/bombastic/indexer/src/lib.rs
@@ -2,6 +2,7 @@ use std::process::ExitCode;
 
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
+use tokio::task::block_in_place;
 use trustification_event_bus::EventBusConfig;
 use trustification_index::{IndexConfig, IndexStore};
 use trustification_indexer::{actix::configure, Indexer, IndexerStatus};
@@ -31,13 +32,13 @@ pub struct Run {
     pub bus: EventBusConfig,
 
     #[command(flatten)]
-    pub index: IndexConfig,
-
-    #[command(flatten)]
     pub storage: StorageConfig,
 
     #[command(flatten)]
     pub infra: InfrastructureConfig,
+
+    #[command(flatten)]
+    pub index: IndexConfig,
 }
 
 impl Run {
@@ -50,10 +51,16 @@ impl Run {
             .run_with_config(
                 "bombastic-indexer",
                 |metrics| async move {
-                    let index = IndexStore::new(&self.index, bombastic_index::Index::new(), metrics.registry())?;
+                    let index = block_in_place(|| {
+                        IndexStore::new(
+                            &self.storage,
+                            &self.index,
+                            bombastic_index::Index::new(),
+                            metrics.registry(),
+                        )
+                    })?;
                     let storage = self.storage.create("bombastic", self.devmode, metrics.registry())?;
 
-                    let interval = self.index.sync_interval.into();
                     let bus = self.bus.create(metrics.registry()).await?;
                     if self.devmode {
                         bus.create(&[self.stored_topic.as_str()]).await?;
@@ -70,7 +77,7 @@ impl Run {
                         stored_topic: self.stored_topic.as_str(),
                         indexed_topic: self.indexed_topic.as_str(),
                         failed_topic: self.failed_topic.as_str(),
-                        sync_interval: interval,
+                        sync_interval: self.index.sync_interval.into(),
                         status: s.clone(),
                         commands: command_receiver,
                         command_sender: c,

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -15,7 +15,11 @@ tantivy = "0.19.2"
 tar = "0.4"
 time = "0.3"
 zstd = "0.12"
-
+rust-s3 = { git = "https://github.com/jcrossley3/rust-s3.git", branch = "issue-352", features = ["blocking"] }
+crc32fast = "1.3.2"
+async-trait = "0.1"
+trustification-storage = { path = "../storage"}
+thiserror = "1"
 trustification-api = { path = "../api"}
 
 [dev-dependencies]

--- a/index/src/s3dir.rs
+++ b/index/src/s3dir.rs
@@ -1,0 +1,361 @@
+use std::{
+    fmt::Debug,
+    io::{self, BufWriter, Write},
+    ops::Range,
+    path::Path,
+    sync::Arc,
+};
+
+pub use s3::{creds::Credentials, Region};
+use s3::{error::S3Error, Bucket};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time::Duration;
+use tantivy::{
+    directory::{
+        error::{DeleteError, OpenReadError, OpenWriteError},
+        FileHandle, OwnedBytes, TerminatingWrite, WatchCallback, WatchHandle, WritePtr,
+    },
+    Directory, HasLen,
+};
+
+use crc32fast::Hasher;
+
+use tantivy::directory::WatchCallbackList;
+
+#[derive(Clone)]
+pub struct S3Directory {
+    bucket: Bucket,
+    watcher: Arc<S3FileWatcher>,
+}
+
+impl Debug for S3Directory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3Directory")
+            .field("bucket", &"foo".to_string())
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct S3File {
+    bucket: Bucket,
+    path: String,
+    data: Vec<u8>,
+}
+
+impl S3File {
+    fn new(path: &str, bucket: Bucket, data: Vec<u8>) -> Self {
+        // log::info!("{}: New s3 file with len {}", path, data.len());
+        Self {
+            bucket,
+            path: path.to_string(),
+            data,
+        }
+    }
+}
+
+impl FileHandle for S3File {
+    fn read_bytes(&self, range: Range<usize>) -> std::io::Result<OwnedBytes> {
+        //        let data = self.bucket.get_object_range_blocking(&self.path, range.start as u64, Some(range.end as u64)).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let data: Vec<u8> = self.data[range].to_vec();
+        Ok(OwnedBytes::new(data))
+    }
+}
+
+impl Write for S3File {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // log::info!("{}: WRITE {} bytes", self.path, buf.len());
+        self.data.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // log::info!("{}: FLUSH {} bytes", self.path, self.data.len());
+        Ok(())
+    }
+}
+
+impl TerminatingWrite for S3File {
+    fn terminate_ref(&mut self, _: tantivy::directory::AntiCallToken) -> io::Result<()> {
+        // log::info!("{}: TERMINATE REF, size is {}", self.path, self.data.len());
+        match self.bucket.put_object_blocking(&self.path, &self.data[..]) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                panic!("{:?}", e);
+            }
+        }
+    }
+}
+
+impl HasLen for S3File {
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+/*
+impl core::ops::Deref for S3File {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        todo!()
+    }
+
+}*/
+
+fn s3_to_io(e: S3Error) -> Arc<io::Error> {
+    Arc::new(io::Error::new(io::ErrorKind::Other, e))
+}
+
+impl S3Directory {
+    pub fn new(bucket: Bucket) -> Self {
+        let root_path = Path::new(INDEX_PATH);
+        Self {
+            bucket: bucket.clone(),
+            watcher: Arc::new(S3FileWatcher::new(bucket, &root_path.join("meta.json"))),
+        }
+    }
+}
+
+const INDEX_PATH: &str = "/index/";
+impl Directory for S3Directory {
+    fn get_file_handle(&self, path: &Path) -> Result<Arc<dyn FileHandle>, OpenReadError> {
+        if let Some(p) = path.to_str() {
+            let p = format!("{}{}", INDEX_PATH, p);
+            // log::info!("{}: Get file handle", p);
+            let p2 = p.clone();
+            let pb = path.to_path_buf();
+            let bucket = self.bucket.clone();
+            let result = bucket.get_object_blocking(&p).map_err(|e| {
+                // log::info!("GET FILE HANDLE ERROR: {:?}", e);
+                OpenReadError::IoError {
+                    io_error: s3_to_io(e),
+                    filepath: pb,
+                }
+            })?;
+            Ok(Arc::new(S3File::new(&p2, self.bucket.clone(), result.to_vec())))
+        } else {
+            // log::info!("ARROR MAKING STR OF PATH {:?}", path);
+
+            Err(OpenReadError::FileDoesNotExist(path.to_path_buf()))
+        }
+    }
+
+    fn delete(&self, path: &Path) -> Result<(), DeleteError> {
+        if let Some(p) = path.to_str() {
+            let p = format!("{}{}", INDEX_PATH, p);
+            // log::info!("DELETE {}", p);
+            self.bucket.delete_object_blocking(p).map_err(|e| {
+                // log::info!("DELETE IO ERROR :{:?}", e);
+                DeleteError::IoError {
+                    io_error: s3_to_io(e),
+                    filepath: path.to_path_buf(),
+                }
+            })?;
+            Ok(())
+        } else {
+            Err(DeleteError::FileDoesNotExist(path.to_path_buf()))
+        }
+    }
+
+    fn exists(&self, path: &Path) -> Result<bool, OpenReadError> {
+        if let Some(p) = path.to_str() {
+            let p = format!("{}{}", INDEX_PATH, p);
+            // log::info!("{}: check exists", p);
+            let bucket = self.bucket.clone();
+            let result = bucket.head_object_blocking(p);
+
+            match result {
+                Err(S3Error::HttpFailWithBody(status, _)) if status == 404 => Ok(false),
+                Err(e) => {
+                    // log::info!("EXISTS ERROR: {:?}", e);
+                    Err(OpenReadError::IoError {
+                        io_error: s3_to_io(e),
+                        filepath: path.to_path_buf(),
+                    })
+                }
+                Ok(_) => Ok(true),
+            }
+        } else {
+            // log::info!("ARROR MAKING STR OF PATH {:?}", path);
+            Err(OpenReadError::FileDoesNotExist(path.to_path_buf()))
+        }
+    }
+
+    fn open_write(&self, path: &Path) -> Result<WritePtr, OpenWriteError> {
+        if let Some(p) = path.to_str() {
+            let p = format!("{}{}", INDEX_PATH, p);
+            // log::info!("{}: open write", p);
+            let bucket = self.bucket.clone();
+            let result = bucket.get_object_blocking(&p);
+
+            if let Err(S3Error::HttpFailWithBody(404, _)) = result {
+                Ok(BufWriter::new(Box::new(S3File::new(
+                    &p,
+                    self.bucket.clone(),
+                    Vec::new(),
+                ))))
+            } else {
+                Err(OpenWriteError::FileAlreadyExists(path.to_path_buf()))
+            }
+        } else {
+            // log::info!("OPEN WRITE IO ERROR");
+            Err(OpenWriteError::IoError {
+                io_error: Arc::new(io::Error::new(io::ErrorKind::Other, "".to_string())),
+                filepath: path.to_path_buf(),
+            })
+        }
+    }
+
+    fn atomic_read(&self, path: &Path) -> Result<Vec<u8>, OpenReadError> {
+        if let Some(p) = path.to_str() {
+            let p = format!("{}{}", INDEX_PATH, p);
+            // log::info!("{}: atomic read", p);
+            let bucket = self.bucket.clone();
+            let result = bucket.get_object_blocking(p);
+
+            match result {
+                Err(S3Error::HttpFailWithBody(status, _)) if status == 404 => {
+                    Err(OpenReadError::FileDoesNotExist(path.to_path_buf()))
+                }
+                Err(e) => {
+                    // log::info!("aTOMIC READ ERROR: {:?}", e);
+                    Err(OpenReadError::IoError {
+                        io_error: s3_to_io(e),
+                        filepath: path.to_path_buf(),
+                    })
+                }
+                Ok(data) => Ok(data.to_vec()),
+            }
+        } else {
+            // log::info!("ARROR MAKING STR OF PATH {:?}", path);
+            Err(OpenReadError::FileDoesNotExist(path.to_path_buf()))
+        }
+    }
+
+    fn atomic_write(&self, path: &Path, data: &[u8]) -> std::io::Result<()> {
+        if let Some(p) = path.to_str() {
+            let p = format!("{}{}", INDEX_PATH, p);
+            // log::info!("{}: atomic write", p);
+            let bucket = self.bucket.clone();
+            let data = data.to_vec();
+            let result = bucket.put_object_blocking(p, &data);
+
+            match result {
+                Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
+                Ok(_) => Ok(()),
+            }
+        } else {
+            Err(io::Error::new(io::ErrorKind::Other, "".to_string()))
+        }
+    }
+
+    fn sync_directory(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    /// Registers a callback that will be called whenever a change on the `meta.json`
+    /// using the [`Directory::atomic_write()`] API is detected.
+    ///
+    /// The behavior when using `.watch()` on a file using [`Directory::open_write()`] is, on the
+    /// other hand, undefined.
+    ///
+    /// The file will be watched for the lifetime of the returned `WatchHandle`. The caller is
+    /// required to keep it.
+    /// It does not override previous callbacks. When the file is modified, all callback that are
+    /// registered (and whose [`WatchHandle`] is still alive) are triggered.
+    ///
+    /// Internally, tantivy only uses this API to detect new commits to implement the
+    /// `OnCommit` `ReloadPolicy`. Not implementing watch in a `Directory` only prevents the
+    /// `OnCommit` `ReloadPolicy` to work properly.
+    fn watch(&self, watch_callback: WatchCallback) -> tantivy::Result<WatchHandle> {
+        Ok(self.watcher.watch(watch_callback))
+    }
+}
+
+const POLLING_INTERVAL: Duration = Duration::from_millis(if cfg!(test) { 1 } else { 500 });
+
+pub struct S3FileWatcher {
+    bucket: Bucket,
+    path: Arc<Path>,
+    callbacks: Arc<WatchCallbackList>,
+    state: Arc<AtomicUsize>, // 0: new, 1: runnable, 2: terminated
+}
+
+impl S3FileWatcher {
+    pub fn new(bucket: Bucket, path: &Path) -> S3FileWatcher {
+        S3FileWatcher {
+            bucket,
+            path: Arc::from(path),
+            callbacks: Default::default(),
+            state: Default::default(),
+        }
+    }
+
+    pub fn spawn(&self) {
+        if self
+            .state
+            .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return;
+        }
+
+        let path = self.path.clone();
+        let callbacks = self.callbacks.clone();
+        let state = self.state.clone();
+
+        let bucket = self.bucket.clone();
+        thread::Builder::new()
+            .name("index-s3-meta-file-watcher".to_string())
+            .spawn(move || {
+                let mut current_checksum_opt = None;
+
+                while state.load(Ordering::SeqCst) == 1 {
+                    if let Ok(checksum) = Self::compute_checksum(&bucket, &path) {
+                        let metafile_has_changed = current_checksum_opt
+                            .map(|current_checksum| current_checksum != checksum)
+                            .unwrap_or(true);
+                        if metafile_has_changed {
+                            log::info!("Meta file {:?} was modified", path);
+                            current_checksum_opt = Some(checksum);
+                            // We actually ignore callbacks failing here.
+                            // We just wait for the end of their execution.
+                            let _ = callbacks.broadcast().wait();
+                        }
+                    }
+
+                    thread::sleep(POLLING_INTERVAL);
+                }
+            })
+            .expect("Failed to spawn meta s3 file watcher thread");
+    }
+
+    pub fn watch(&self, callback: WatchCallback) -> WatchHandle {
+        let handle = self.callbacks.subscribe(callback);
+        self.spawn();
+        handle
+    }
+
+    fn compute_checksum(bucket: &Bucket, path: &Path) -> Result<u32, io::Error> {
+        match bucket.get_object_blocking(path.to_str().unwrap()) {
+            Ok(response) => {
+                let data = response.to_vec();
+
+                let mut hasher = Hasher::new();
+                hasher.update(&data[..]);
+                Ok(hasher.finalize())
+            }
+            Err(e) => {
+                // log::warn!("Failed to open meta file {:?}: {:?}", path, e);
+                Err(io::Error::new(io::ErrorKind::Other, e))
+            }
+        }
+    }
+}
+
+impl Drop for S3FileWatcher {
+    fn drop(&mut self) {
+        self.state.store(2, Ordering::SeqCst);
+    }
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -50,7 +50,8 @@ fn bombastic_indexer() -> bombastic_indexer::Run {
         devmode: true,
         reindex: false,
         index: IndexConfig {
-            index: None,
+            index_dir: None,
+            mode: Default::default(),
             sync_interval: Duration::from_secs(2).into(),
         },
         storage: StorageConfig {
@@ -79,7 +80,8 @@ fn bombastic_api() -> bombastic_api::Run {
         port: 8082,
         devmode: false,
         index: IndexConfig {
-            index: None,
+            index_dir: None,
+            mode: Default::default(),
             sync_interval: Duration::from_secs(2).into(),
         },
         storage: StorageConfig {
@@ -109,7 +111,8 @@ fn vexination_indexer() -> vexination_indexer::Run {
         devmode: true,
         reindex: false,
         index: IndexConfig {
-            index: None,
+            index_dir: None,
+            mode: Default::default(),
             sync_interval: Duration::from_secs(2).into(),
         },
         storage: StorageConfig {
@@ -138,7 +141,8 @@ fn vexination_api() -> vexination_api::Run {
         port: 8081,
         devmode: false,
         index: IndexConfig {
-            index: None,
+            index_dir: None,
+            mode: Default::default(),
             sync_interval: Duration::from_secs(2).into(),
         },
         storage: StorageConfig {

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -85,7 +85,7 @@ impl actix_web::error::ResponseError for Error {
     fn status_code(&self) -> StatusCode {
         match self {
             Self::Storage(StorageError::NotFound) => StatusCode::NOT_FOUND,
-            Self::Index(IndexError::Parser(_)) => StatusCode::BAD_REQUEST,
+            Self::Index(IndexError::QueryParser(_)) => StatusCode::BAD_REQUEST,
             e => {
                 log::error!("{e:?}");
                 StatusCode::INTERNAL_SERVER_ERROR
@@ -243,9 +243,11 @@ async fn search_vex(
 
     log::info!("Querying VEX using {}", params.q);
 
-    let index = state.index.read().await;
-    let (result, total) = index
-        .search(&params.q, params.offset, params.limit, (&params).into())
-        .map_err(Error::Index)?;
+    let (result, total) = actix_web::web::block(move || {
+        let index = state.index.blocking_read();
+        index.search(&params.q, params.offset, params.limit, (&params).into())
+    })
+    .await?
+    .map_err(Error::Index)?;
     Ok(HttpResponse::Ok().json(SearchResult { total, result }))
 }

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -301,7 +301,7 @@ impl trustification_index::Index for Index {
             });
         }
 
-        let mut query = Vulnerabilities::parse(q).map_err(|err| SearchError::Parser(err.to_string()))?;
+        let mut query = Vulnerabilities::parse(q).map_err(|err| SearchError::QueryParser(err.to_string()))?;
 
         query.term = query.term.compact();
 


### PR DESCRIPTION
* Add a runtime config option to enable s3 directory backed index.
* Implement tantivy directory trait based on s3 storage to bypass the local filesystem and syncing.

Issue #333
