### PR TITLE
fix: add Z option to volume mount as an env var

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -11,6 +11,11 @@ For creating new services in trustification, see [NEWSERVICE.md](NEWSERVICE.md).
 
 Requires `docker-compose` to run dependent services.
 
+For Linux systems only:
+``` shell
+$ export SELINUX_VOLUME_OPTIONS=':Z'
+```
+
 ```shell
 cd deploy/compose
 docker-compose -f compose.yaml up

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ the latter, v1.0.6 or higher is required.
 
 To start all dependencies and trustification components:
 
+For Linux systems only:
+``` shell
+$ export SELINUX_VOLUME_OPTIONS=':Z'
+```
+
 First we need to start up the minio, kafka, and keycloak with podman-compose:
 ``` shell
 cd deploy/compose

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -113,6 +113,6 @@ services:
       # So the "frontend" needs to be set to that
       - SSO_FRONTEND_URL=http://localhost:8090
     volumes:
-      - ./container_files/init-sso:/init-sso
+      - ./container_files/init-sso:/init-sso${SELINUX_VOLUME_OPTIONS}
     entrypoint: /usr/bin/bash
     command: /init-sso/init.sh


### PR DESCRIPTION
This commit adds the Z option to the volume mount for init-sso.
    
The motivation for this change is that on Linux systems the SELinux
context for the volume mount is not set correctly and init-keycloak
container is not able access the volume mount.
This can been seen by the following erorr in the logs:
```console
[minio]
podman start -a compose_init-keycloak_1
/usr/bin/bash: /init-sso/init.sh: Permission denied
```
    
Adding this option as an environment variable should fix this issue
and allows the init-keycloak container to access the volume mount.

Refs: [podman-compose-issue.md](https://github.com/danbev/learning-crypto/blob/main/notes/seedwing/podman-compose-issue.md)