### PR TITLE
doc: update instructions for starting containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,21 @@ the latter, v1.0.6 or higher is required.
 
 To start all dependencies and trustification components:
 
+First we need to start up the minio, kafka, and keycloak with podman-compose:
 ``` shell
 cd deploy/compose
-podman-compose -f compose.yaml -f compose-trustification.yaml -f compose-guac.yaml -f compose-walkers.yaml up
+podman-compose -f compose.yaml up
+```
+
+After keycloak has started successfully, which can be checked by verifying that
+the following line is present in the output from the command above:
+``` shell
+[init-keycloak] | SSO initialization complete
+```
+
+After that we can start the additional containers:
+``` shell
+podman-compose -f compose-trustification.yaml -f compose-guac.yaml -f compose-walkers.yaml up
 ```
 
 If you'd like to run [a specific


### PR DESCRIPTION
This commit updates the instructions for starting the containers locally and specifically that the keycloak container needs to be started first and fully initialized before the other containers are started.

The motivation for this change is that the containers that depend on keyclaok will fail because the
http://keycloak:8080/realms/chicken/.well-known/openid-configuration endpoint will not be available that the time they start.

At least this is the behavior that I seeing on Linux and I think it would help others starting up the project to have this information in the README as a possible workaround.

Refs: https://github.com/danbev/learning-crypto/blob/main/notes/seedwing/podman-compose-issue.md#second-issue