### PR TITLE
fix: add wait for keycloak in compose-trustification

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,21 +43,9 @@ For Linux systems only:
 $ export SELINUX_VOLUME_OPTIONS=':Z'
 ```
 
-First we need to start up the minio, kafka, and keycloak with podman-compose:
 ``` shell
 cd deploy/compose
-podman-compose -f compose.yaml up
-```
-
-After keycloak has started successfully, which can be checked by verifying that
-the following line is present in the output from the command above:
-``` shell
-[init-keycloak] | SSO initialization complete
-```
-
-After that we can start the additional containers:
-``` shell
-podman-compose -f compose-trustification.yaml -f compose-guac.yaml -f compose-walkers.yaml up
+podman-compose -f compose.yaml -f compose-trustification.yaml -f compose-guac.yaml -f compose-walkers.yaml up
 ```
 
 If you'd like to run [a specific

--- a/deploy/compose/compose-trustification.yaml
+++ b/deploy/compose/compose-trustification.yaml
@@ -4,12 +4,15 @@ services:
   vexination-api:
     image: $TRUST_IMAGE:${TRUST_VERSION:?TRUST_VERSION is required}
     depends_on:
-      - keycloak
+      - init-keycloak
     expose:
       - "$VEXINATION_API_PORT"
     ports:
       - "$VEXINATION_API_PORT:8080"
-    command: vexination api --devmode --storage-endpoint http://minio:9000
+        #command: vexination api --devmode --storage-endpoint http://minio:9000
+    command:
+      -c 'while [[ "$$(curl --connect-timeout 2 -s -o /dev/null -w ''%{http_code}'' http://keycloak:8080/realms/chicken/.well-known/openid-configuration)" != "200" ]]; do echo waiting for keycloak...; sleep 5; done; echo keycloak is up; /trust vexination api --devmode --storage-endpoint http://minio:9000'
+    entrypoint: /usr/bin/bash
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9010" ]
     restart: on-failure
@@ -25,12 +28,14 @@ services:
   bombastic-api:
     image: $TRUST_IMAGE:${TRUST_VERSION:?}
     depends_on:
-      - keycloak
+      - init-keycloak
     expose:
       - "$BOMBASTIC_API_PORT"
     ports:
       - "$BOMBASTIC_API_PORT:8080"
-    command: bombastic api --devmode --storage-endpoint http://minio:9000
+    command:
+      -c 'while [[ "$$(curl --connect-timeout 2 -s -o /dev/null -w ''%{http_code}'' http://keycloak:8080/realms/chicken/.well-known/openid-configuration)" != "200" ]]; do echo waiting for keycloak...; sleep 5; done; echo keycloak is up; /trust bombastic api --devmode --storage-endpoint http://minio:9000'
+    entrypoint: /usr/bin/bash
     restart: on-failure
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9010" ]
@@ -46,14 +51,16 @@ services:
   spog-api:
     image: $TRUST_IMAGE:${TRUST_VERSION:?}
     depends_on:
-      - keycloak
+      - init-keycloak
       - bombastic-api
       - vexination-api
     expose:
       - "$SPOG_API_PORT"
     ports:
       - "$SPOG_API_PORT:8080"
-    command: spog api --devmode --bombastic-url http://bombastic-api:8080 --vexination-url http://vexination-api:8080
+    command:
+      -c 'while [[ "$$(curl --connect-timeout 2 -s -o /dev/null -w ''%{http_code}'' http://keycloak:8080/realms/chicken/.well-known/openid-configuration)" != "200" ]]; do echo waiting for keycloak...; sleep 5; done; echo keycloak is up; /trust spog api --devmode --bombastic-url http://bombastic-api:8080 --vexination-url http://vexination-api:8080'
+    entrypoint: /usr/bin/bash
     restart: on-failure
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9010" ]

--- a/deploy/compose/compose-trustification.yaml
+++ b/deploy/compose/compose-trustification.yaml
@@ -11,7 +11,16 @@ services:
       - "$VEXINATION_API_PORT:8080"
         #command: vexination api --devmode --storage-endpoint http://minio:9000
     command:
-      -c 'while [[ "$$(curl --connect-timeout 2 -s -o /dev/null -w ''%{http_code}'' http://keycloak:8080/realms/chicken/.well-known/openid-configuration)" != "200" ]]; do echo waiting for keycloak...; sleep 5; done; echo keycloak is up; /trust vexination api --devmode --storage-endpoint http://minio:9000'
+      - -c
+      - |
+        while [[ "$$(curl --connect-timeout 2 \
+                  -s -o /dev/null -w ''%{http_code}'' \
+                  $$OPENID_CONFIGURATION)" != "200" ]]; do
+          echo waiting for keycloak...
+          sleep 5
+        done
+        echo keycloak is up
+        /trust vexination api --devmode --storage-endpoint http://minio:9000
     entrypoint: /usr/bin/bash
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9010" ]
@@ -19,6 +28,7 @@ services:
     environment:
       ISSUER_URL: http://keycloak:8080/realms/chicken
       INFRASTRUCTURE_ENABLED: "true"
+      OPENID_CONFIGURATION: "http://keycloak:8080/realms/chicken/.well-known/openid-configuration"
 
   vexination-indexer:
     image: $TRUST_IMAGE:${TRUST_VERSION:?}
@@ -34,7 +44,16 @@ services:
     ports:
       - "$BOMBASTIC_API_PORT:8080"
     command:
-      -c 'while [[ "$$(curl --connect-timeout 2 -s -o /dev/null -w ''%{http_code}'' http://keycloak:8080/realms/chicken/.well-known/openid-configuration)" != "200" ]]; do echo waiting for keycloak...; sleep 5; done; echo keycloak is up; /trust bombastic api --devmode --storage-endpoint http://minio:9000'
+      - -c
+      - |
+        while [[ "$$(curl --connect-timeout 2 \
+                  -s -o /dev/null -w ''%{http_code}'' \
+                  $$OPENID_CONFIGURATION)" != "200" ]]; do
+          echo waiting for keycloak...
+          sleep 5
+        done
+        echo keycloak is up
+        /trust bombastic api --devmode --storage-endpoint http://minio:9000
     entrypoint: /usr/bin/bash
     restart: on-failure
     healthcheck:
@@ -42,6 +61,7 @@ services:
     environment:
       ISSUER_URL: http://keycloak:8080/realms/chicken
       INFRASTRUCTURE_ENABLED: "true"
+      OPENID_CONFIGURATION: "http://keycloak:8080/realms/chicken/.well-known/openid-configuration"
 
   bombastic-indexer:
     image: $TRUST_IMAGE:${TRUST_VERSION:?}
@@ -59,7 +79,16 @@ services:
     ports:
       - "$SPOG_API_PORT:8080"
     command:
-      -c 'while [[ "$$(curl --connect-timeout 2 -s -o /dev/null -w ''%{http_code}'' http://keycloak:8080/realms/chicken/.well-known/openid-configuration)" != "200" ]]; do echo waiting for keycloak...; sleep 5; done; echo keycloak is up; /trust spog api --devmode --bombastic-url http://bombastic-api:8080 --vexination-url http://vexination-api:8080'
+      - -c
+      - |
+        while [[ "$$(curl --connect-timeout 2 \
+                  -s -o /dev/null -w ''%{http_code}'' \
+                  $$OPENID_CONFIGURATION)" != "200" ]]; do
+          echo waiting for keycloak...
+          sleep 5
+        done
+        echo keycloak is up
+        /trust spog api --devmode --bombastic-url http://bombastic-api:8080 --vexination-url http://vexination-api:8080
     entrypoint: /usr/bin/bash
     restart: on-failure
     healthcheck:
@@ -67,6 +96,7 @@ services:
     environment:
       ISSUER_URL: http://keycloak:8080/realms/chicken
       INFRASTRUCTURE_ENABLED: "true"
+      OPENID_CONFIGURATION: "http://keycloak:8080/realms/chicken/.well-known/openid-configuration"
 
   spog-ui:
     image: $TRUST_UI_IMAGE:${TRUST_VERSION:?}


### PR DESCRIPTION
This commit adds a wait for keycloak to be up and running before starting the trustification services. This is done by adding a command to the services that will wait for keycloak to be up and running before starting the trustification services.

The motivation for this is that currently if one tries run the following command:
```console
$ podman-compose -f compose.yaml -f compose-trustification.yaml up
```
This would lead to the trustification services failing to start.

With this commit and using the same command as above we should see something like the following while it is running:
```console
$ podman logs -f compose_spog-api_1
waiting for keycloak...
waiting for keycloak...
waiting for keycloak...
keycloak is up
[2023-08-22T06:52:17.329Z INFO  trustification_infrastructure::infra] Setting up infrastructure endpoint
[2023-08-22T06:52:17.330Z INFO  trustification_infrastructure::infra] Running infrastructure endpoint on:
[2023-08-22T06:52:17.330Z INFO  trustification_infrastructure::infra]    http://[::1]:9010
[2023-08-22T06:52:17.330Z INFO  trustification_infrastructure::infra]    http://127.0.0.1:9010
```

This somewhat messy at the moment but if this works we can look at cleaning it up.