### PR TITLE
feat: add indexing timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3287,6 +3287,7 @@ dependencies = [
  "spog-model",
  "test-context",
  "test-with",
+ "time 0.3.23",
  "tokio",
  "trustification-auth",
  "trustification-event-bus",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4"
 test-context = "0.1"
 test-with = "0.9"
 ntest = "0.9"
+time = "0.3"
 
 bombastic-api = { path = "../bombastic/api" }
 bombastic-indexer = { path = "../bombastic/indexer" }

--- a/integration-tests/tests/vexination.rs
+++ b/integration-tests/tests/vexination.rs
@@ -194,10 +194,10 @@ async fn test_upload_vex_empty_json(context: &mut VexinationContext) {
 
 #[test_context(VexinationContext)]
 #[tokio::test]
-#[ntest::timeout(60_000)]
+#[ntest::timeout(90_000)]
 async fn test_upload_vex_empty_file(vexination: &mut VexinationContext) {
     let id = "empty-file-upload";
-    wait_for_event(Duration::from_secs(30), &vexination.config, "vex-failed", id, async {
+    wait_for_event(Duration::from_secs(60), &vexination.config, "vex-failed", id, async {
         let file_path = "empty-test.txt";
         let _ = File::create(&file_path).await.expect("file creation failed");
         let file = File::open(&file_path).await.unwrap();


### PR DESCRIPTION
* Add a timestamp marking the time a document was indexed. This is generally useful to understand when a document was indexed both for debugging and for use by tests.
* Add unit test to verify the indexed timestamp.
* Add integration test to verify index is updated when updating a doc