### PR TITLE
feat: point the integs at a remote trustification server

### DIFF
--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -1,5 +1,5 @@
 TRUST_IMAGE=ghcr.io/trustification/trust
-TRUST_VERSION=0.1.0-nightly.a5badbb9
+TRUST_VERSION=0.1.0-nightly.d8b1c815
 TRUST_UI_IMAGE=ghcr.io/trustification/trust-ui
 VEXINATION_API_PORT=8081
 BOMBASTIC_API_PORT=8082

--- a/integration-tests/src/bom.rs
+++ b/integration-tests/src/bom.rs
@@ -21,7 +21,7 @@ impl Urlifier for BombasticContext {
 pub struct BombasticContext {
     pub url: Url,
     pub provider: ProviderContext,
-    pub config: EventBusConfig,
+    pub events: EventBusConfig,
     _runner: Runner,
 }
 
@@ -32,7 +32,7 @@ pub async fn start_bombastic(provider: ProviderContext) -> BombasticContext {
     let port = listener.local_addr().unwrap().port();
     let url = Url::parse(&format!("http://localhost:{port}")).unwrap();
     let indexer = bombastic_indexer();
-    let config = indexer.bus.clone();
+    let events = indexer.bus.clone();
 
     let runner = Runner::spawn(|| async {
         select! {
@@ -64,7 +64,7 @@ pub async fn start_bombastic(provider: ProviderContext) -> BombasticContext {
     let context = BombasticContext {
         url,
         provider,
-        config,
+        events,
         _runner: runner,
     };
 

--- a/integration-tests/src/config.rs
+++ b/integration-tests/src/config.rs
@@ -1,0 +1,69 @@
+use reqwest::Url;
+use serde_json::Value;
+use trustification_event_bus::{EventBusConfig, EventBusType};
+
+use crate::{create_provider, create_provider_context, ProviderContext};
+
+#[derive(Default)]
+pub struct Config {
+    pub spog: Option<Url>,
+    pub bombastic: Option<Url>,
+    pub vexination: Option<Url>,
+    issuer: String,
+    user: String,
+    manager: String,
+    secret: String,
+}
+
+impl Config {
+    pub async fn new() -> Self {
+        let _ = env_logger::try_init();
+        match std::env::var("TRUST_URL") {
+            Ok(base) => {
+                let url = Url::parse(&base)
+                    .expect(&format!("Invalid TRUST_URL: '{base}'"))
+                    .join("/endpoints/backend.json")
+                    .unwrap();
+                let endpoints: Value = reqwest::get(url)
+                    .await
+                    .expect("Missing backend endpoints")
+                    .json()
+                    .await
+                    .unwrap();
+                Config {
+                    spog: endpoints["url"].as_str().map(Url::parse).unwrap().ok(),
+                    bombastic: endpoints["bombastic"].as_str().map(Url::parse).unwrap().ok(),
+                    vexination: endpoints["vexination"].as_str().map(Url::parse).unwrap().ok(),
+                    issuer: endpoints["oidc"]["issuer"].as_str().unwrap().to_string(),
+                    user: std::env::var("TRUST_USER_ID").expect("TRUST_USER_ID is required"),
+                    manager: std::env::var("TRUST_MANAGER_ID").expect("TRUST_MANAGER_ID is required"),
+                    secret: std::env::var("TRUST_SECRET").expect("TRUST_SECRET is required"),
+                }
+            }
+            _ => Config::default(),
+        }
+    }
+
+    pub async fn provider(&self) -> ProviderContext {
+        match self.spog {
+            Some(_) => ProviderContext {
+                provider_user: create_provider(&self.user, &self.secret, &self.issuer).await,
+                provider_manager: create_provider(&self.manager, &self.secret, &self.issuer).await,
+            },
+            _ => create_provider_context().await,
+        }
+    }
+
+    pub fn events(&self) -> EventBusConfig {
+        match std::env::var("KAFKA_BOOTSTRAP_SERVERS") {
+            Ok(v) => EventBusConfig {
+                event_bus: EventBusType::Kafka,
+                kafka_bootstrap_servers: v,
+            },
+            _ => EventBusConfig {
+                event_bus: EventBusType::Sqs,
+                kafka_bootstrap_servers: String::new(),
+            },
+        }
+    }
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,4 +1,5 @@
 mod bom;
+mod config;
 mod provider;
 mod spog;
 mod vex;

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -41,8 +41,8 @@ pub async fn assert_within_timeout<F: Future>(t: Duration, f: F) {
     );
 }
 
-pub async fn wait_for_event<F: Future>(t: Duration, config: &EventBusConfig, bus_name: &str, id: &str, f: F) {
-    let bus = config.create(&prometheus::Registry::new()).await.unwrap();
+pub async fn wait_for_event<F: Future>(t: Duration, events: &EventBusConfig, bus_name: &str, id: &str, f: F) {
+    let bus = events.create(&prometheus::Registry::new()).await.unwrap();
     let consumer = bus.subscribe("test-client", &[bus_name]).await.unwrap();
     assert_within_timeout(t, async {
         f.await;

--- a/integration-tests/src/provider.rs
+++ b/integration-tests/src/provider.rs
@@ -10,17 +10,17 @@ pub struct ProviderContext {
 
 pub async fn create_provider_context() -> ProviderContext {
     ProviderContext {
-        provider_user: create_provider("testing-user").await,
-        provider_manager: create_provider("testing-manager").await,
+        provider_user: create_provider("testing-user", SSO_TESTING_CLIENT_SECRET, SSO_ENDPOINT).await,
+        provider_manager: create_provider("testing-manager", SSO_TESTING_CLIENT_SECRET, SSO_ENDPOINT).await,
     }
 }
 
-async fn create_provider(client_id: &str) -> Arc<OpenIdTokenProvider> {
+pub async fn create_provider(client_id: &str, secret: &str, issuer: &str) -> Arc<OpenIdTokenProvider> {
     let client_user = openid::Client::discover(
         client_id.into(),
-        Some(SSO_TESTING_CLIENT_SECRET.to_string()),
+        Some(secret.to_string()),
         None,
-        SSO_ENDPOINT.parse().unwrap(),
+        issuer.parse().unwrap(),
     )
     .await
     .unwrap();

--- a/integration-tests/src/vex.rs
+++ b/integration-tests/src/vex.rs
@@ -20,7 +20,7 @@ impl Urlifier for VexinationContext {
 pub struct VexinationContext {
     pub url: Url,
     pub provider: ProviderContext,
-    pub config: EventBusConfig,
+    pub events: EventBusConfig,
     _runner: Runner,
 }
 
@@ -31,7 +31,7 @@ pub async fn start_vexination(provider: ProviderContext) -> VexinationContext {
     let port = listener.local_addr().unwrap().port();
     let url = Url::parse(&format!("http://localhost:{port}")).unwrap();
     let indexer = vexination_indexer();
-    let config = indexer.bus.clone();
+    let events = indexer.bus.clone();
 
     let runner = Runner::spawn(|| async {
         select! {
@@ -64,7 +64,7 @@ pub async fn start_vexination(provider: ProviderContext) -> VexinationContext {
     let context = VexinationContext {
         url,
         provider,
-        config,
+        events,
         _runner: runner,
     };
 

--- a/integration-tests/tests/bombastic.rs
+++ b/integration-tests/tests/bombastic.rs
@@ -14,7 +14,7 @@ use urlencoding::encode;
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_upload(context: &mut BombasticContext) {
+async fn upload_happy_sbom(context: &mut BombasticContext) {
     let input = serde_json::from_str(include_str!("../../bombastic/testdata/my-sbom.json")).unwrap();
     let id = "test-upload";
     upload_sbom(context, id, &input).await;
@@ -34,7 +34,7 @@ async fn test_upload(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_delete(context: &mut BombasticContext) {
+async fn delete_happy_sbom(context: &mut BombasticContext) {
     let input = serde_json::from_str(include_str!("../../bombastic/testdata/my-sbom.json")).unwrap();
     let id = "test-delete";
     upload_sbom(context, id, &input).await;
@@ -81,7 +81,7 @@ async fn test_delete(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_delete_missing(context: &mut BombasticContext) {
+async fn delete_missing_sbom(context: &mut BombasticContext) {
     let client = reqwest::Client::new();
     let response = client
         .delete(context.urlify(format!("/api/v1/sbom")))
@@ -115,7 +115,7 @@ async fn test_delete_missing(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(90_000)]
-async fn test_bombastic_search(context: &mut BombasticContext) {
+async fn bombastic_search(context: &mut BombasticContext) {
     let mut input: Value = serde_json::from_str(include_str!("../../bombastic/testdata/ubi9-sbom.json")).unwrap();
 
     // we generate a unique id and use it as the SBOM's version for searching
@@ -138,7 +138,7 @@ async fn test_bombastic_search(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(90_000)]
-async fn test_bombastic_bad_search_queries(context: &mut BombasticContext) {
+async fn bombastic_bad_search_queries(context: &mut BombasticContext) {
     assert_within_timeout(Duration::from_secs(30), async {
         for query in &[
             "unknown:ubi9-container-9.1.0-1782.noarch",
@@ -163,7 +163,7 @@ async fn test_bombastic_bad_search_queries(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(90_000)]
-async fn test_bombastic_reindexing(context: &mut BombasticContext) {
+async fn bombastic_reindexing(context: &mut BombasticContext) {
     let mut input: Value = serde_json::from_str(include_str!("../../bombastic/testdata/ubi9-sbom.json")).unwrap();
 
     // we generate a unique id and use it as the SBOM's version for searching
@@ -213,7 +213,7 @@ async fn test_bombastic_reindexing(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(90_000)]
-async fn test_bombastic_deletion(context: &mut BombasticContext) {
+async fn bombastic_deletion(context: &mut BombasticContext) {
     let mut input: Value = serde_json::from_str(include_str!("../../bombastic/testdata/ubi9-sbom.json")).unwrap();
 
     let key = id("test-index-deletion");
@@ -242,7 +242,7 @@ async fn test_bombastic_deletion(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_invalid_type(context: &mut BombasticContext) {
+async fn sbom_invalid_type(context: &mut BombasticContext) {
     let response = reqwest::Client::new()
         .post(context.urlify(format!("/api/v1/sbom?id=foo")))
         .body("<foo/>")
@@ -260,7 +260,7 @@ async fn test_invalid_type(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_invalid_encoding(context: &mut BombasticContext) {
+async fn sbom_invalid_encoding(context: &mut BombasticContext) {
     let response = reqwest::Client::new()
         .post(context.urlify(format!("/api/v1/sbom?id=foo")))
         .body("{}")
@@ -279,7 +279,7 @@ async fn test_invalid_encoding(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_upload_sbom_existing_without_change(context: &mut BombasticContext) {
+async fn upload_sbom_existing_without_change(context: &mut BombasticContext) {
     let input = serde_json::from_str(include_str!("../../bombastic/testdata/my-sbom.json")).unwrap();
     let id = "test-upload-without-change";
     let api_end_point = context.urlify(format!("api/v1/sbom?id={id}"));
@@ -301,7 +301,7 @@ async fn test_upload_sbom_existing_without_change(context: &mut BombasticContext
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_upload_sbom_existing_with_change(context: &mut BombasticContext) {
+async fn upload_sbom_existing_with_change(context: &mut BombasticContext) {
     let mut input1 = serde_json::from_str(include_str!("../../bombastic/testdata/my-sbom.json")).unwrap();
     let id = "test-upload-with-change";
     let api_end_point = context.urlify(format!("api/v1/sbom?id={id}"));
@@ -324,7 +324,7 @@ async fn test_upload_sbom_existing_with_change(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_upload_empty_json(context: &mut BombasticContext) {
+async fn sbom_upload_empty_json(context: &mut BombasticContext) {
     let input: serde_json::Value = serde_json::json!({});
     let id = "empty-json-upload";
     let client = reqwest::Client::new();
@@ -347,7 +347,7 @@ async fn test_upload_empty_json(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_upload_empty_file(context: &mut BombasticContext) {
+async fn sbom_upload_empty_file(context: &mut BombasticContext) {
     let file_path = "empty-test.txt";
     let _ = File::create(&file_path).await.expect("file creation failed");
     let file = File::open(&file_path).await.unwrap();
@@ -367,7 +367,7 @@ async fn test_upload_empty_file(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_upload_user_not_allowed(context: &mut BombasticContext) {
+async fn sbom_upload_user_not_allowed(context: &mut BombasticContext) {
     let input: serde_json::Value = serde_json::from_str(include_str!("../../bombastic/testdata/my-sbom.json")).unwrap();
     let id = "test-upload-user-not-allowed";
     let response = reqwest::Client::new()
@@ -385,7 +385,7 @@ async fn test_upload_user_not_allowed(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_upload_unauthorized(context: &mut BombasticContext) {
+async fn sbom_upload_unauthorized(context: &mut BombasticContext) {
     let input: serde_json::Value = serde_json::from_str(include_str!("../../bombastic/testdata/my-sbom.json")).unwrap();
     let id = "test-upload-unauthorized";
     let response = reqwest::Client::new()
@@ -400,7 +400,7 @@ async fn test_upload_unauthorized(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_delete_user_not_allowed(context: &mut BombasticContext) {
+async fn sbom_delete_user_not_allowed(context: &mut BombasticContext) {
     let input: serde_json::Value = serde_json::from_str(include_str!("../../bombastic/testdata/my-sbom.json")).unwrap();
     let id = "test-delete-user-not-allowed";
     upload_sbom(context, id, &input).await;
@@ -419,7 +419,7 @@ async fn test_delete_user_not_allowed(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_delete_unauthorized(context: &mut BombasticContext) {
+async fn sbom_delete_unauthorized(context: &mut BombasticContext) {
     let input: serde_json::Value = serde_json::from_str(include_str!("../../bombastic/testdata/my-sbom.json")).unwrap();
     let id = "test-delete-unauthorized";
     upload_sbom(context, id, &input).await;
@@ -435,7 +435,7 @@ async fn test_delete_unauthorized(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_get_sbom_with_invalid_id(context: &mut BombasticContext) {
+async fn get_sbom_with_invalid_id(context: &mut BombasticContext) {
     let id = "invalid-sbom-id";
     let api_endpoint = context.urlify(format!("api/v1/sbom?id={id}"));
     get_response(&api_endpoint, StatusCode::NOT_FOUND, &context.provider).await;
@@ -444,7 +444,7 @@ async fn test_get_sbom_with_invalid_id(context: &mut BombasticContext) {
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_get_sbom_with_missing_id(context: &mut BombasticContext) {
+async fn get_sbom_with_missing_id(context: &mut BombasticContext) {
     let api_endpoint = context.urlify(format!("api/v1/sbom?ID=test"));
     get_response(&api_endpoint, StatusCode::BAD_REQUEST, &context.provider).await;
 }

--- a/integration-tests/tests/bombastic.rs
+++ b/integration-tests/tests/bombastic.rs
@@ -329,7 +329,7 @@ async fn test_upload_empty_json(context: &mut BombasticContext) {
     let id = "empty-json-upload";
     let client = reqwest::Client::new();
     let url = context.urlify(format!("/api/v1/sbom?id={id}"));
-    wait_for_event(Duration::from_secs(30), &context.config, "sbom-failed", id, async {
+    wait_for_event(Duration::from_secs(30), &context.events, "sbom-failed", id, async {
         let response = client
             .post(url)
             .json(&input)

--- a/integration-tests/tests/spog.rs
+++ b/integration-tests/tests/spog.rs
@@ -9,7 +9,7 @@ use trustification_auth::client::TokenInjector;
 #[test_context(SpogContext)]
 #[tokio::test]
 #[ntest::timeout(30_000)]
-async fn test_version(context: &mut SpogContext) {
+async fn spog_version(context: &mut SpogContext) {
     let response = reqwest::Client::new()
         .get(context.urlify("/.well-known/trustification/version"))
         .inject_token(&context.provider.provider_user)
@@ -29,7 +29,7 @@ async fn test_version(context: &mut SpogContext) {
 #[test_context(SpogContext)]
 #[tokio::test]
 #[ntest::timeout(30_000)]
-async fn test_search_forward_bombastic(context: &mut SpogContext) {
+async fn spog_search_forward_bombastic(context: &mut SpogContext) {
     let client = reqwest::Client::new();
 
     let response = client
@@ -65,7 +65,7 @@ async fn test_search_forward_bombastic(context: &mut SpogContext) {
 #[test_context(SpogContext)]
 #[tokio::test]
 #[ntest::timeout(30_000)]
-async fn test_search_forward_vexination(context: &mut SpogContext) {
+async fn spog_search_forward_vexination(context: &mut SpogContext) {
     let client = reqwest::Client::new();
 
     let response = client
@@ -84,7 +84,7 @@ async fn test_search_forward_vexination(context: &mut SpogContext) {
 #[test_context(SpogContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_crda_integration(context: &mut SpogContext) {
+async fn spog_crda_integration(context: &mut SpogContext) {
     let client = reqwest::Client::new();
 
     let sbom = include_bytes!("crda/test1.sbom.json");
@@ -112,7 +112,7 @@ async fn test_crda_integration(context: &mut SpogContext) {
 #[test_context(SpogContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_search_correlation(context: &mut SpogContext) {
+async fn spog_search_correlation(context: &mut SpogContext) {
     let input = serde_json::from_str(include_str!("testdata/correlation/stf-1.5.json")).unwrap();
     upload_sbom(&context.bombastic, "stf-1.5", &input).await;
 

--- a/integration-tests/tests/vexination.rs
+++ b/integration-tests/tests/vexination.rs
@@ -10,7 +10,7 @@ use urlencoding::encode;
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_vexination(vexination: &mut VexinationContext) {
+async fn vexination_roundtrip(vexination: &mut VexinationContext) {
     let client = reqwest::Client::new();
     let input = serde_json::from_str(include_str!("../../vexination/testdata/rhsa-2023_1441.json")).unwrap();
     upload_vex(vexination, &input).await;
@@ -72,7 +72,7 @@ async fn test_vexination(vexination: &mut VexinationContext) {
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_upload_existing_vex_without_change(vexination: &VexinationContext) {
+async fn upload_existing_vex_without_change(vexination: &VexinationContext) {
     let input: serde_json::Value =
         serde_json::from_str(include_str!("../../vexination/testdata/rhsa-2023_3408.json")).unwrap();
     let id = encode(&input["document"]["tracking"]["id"].as_str().unwrap());
@@ -91,7 +91,7 @@ async fn test_upload_existing_vex_without_change(vexination: &VexinationContext)
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_upload_existing_vex_with_change(vexination: &VexinationContext) {
+async fn upload_existing_vex_with_change(vexination: &VexinationContext) {
     let mut input: serde_json::Value =
         serde_json::from_str(include_str!("../../vexination/testdata/rhsa-2021_3029.json")).unwrap();
     let id = encode(&input["document"]["tracking"]["id"].as_str().unwrap());
@@ -111,7 +111,7 @@ async fn test_upload_existing_vex_with_change(vexination: &VexinationContext) {
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_vex_invalid_type(vexination: &mut VexinationContext) {
+async fn vex_invalid_type(vexination: &mut VexinationContext) {
     let response = reqwest::Client::new()
         .post(vexination.urlify("/api/v1/vex?id=foo"))
         .body("<foo/>")
@@ -128,7 +128,7 @@ async fn test_vex_invalid_type(vexination: &mut VexinationContext) {
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_vex_invalid_encoding(vexination: &mut VexinationContext) {
+async fn vex_invalid_encoding(vexination: &mut VexinationContext) {
     let response = reqwest::Client::new()
         .post(vexination.urlify("/api/v1/vex?id=foo"))
         .body("{}")
@@ -146,7 +146,7 @@ async fn test_vex_invalid_encoding(vexination: &mut VexinationContext) {
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_0000)]
-async fn test_upload_vex_empty_json(context: &mut VexinationContext) {
+async fn upload_vex_empty_json(context: &mut VexinationContext) {
     let id = "empty-file-json";
     wait_for_event(Duration::from_secs(30), &context.events, "vex-failed", id, async {
         let input = serde_json::json!({});
@@ -167,7 +167,7 @@ async fn test_upload_vex_empty_json(context: &mut VexinationContext) {
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(90_000)]
-async fn test_upload_vex_empty_file(vexination: &mut VexinationContext) {
+async fn upload_vex_empty_file(vexination: &mut VexinationContext) {
     let id = "empty-file-upload";
     wait_for_event(Duration::from_secs(60), &vexination.events, "vex-failed", id, async {
         let file_path = "empty-test.txt";
@@ -191,7 +191,7 @@ async fn test_upload_vex_empty_file(vexination: &mut VexinationContext) {
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_vex_upload_user_not_allowed(vexination: &mut VexinationContext) {
+async fn vex_upload_user_not_allowed(vexination: &mut VexinationContext) {
     let input: serde_json::Value =
         serde_json::from_str(include_str!("../../vexination/testdata/rhsa-2023_1441.json")).unwrap();
     let id = encode(&input["document"]["tracking"]["id"].as_str().unwrap());
@@ -210,7 +210,7 @@ async fn test_vex_upload_user_not_allowed(vexination: &mut VexinationContext) {
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_vex_upload_unauthorized(vexination: &mut VexinationContext) {
+async fn vex_upload_unauthorized(vexination: &mut VexinationContext) {
     let input: serde_json::Value =
         serde_json::from_str(include_str!("../../vexination/testdata/rhsa-2023_1441.json")).unwrap();
     let id = encode(&input["document"]["tracking"]["id"].as_str().unwrap());
@@ -226,7 +226,7 @@ async fn test_vex_upload_unauthorized(vexination: &mut VexinationContext) {
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_get_vex_with_missing_qualifier(vexination: &mut VexinationContext) {
+async fn get_vex_with_missing_qualifier(vexination: &mut VexinationContext) {
     let api_endpoint = vexination.urlify(format!("api/v1/vex?id=missing_qualifier"));
     get_response(&api_endpoint, StatusCode::BAD_REQUEST, &vexination.provider).await;
 }
@@ -234,7 +234,7 @@ async fn test_get_vex_with_missing_qualifier(vexination: &mut VexinationContext)
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
-async fn test_get_vex_invalid_advisory(vexination: &mut VexinationContext) {
+async fn get_vex_invalid_advisory(vexination: &mut VexinationContext) {
     let api_endpoint = vexination.urlify(format!("api/v1/vex?advisory=invalid_vex"));
     get_response(&api_endpoint, StatusCode::NOT_FOUND, &vexination.provider).await;
 }

--- a/integration-tests/tests/vexination.rs
+++ b/integration-tests/tests/vexination.rs
@@ -148,7 +148,7 @@ async fn test_vex_invalid_encoding(vexination: &mut VexinationContext) {
 #[ntest::timeout(60_0000)]
 async fn test_upload_vex_empty_json(context: &mut VexinationContext) {
     let id = "empty-file-json";
-    wait_for_event(Duration::from_secs(30), &context.config, "vex-failed", id, async {
+    wait_for_event(Duration::from_secs(30), &context.events, "vex-failed", id, async {
         let input = serde_json::json!({});
         let response = reqwest::Client::new()
             .post(context.urlify(format!("/api/v1/vex?advisory={id}")))
@@ -169,7 +169,7 @@ async fn test_upload_vex_empty_json(context: &mut VexinationContext) {
 #[ntest::timeout(90_000)]
 async fn test_upload_vex_empty_file(vexination: &mut VexinationContext) {
     let id = "empty-file-upload";
-    wait_for_event(Duration::from_secs(60), &vexination.config, "vex-failed", id, async {
+    wait_for_event(Duration::from_secs(60), &vexination.events, "vex-failed", id, async {
         let file_path = "empty-test.txt";
         let _ = File::create(&file_path).await.expect("file creation failed");
         let file = File::open(&file_path).await.unwrap();


### PR DESCRIPTION
Fixes #401

Setting the `TRUST_URL` env var to a remote trustification server triggers the integs to be run against it.

If it's set, other env vars will be required:
- `TRUST_USER_ID` -- the client id of the user
- `TRUST_MANAGER_ID` -- the client id of the manager
- `TRUST_SECRET` -- the secret is assumed to be the same for user & mgr

If `KAFKA_BOOTSTRAP_SERVERS` is set, its value will be used to configure the event bus. Otherwise, SQS is assumed and valid AWS credentials will be required.