### PR TITLE
fix: add Self::Provided match arm props_query

### DIFF
--- a/spog/ui/src/components/search/mod.rs
+++ b/spog/ui/src/components/search/mod.rs
@@ -18,7 +18,25 @@ impl SearchPropertiesMode {
     pub fn props_query(&self) -> Option<String> {
         match &self {
             Self::Managed { query } => query.clone(),
-            _ => None,
+            Self::Provided { terms } => Some(terms.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prop_query() {
+        let mode = SearchPropertiesMode::Managed {
+            query: Some("some_managed".to_string()),
+        };
+        assert_eq!(mode.props_query(), Some("some_managed".to_string()));
+
+        let mode = SearchPropertiesMode::Provided {
+            terms: "some_term".to_string(),
+        };
+        assert_eq!(mode.props_query(), Some("some_term".to_string()));
     }
 }


### PR DESCRIPTION
This commit adds a match arm for the SearchPropertiesMode::Provided variant in SearchPropertiesMode::props_query.

The motivation for this is that when an AdvisorySearch component is instantiated it will be passed a SearchPropertiesMode::Provided variant:
```rust
<AdvisorySearch callback={advisory_callback}
     mode={SearchPropertiesMode::Provided {terms: (*search_terms).clone()}}>
    <AdvisoryResult state={(*advisory_search).clone()} />
</AdvisorySearch>
```
Notice here that the `mode` property of the `AdvisorySearch` component is set to `SearchPropertiesMode::Provided` and the term is set to the search term. But if we look at the current implementation of the SearchPropertiesMode::props_query method we see that it only returns the query if the mode is Managed:
```rust
pub enum SearchPropertiesMode {
    Managed { query: Option<String> },
    Provided { terms: String },
}

impl SearchPropertiesMode {
    pub fn props_query(&self) -> Option<String> {
        match &self {
            Self::Managed { query } => query.clone(),
            _ => None,
        }
    }
}
```
When props_query is later called by AdvisorySearch::advisory_search and SbomSearch::sbom_search, the query term will not be available as props_query will return None, and the search will be performed without a query parameter which will return all the advisories and sboms.

Fixes: https://github.com/trustification/trustification/issues/386