### PR TITLE
fix: compose connection between spog api and guac

### DIFF
--- a/deploy/compose/compose-guac.yaml
+++ b/deploy/compose/compose-guac.yaml
@@ -59,6 +59,8 @@ services:
     depends_on:
       nats:
         condition: service_healthy
+    expose:
+      - "$GUAC_API_PORT"
     ports:
       - "$GUAC_API_PORT:8080"
     volumes:

--- a/deploy/compose/compose-trustification.yaml
+++ b/deploy/compose/compose-trustification.yaml
@@ -73,6 +73,7 @@ services:
       - init-keycloak
       - bombastic-api
       - vexination-api
+      - guac-graphql
     expose:
       - "$SPOG_API_PORT"
     ports:
@@ -87,7 +88,7 @@ services:
           sleep 5
         done
         echo keycloak is up
-        /trust spog api --devmode --bombastic-url http://bombastic-api:8080 --vexination-url http://vexination-api:8080
+        /trust spog api --devmode --bombastic-url http://bombastic-api:8080 --vexination-url http://vexination-api:8080 --guac http://guac-graphql:8080/query
     entrypoint: /usr/bin/bash
     restart: on-failure
     healthcheck:


### PR DESCRIPTION
Here are some steps to test spog api guac integration

* Start everything
```
docker compose -f compose.yaml -f compose-guac.yaml -f compose-trustification.yaml up
```

* Get auth token
```
TOKEN=$(curl -s -d "client_id=walker" -d "client_secret=ZVzq9AMOVUdMY1lSohpx1jI3aW56QDPS" -d 'grant_type=client_credentials' \
  'http://localhost:8090/realms/chicken/protocol/openid-connect/token' | jq -r .access_token)
```

* Ingest SBOM
```  
curl -v -H "transfer-encoding: chunked" --json @bombastic/testdata/ubi9-1750-sbom.json --oauth2-bearer $TOKEN  "http://localhost:8082/api/v1/sbom?id=my-sbom"
```

* Run some queries (dependencies, dependents, related packages)
```
curl -v -X GET --oauth2-bearer $TOKEN "http://localhost:8083/api/v1/packages/dependencies?purl=pkg:oci/registry.redhat./ubi9-container@sha256:4227a4b5013999a412196237c62e40d778d09cdc751720a66ff3701fbe5a4a9d?tag=9.1.0-1750" | jq

curl -v -X GET --oauth2-bearer $TOKEN "http://localhost:8083/api/v1/packages/dependents?purl=pkg:rpm/redhat/json-c@0.14-11.el9" | jq 

curl -v -X GET --oauth2-bearer $TOKEN "http://localhost:8083/api/v1/packages?purl=pkg:rpm/redhat/json-c@0.14-11.el9" | jq 
```