### PR TITLE
chore: enforce black box testing in integration tests

### DIFF
--- a/integration-tests/tests/bombastic.rs
+++ b/integration-tests/tests/bombastic.rs
@@ -356,6 +356,7 @@ async fn upload_sbom_existing_with_change(context: &mut BombasticContext) {
     );
 }
 
+#[ignore("Ignored until API can support failures so that event bus is not needed to check")]
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]

--- a/integration-tests/tests/vexination.rs
+++ b/integration-tests/tests/vexination.rs
@@ -143,6 +143,7 @@ async fn vex_invalid_encoding(vexination: &mut VexinationContext) {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
+#[ignore("Ignored until API can support failures so that event bus is not needed to check")]
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_0000)]
@@ -164,6 +165,7 @@ async fn upload_vex_empty_json(context: &mut VexinationContext) {
     .await;
 }
 
+#[ignore("Ignored until API can support failures so that event bus is not needed to check")]
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(90_000)]


### PR DESCRIPTION
Ignores the tests that use the event bus for now since they require access to the internal infrastructure of trustification services in order to run.