### PR TITLE
feat: allow searching without fetching document summaries

### DIFF
--- a/api/src/search.rs
+++ b/api/src/search.rs
@@ -1,11 +1,23 @@
 use crate::Apply;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct SearchOptions {
     #[serde(default)]
     pub explain: bool,
     #[serde(default)]
     pub metadata: bool,
+    #[serde(default)]
+    pub summaries: bool,
+}
+
+impl Default for SearchOptions {
+    fn default() -> Self {
+        Self {
+            explain: Default::default(),
+            metadata: Default::default(),
+            summaries: true,
+        }
+    }
 }
 
 impl Apply<SearchOptions> for reqwest::RequestBuilder {
@@ -16,6 +28,10 @@ impl Apply<SearchOptions> for reqwest::RequestBuilder {
 
         if options.metadata {
             self = self.query(&[("metadata", "true")]);
+        }
+
+        if !options.summaries {
+            self = self.query(&[("summaries", "false")]);
         }
 
         self

--- a/api/src/search.rs
+++ b/api/src/search.rs
@@ -6,8 +6,12 @@ pub struct SearchOptions {
     pub explain: bool,
     #[serde(default)]
     pub metadata: bool,
-    #[serde(default)]
+    #[serde(default = "default_summaries")]
     pub summaries: bool,
+}
+
+const fn default_summaries() -> bool {
+    true
 }
 
 impl Default for SearchOptions {

--- a/api/src/search.rs
+++ b/api/src/search.rs
@@ -13,8 +13,8 @@ pub struct SearchOptions {
 impl Default for SearchOptions {
     fn default() -> Self {
         Self {
-            explain: Default::default(),
-            metadata: Default::default(),
+            explain: false,
+            metadata: false,
             summaries: true,
         }
     }
@@ -32,6 +32,8 @@ impl Apply<SearchOptions> for reqwest::RequestBuilder {
 
         if !options.summaries {
             self = self.query(&[("summaries", "false")]);
+        } else {
+            self = self.query(&[("summaries", "true")]);
         }
 
         self

--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -177,6 +177,9 @@ pub struct SearchParams {
     /// Provide additional metadata from the index
     #[serde(default = "default_metadata")]
     pub metadata: bool,
+    /// Enable fetching document summaries
+    #[serde(default = "default_summaries")]
+    pub summaries: bool,
 }
 
 const fn default_offset() -> usize {
@@ -195,11 +198,16 @@ const fn default_metadata() -> bool {
     false
 }
 
+const fn default_summaries() -> bool {
+    true
+}
+
 impl From<&SearchParams> for SearchOptions {
     fn from(value: &SearchParams) -> Self {
         Self {
             explain: value.explain,
             metadata: value.metadata,
+            summaries: value.summaries,
         }
     }
 }

--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -673,6 +673,7 @@ mod tests {
                 SearchOptions {
                     metadata: false,
                     explain: false,
+                    summaries: true,
                 },
             )
             .unwrap()
@@ -827,6 +828,7 @@ mod tests {
                     SearchOptions {
                         explain: false,
                         metadata: true,
+                        summaries: true,
                     },
                 )
                 .unwrap();
@@ -852,6 +854,7 @@ mod tests {
                     SearchOptions {
                         explain: true,
                         metadata: false,
+                        summaries: true,
                     },
                 )
                 .unwrap();

--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -583,11 +583,7 @@ impl trustification_index::Index for Index {
             })
             .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
 
-        let dependencies: Vec<String> = field2strvec(&doc, self.fields.dep.purl)?
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-
+        let dependencies: u64 = doc.get_all(self.fields.dep.purl).count() as u64;
         let document = SearchDocument {
             id: id.to_string(),
             version: version.to_string(),

--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -20,7 +20,7 @@ use tantivy::{
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use trustification_api::search::SearchOptions;
 use trustification_index::{
-    boost, create_boolean_query, create_date_query, create_string_query, create_text_query, field2str, field2strvec,
+    boost, create_boolean_query, create_date_query, create_string_query, create_text_query, field2str,
     metadata::doc2metadata,
     tantivy::{
         doc,

--- a/bombastic/model/src/search.rs
+++ b/bombastic/model/src/search.rs
@@ -75,8 +75,8 @@ pub struct SearchDocument {
     /// SBOM creation time in RFC3339 format
     #[schema(value_type = String)]
     pub created: time::OffsetDateTime,
-    /// List of dependency package names that matched
-    pub dependencies: Vec<String>,
+    /// Number of dependencies with package names that matched
+    pub dependencies: u64,
 }
 
 /// The hit describes the document, its score and optionally an explanation of why that score was given.

--- a/integration-tests/tests/spog.rs
+++ b/integration-tests/tests/spog.rs
@@ -144,8 +144,8 @@ async fn spog_search_correlation(context: &mut SpogContext) {
                 serde_json::from_value(payload["result"][0].clone()).unwrap();
             // println!("Data: {:?}", data);
             // Data might not be available until vex index is synced
-            if !data.advisories.is_empty() {
-                assert_eq!(data.advisories[0], vex_id);
+            if data.advisories > 0 {
+                assert_eq!(data.advisories, 1);
                 break;
             }
         }

--- a/spog/model/src/search.rs
+++ b/spog/model/src/search.rs
@@ -44,7 +44,7 @@ pub struct PackageSummary {
     pub classifier: String,
     pub description: String,
     pub supplier: String,
-    pub dependencies: Vec<String>,
+    pub dependencies: u64,
     pub href: String,
     pub advisories: u64,
     pub created: OffsetDateTime,

--- a/spog/model/src/search.rs
+++ b/spog/model/src/search.rs
@@ -46,7 +46,7 @@ pub struct PackageSummary {
     pub supplier: String,
     pub dependencies: Vec<String>,
     pub href: String,
-    pub advisories: Vec<String>,
+    pub advisories: u64,
     pub created: OffsetDateTime,
 
     #[serde(default, skip_serializing_if = "Value::is_null", rename = "$metadata")]

--- a/spog/ui/src/backend/search.rs
+++ b/spog/ui/src/backend/search.rs
@@ -16,7 +16,8 @@ impl Default for SearchParameters {
             options: SearchOptions {
                 // in debug mode, we ask for metadata by default
                 metadata: default_metadata(),
-                ..Default::default()
+                summaries: true,
+                explain: false,
             },
         }
     }

--- a/spog/ui/src/components/package.rs
+++ b/spog/ui/src/components/package.rs
@@ -62,7 +62,7 @@ impl TableEntryRenderer<Column> for PackageEntry {
                 }
             )
             .into(),
-            Column::Dependencies => html!(&self.package.dependencies.len()).into(),
+            Column::Dependencies => html!(&self.package.dependencies).into(),
             Column::Advisories => {
                 let q = self.package.advisories_query();
                 html!(<Link<AppRoute>

--- a/spog/ui/src/components/sbom/mod.rs
+++ b/spog/ui/src/components/sbom/mod.rs
@@ -74,7 +74,7 @@ impl TableEntryRenderer<Column> for PackageEntry {
                 html!(<Link<AppRoute>
                           target={AppRoute::Advisory(View::Search{query: q})}
                             >
-                        { self.package.advisories.len() }
+                        { self.package.advisories }
                     </Link<AppRoute>>
                 )
                 .into()

--- a/spog/ui/src/components/sbom/mod.rs
+++ b/spog/ui/src/components/sbom/mod.rs
@@ -68,7 +68,7 @@ impl TableEntryRenderer<Column> for PackageEntry {
                 }
             )
             .into(),
-            Column::Dependencies => html!(&self.package.dependencies.len()).into(),
+            Column::Dependencies => html!(&self.package.dependencies).into(),
             Column::Advisories => {
                 let q = self.package.advisories_query();
                 html!(<Link<AppRoute>

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -199,6 +199,9 @@ pub struct SearchParams {
     /// Provide additional metadata from the index
     #[serde(default = "default_metadata")]
     pub metadata: bool,
+    /// Enable fetching document summaries
+    #[serde(default = "default_summaries")]
+    pub summaries: bool,
 }
 
 const fn default_offset() -> usize {
@@ -217,11 +220,16 @@ const fn default_metadata() -> bool {
     false
 }
 
+const fn default_summaries() -> bool {
+    true
+}
+
 impl From<&SearchParams> for SearchOptions {
     fn from(value: &SearchParams) -> Self {
         Self {
             explain: value.explain,
             metadata: value.metadata,
+            summaries: value.summaries,
         }
     }
 }

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -808,17 +808,7 @@ mod tests {
     }
 
     fn search(index: &IndexStore<Index>, query: &str) -> (Vec<SearchHit>, usize) {
-        index
-            .search(
-                query,
-                0,
-                10000,
-                SearchOptions {
-                    explain: false,
-                    metadata: false,
-                },
-            )
-            .unwrap()
+        index.search(query, 0, 10000, SearchOptions::default()).unwrap()
     }
 
     #[tokio::test]
@@ -1048,6 +1038,7 @@ mod tests {
                     SearchOptions {
                         explain: false,
                         metadata: true,
+                        summaries: true,
                     },
                 )
                 .unwrap();


### PR DESCRIPTION
In some cases, it is only interesting to know the number of hits/results for display purposes without actually showing the results. This adds a query flag summaries=true/false
 (default true) which allows the client to discard document summaries to be fetched, with
 the benefit of a faster search execution.

Issue #450

@ctron This should speed things up, but hold on the merge until I've done some more testing.