### PR TITLE
refactor: use plain string for OIDC scope configuration

### DIFF
--- a/spog/ui/src/app.rs
+++ b/spog/ui/src/app.rs
@@ -52,7 +52,7 @@ fn application_with_backend() -> Html {
             // oauth2 context must also wrap the backdrop viewer
             <OAuth2
                 {config}
-                scopes={backend.endpoints.oidc.scopes.clone()}
+                scopes={backend.endpoints.oidc.scopes()}
             >
                 <Configuration>
                     <BackdropViewer>

--- a/spog/ui/src/backend/mod.rs
+++ b/spog/ui/src/backend/mod.rs
@@ -37,9 +37,15 @@ pub struct OpenIdConnect {
     #[serde(default = "default::client_id")]
     pub client_id: String,
     #[serde(default = "default::scopes")]
-    pub scopes: Vec<String>,
+    pub scopes: String,
     #[serde(default = "default::after_logout")]
     pub after_logout: String,
+}
+
+impl OpenIdConnect {
+    pub fn scopes(&self) -> Vec<String> {
+        self.scopes.split(' ').map(|s| s.to_string()).collect()
+    }
 }
 
 mod default {
@@ -47,8 +53,8 @@ mod default {
         "frontend".to_string()
     }
 
-    pub fn scopes() -> Vec<String> {
-        vec!["openid".to_string()]
+    pub fn scopes() -> String {
+        "openid".to_string()
     }
 
     pub fn after_logout() -> String {


### PR DESCRIPTION
This makes it easier to handle in the configuration, where injecting an array of string is rather complicated.