### PR TITLE
Refactor and add thrid option for unified result

### DIFF
--- a/spog/ui/src/components/sbom/mod.rs
+++ b/spog/ui/src/components/sbom/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 #[derive(PartialEq, Properties)]
-pub struct PackageResultProperties {
+pub struct SbomResultProperties {
     pub state: UseAsyncState<SearchResult<Rc<Vec<PackageSummary>>>, String>,
 }
 
@@ -93,8 +93,8 @@ impl TableEntryRenderer<Column> for PackageEntry {
     }
 }
 
-#[function_component(PackageResult)]
-pub fn sbom_result(props: &PackageResultProperties) -> Html {
+#[function_component(SbomResult)]
+pub fn sbom_result(props: &SbomResultProperties) -> Html {
     let backend = use_backend();
     let data = match &props.state {
         UseAsyncState::Ready(Ok(val)) => {

--- a/spog/ui/src/components/search/simple.rs
+++ b/spog/ui/src/components/search/simple.rs
@@ -1,6 +1,5 @@
 use crate::utils::search::*;
 use patternfly_yew::prelude::*;
-use std::borrow::Cow;
 use std::collections::HashSet;
 use std::rc::Rc;
 use yew::prelude::*;
@@ -125,10 +124,10 @@ where
         }
     }
 
-    pub fn as_str(&self, context: &T::Context) -> Cow<'_, str> {
+    pub fn as_str(&self, context: &T::Context) -> String {
         match self {
             Self::Complex(s) => s.into(),
-            Self::Simple(s) => s.to_filter_expression(context).into(),
+            Self::Simple(s) => s.to_filter_expression(context),
         }
     }
 

--- a/spog/ui/src/pages/search.rs
+++ b/spog/ui/src/pages/search.rs
@@ -4,7 +4,7 @@ use crate::{
     components::{
         advisory::{use_advisory_search, AdvisoryResult, AdvisorySearchControls},
         common::Visible,
-        sbom::{use_sbom_search, PackageResult, SbomSearchControls},
+        sbom::{use_sbom_search, SbomResult, SbomSearchControls},
         search::{DynamicSearchParameters, SearchMode},
     },
     utils::count::count_tab_title,
@@ -220,7 +220,7 @@ pub fn search(props: &SearchProperties) -> Html {
                             }
                             if *tab == TabIndex::Sboms {
                                 <PaginationWrapped pagination={sbom_pagination} total={*sbom_total}>
-                                    <PackageResult state={(*sbom_search).clone()} />
+                                    <SbomResult state={(*sbom_search).clone()} />
                                 </PaginationWrapped>
                             }
                         </div>


### PR DESCRIPTION
This refactors out the common code of unified search, and with that adds a third option to the search results.

The third option searches SBOMs by dependency and acts as a guinea pig. We can drop it if we want.