### PR TITLE
Allow testing CI locally with act

### DIFF
--- a/.github/actions/install-rust/action.yaml
+++ b/.github/actions/install-rust/action.yaml
@@ -1,0 +1,20 @@
+name: Install Rust toolchain
+description: Install Rust toolchain
+inputs:
+  profile:
+    description: rustup profile
+    required: false
+    default: minimal
+  force:
+    description: Force the installation
+    required: false
+    default: false
+runs:
+  using: composite
+  steps:
+    - run: |
+        if ! command -v rustup >/dev/null 2>&1 || [ "${{ inputs.force }}" = true ]; then
+          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y --profile ${{ inputs.profile }}
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        fi
+      shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/install-rust
+        if: ${{ env.ACT }}
 
       - name: Check formatting
         run: |
@@ -44,6 +46,13 @@ jobs:
       - formatting
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/install-rust
+        if: ${{ env.ACT }}
+      - uses: jwlawson/actions-setup-cmake@v1.13
+        if: ${{ env.ACT }}
+        with:
+          # Version installed on ubuntu-22.04
+          cmake-version: '3.27.3'
       - run: rustup component add clippy
       - uses: actions/cache@v3
         with:
@@ -79,6 +88,8 @@ jobs:
       - formatting
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/install-rust
+        if: ${{ env.ACT }}
       - run: rustup component add clippy
       - run: rustup target add wasm32-unknown-unknown
       - uses: actions/cache@v3
@@ -116,6 +127,8 @@ jobs:
       - formatting
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/install-rust
+        if: ${{ env.ACT }}
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -9,6 +9,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/install-rust
+        if: ${{ env.ACT }}
+      - uses: jwlawson/actions-setup-cmake@v1.13
+        if: ${{ env.ACT }}
+        with:
+          # Version installed on ubuntu-22.04
+          cmake-version: '3.27.3'
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        if: ${{ env.ACT }}
+        with:
+          # Version installed on ubuntu-22.04. There's also v2.20.3 installed
+          # but it fails with:
+          #   network compose_default was found but has incorrect label
+          #   com.docker.compose.network set to ""
+          version: '1.29.2'
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
Adjust `.github/workflows/ci.yaml` and related files so it can be tested locally using `act` tool and describe the process in `DEVELOPING.md`.