### PR TITLE
chore: refactor storage config to expose a consistent set of parameters

### DIFF
--- a/bombastic/api/src/lib.rs
+++ b/bombastic/api/src/lib.rs
@@ -110,13 +110,13 @@ impl Run {
 
     fn configure(
         index_config: IndexConfig,
-        mut storage: StorageConfig,
+        storage: StorageConfig,
         registry: &Registry,
         devmode: bool,
     ) -> anyhow::Result<Arc<AppState>> {
         let index =
             block_in_place(|| IndexStore::new(&storage, &index_config, bombastic_index::Index::new(), registry))?;
-        let storage = storage.create("bombastic", devmode, registry)?;
+        let storage = Storage::new(storage.process("bombastic", devmode), registry)?;
 
         let state = Arc::new(AppState {
             storage: RwLock::new(storage),

--- a/deploy/compose/compose-trustification.yaml
+++ b/deploy/compose/compose-trustification.yaml
@@ -19,20 +19,23 @@ services:
           sleep 5
         done
         echo keycloak is up
-        /trust vexination api --devmode --storage-endpoint http://minio:9000
+        /trust vexination api --devmode
     entrypoint: /usr/bin/bash
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9010" ]
     restart: on-failure
     environment:
+      STORAGE_ENDPOINT: http://minio:9000
       ISSUER_URL: http://keycloak:8080/realms/chicken
       INFRASTRUCTURE_ENABLED: "true"
       OPENID_CONFIGURATION: "http://keycloak:8080/realms/chicken/.well-known/openid-configuration"
 
   vexination-indexer:
     image: $TRUST_IMAGE:${TRUST_VERSION:?TRUST_VERSION is required}
-    command: vexination indexer --devmode --storage-endpoint http://minio:9000 --kafka-bootstrap-servers kafka:9094
+    command: vexination indexer --devmode --kafka-bootstrap-servers kafka:9094
     restart: on-failure
+    environment:
+      STORAGE_ENDPOINT: http://minio:9000
 
   bombastic-api:
     image: $TRUST_IMAGE:${TRUST_VERSION:?TRUST_VERSION is required}
@@ -52,7 +55,7 @@ services:
           sleep 5
         done
         echo keycloak is up
-        /trust bombastic api --devmode --storage-endpoint http://minio:9000
+        /trust bombastic api --devmode
     entrypoint: /usr/bin/bash
     restart: on-failure
     healthcheck:
@@ -61,11 +64,14 @@ services:
       ISSUER_URL: http://keycloak:8080/realms/chicken
       INFRASTRUCTURE_ENABLED: "true"
       OPENID_CONFIGURATION: "http://keycloak:8080/realms/chicken/.well-known/openid-configuration"
+      STORAGE_ENDPOINT: http://minio:9000
 
   bombastic-indexer:
     image: $TRUST_IMAGE:${TRUST_VERSION:?TRUST_VERSION is required}
-    command: bombastic indexer --devmode --storage-endpoint http://minio:9000 --kafka-bootstrap-servers kafka:9094
+    command: bombastic indexer --devmode --kafka-bootstrap-servers kafka:9094
     restart: on-failure
+    environment:
+      STORAGE_ENDPOINT: http://minio:9000
 
   spog-api:
     image: $TRUST_IMAGE:${TRUST_VERSION:?TRUST_VERSION is required}

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -31,19 +31,19 @@ use time::{OffsetDateTime, UtcOffset};
 #[command(rename_all_env = "SCREAMING_SNAKE_CASE")]
 pub struct IndexConfig {
     /// Local folder to store index.
-    #[arg(short = 'i', long = "index-dir")]
+    #[arg(env = "INDEX_DIR", short = 'i', long = "index-dir")]
     pub index_dir: Option<std::path::PathBuf>,
 
     /// Synchronization interval for index persistence.
-    #[arg(long = "index-sync-interval", default_value = "30s")]
+    #[arg(env = "INDEX_SYNC_INTERVAL", long = "index-sync-interval", default_value = "30s")]
     pub sync_interval: humantime::Duration,
 
     /// Memory available to index writer
-    #[arg(long = "index-writer-memory-bytes", default_value_t = 32 * 1024 * 1024)]
+    #[arg(env = "INDEX_WRITER_MEMORY_BYTES", long = "index-writer-memory-bytes", default_value_t = 32 * 1024 * 1024)]
     pub index_writer_memory_bytes: usize,
 
     /// Synchronization interval for index persistence.
-    #[arg(long = "index-mode", default_value_t = IndexMode::File)]
+    #[arg(env = "INDEX_MODE", long = "index-mode", default_value_t = IndexMode::File)]
     pub mode: IndexMode,
 }
 

--- a/integration-tests/src/bom.rs
+++ b/integration-tests/src/bom.rs
@@ -191,6 +191,7 @@ fn bombastic_indexer() -> bombastic_indexer::Run {
 
 #[cfg(feature = "with-services")]
 fn bombastic_api() -> bombastic_api::Run {
+    use trustification_storage::Region;
     bombastic_api::Run {
         bind: "127.0.0.1".to_string(),
         port: 8082,
@@ -202,7 +203,10 @@ fn bombastic_api() -> bombastic_api::Run {
             sync_interval: Duration::from_secs(2).into(),
         },
         storage: StorageConfig {
-            region: None,
+            region: Some(Region::Custom {
+                endpoint: STORAGE_ENDPOINT.into(),
+                region: Region::EuCentral1.to_string(),
+            }),
             bucket: Some("bombastic".into()),
             endpoint: Some(STORAGE_ENDPOINT.into()),
             access_key: Some("admin".into()),

--- a/integration-tests/src/vex.rs
+++ b/integration-tests/src/vex.rs
@@ -166,6 +166,8 @@ fn vexination_indexer() -> vexination_indexer::Run {
 
 #[cfg(feature = "with-services")]
 fn vexination_api() -> vexination_api::Run {
+    use trustification_storage::Region;
+
     vexination_api::Run {
         bind: "127.0.0.1".to_string(),
         port: 8081,
@@ -177,7 +179,10 @@ fn vexination_api() -> vexination_api::Run {
             sync_interval: Duration::from_secs(2).into(),
         },
         storage: StorageConfig {
-            region: None,
+            region: Some(Region::Custom {
+                endpoint: STORAGE_ENDPOINT.into(),
+                region: Region::EuCentral1.to_string(),
+            }),
             bucket: Some("vexination".into()),
             endpoint: Some(STORAGE_ENDPOINT.into()),
             access_key: Some("admin".into()),

--- a/vexination/api/src/lib.rs
+++ b/vexination/api/src/lib.rs
@@ -110,13 +110,13 @@ impl Run {
 
     fn configure(
         index_config: IndexConfig,
-        mut storage: StorageConfig,
+        storage: StorageConfig,
         registry: &Registry,
         devmode: bool,
     ) -> anyhow::Result<Arc<AppState>> {
         let index =
             block_in_place(|| IndexStore::new(&storage, &index_config, vexination_index::Index::new(), registry))?;
-        let storage = storage.create("vexination", devmode, registry)?;
+        let storage = Storage::new(storage.process("vexination", devmode), registry)?;
 
         let state = Arc::new(AppState {
             storage: RwLock::new(storage),

--- a/vexination/walker/src/lib.rs
+++ b/vexination/walker/src/lib.rs
@@ -46,10 +46,10 @@ pub struct Run {
 }
 
 impl Run {
-    pub async fn run(mut self) -> anyhow::Result<ExitCode> {
+    pub async fn run(self) -> anyhow::Result<ExitCode> {
         Infrastructure::from(self.infra)
             .run("vexination-walker", |metrics| async move {
-                let storage = self.storage.create("vexination", self.devmode, metrics.registry())?;
+                let storage = Storage::new(self.storage.process("vexination", self.devmode), metrics.registry())?;
                 let validation_date: Option<SystemTime> = match (self.policy_date, self.v3_signatures) {
                     (_, true) => Some(SystemTime::from(
                         Date::from_calendar_date(2007, Month::January, 1)


### PR DESCRIPTION
Previously the storage config was a mix of some env vars picked up by the underlying libraries. With this change all the required parameters are exposed as env vars and the k8s manifests will be updated to make use of it.