### PR TITLE
fast index switch

### DIFF
--- a/bombastic/api/src/lib.rs
+++ b/bombastic/api/src/lib.rs
@@ -119,7 +119,7 @@ impl Run {
         let storage = Storage::new(storage.process("bombastic", devmode), registry)?;
 
         let state = Arc::new(AppState {
-            storage: RwLock::new(storage),
+            storage,
             index: RwLock::new(index),
         });
 
@@ -150,7 +150,7 @@ impl Run {
 
 pub(crate) type Index = IndexStore<bombastic_index::Index>;
 pub struct AppState {
-    storage: RwLock<Storage>,
+    storage: Storage,
     index: RwLock<Index>,
 }
 
@@ -158,9 +158,9 @@ pub(crate) type SharedState = Arc<AppState>;
 
 impl AppState {
     async fn sync_index(&self) -> Result<(), anyhow::Error> {
-        let storage = self.storage.read().await;
+        let storage = &self.storage;
         let mut index = self.index.write().await;
-        index.sync(&storage).await?;
+        index.sync(storage).await?;
         Ok(())
     }
 }

--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -242,8 +242,9 @@ async fn search_sbom(
     log::info!("Querying SBOM: '{}'", params.q);
 
     let (result, total) = actix_web::web::block(move || {
-        let index = state.index.blocking_read();
-        index.search(&params.q, params.offset, params.limit, (&params).into())
+        state
+            .index
+            .search(&params.q, params.offset, params.limit, (&params).into())
     })
     .await?
     .map_err(Error::Index)?;

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1"
 trustification-storage = { path = "../storage"}
 thiserror = "1"
 trustification-api = { path = "../api"}
+tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -433,10 +433,6 @@ impl<INDEX: Index> IndexStore<INDEX> {
     /// Sync the index from a snapshot.
     ///
     /// NOTE: Only applicable for file indices.
-    ///
-    /// # Safety
-    ///
-    /// Only a single thread should call this method at a time. If not, it will panic while acquiring the RefCell
     pub async fn sync(&self, storage: &Storage) -> Result<(), Error> {
         if let Some(index_dir) = &self.index_dir {
             let data = storage.get_index().await?;

--- a/vexination/api/src/lib.rs
+++ b/vexination/api/src/lib.rs
@@ -119,7 +119,7 @@ impl Run {
         let storage = Storage::new(storage.process("vexination", devmode), registry)?;
 
         let state = Arc::new(AppState {
-            storage: RwLock::new(storage),
+            storage,
             index: RwLock::new(index),
         });
 
@@ -150,7 +150,7 @@ impl Run {
 
 pub(crate) type Index = IndexStore<vexination_index::Index>;
 pub struct AppState {
-    storage: RwLock<Storage>,
+    storage: Storage,
     index: RwLock<Index>,
 }
 
@@ -158,9 +158,9 @@ pub(crate) type SharedState = Arc<AppState>;
 
 impl AppState {
     async fn sync_index(&self) -> Result<(), anyhow::Error> {
-        let storage = self.storage.read().await;
+        let storage = &self.storage;
         let mut index = self.index.write().await;
-        index.sync(&storage).await?;
+        index.sync(storage).await?;
         Ok(())
     }
 }

--- a/vexination/api/src/lib.rs
+++ b/vexination/api/src/lib.rs
@@ -11,7 +11,6 @@ use actix_web::{web, HttpServer};
 use actix_web_prom::PrometheusMetricsBuilder;
 use anyhow::anyhow;
 use prometheus::Registry;
-use tokio::sync::RwLock;
 use tokio::task::block_in_place;
 use trustification_auth::auth::AuthConfigArguments;
 use trustification_auth::authenticator::Authenticator;
@@ -118,10 +117,7 @@ impl Run {
             block_in_place(|| IndexStore::new(&storage, &index_config, vexination_index::Index::new(), registry))?;
         let storage = Storage::new(storage.process("vexination", devmode), registry)?;
 
-        let state = Arc::new(AppState {
-            storage,
-            index: RwLock::new(index),
-        });
+        let state = Arc::new(AppState { storage, index });
 
         let sinker = state.clone();
         let sync_interval = index_config.sync_interval.into();
@@ -151,7 +147,7 @@ impl Run {
 pub(crate) type Index = IndexStore<vexination_index::Index>;
 pub struct AppState {
     storage: Storage,
-    index: RwLock<Index>,
+    index: Index,
 }
 
 pub(crate) type SharedState = Arc<AppState>;
@@ -159,7 +155,7 @@ pub(crate) type SharedState = Arc<AppState>;
 impl AppState {
     async fn sync_index(&self) -> Result<(), anyhow::Error> {
         let storage = &self.storage;
-        let mut index = self.index.write().await;
+        let index = &self.index;
         index.sync(storage).await?;
         Ok(())
     }

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -265,8 +265,9 @@ async fn search_vex(
     log::info!("Querying VEX using {}", params.q);
 
     let (result, total) = web::block(move || {
-        let index = state.index.blocking_read();
-        index.search(&params.q, params.offset, params.limit, (&params).into())
+        state
+            .index
+            .search(&params.q, params.offset, params.limit, (&params).into())
     })
     .await?
     .map_err(Error::Index)?;


### PR DESCRIPTION
- fix: reduce API latencies by removing unneeded storage lock
- fix: remove coarse grained index lock

Fixes #484 