### PR TITLE
Don't end up with double-escape-quoted reference types

### DIFF
--- a/collector/osv/src/client/schema.rs
+++ b/collector/osv/src/client/schema.rs
@@ -1,6 +1,7 @@
-use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 /// Package identifies the code library or command that
 /// is potentially affected by a particular vulnerability.
@@ -225,6 +226,27 @@ pub enum ReferenceType {
     Introduced,
     Evidence,
     Git,
+}
+
+//impl ReferenceType {
+impl Display for ReferenceType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}",
+            match self {
+                ReferenceType::Undefined => "NONE",
+                ReferenceType::Web => "WEB",
+                ReferenceType::Advisory => "ADVISORY",
+                ReferenceType::Report => "REPORT",
+                ReferenceType::Fix => "FIX",
+                ReferenceType::Package => "PACKAGE",
+                ReferenceType::Article => "ARTICLE",
+                ReferenceType::Detection => "DETECTION",
+                ReferenceType::Introduced => "INTRODUCED",
+                ReferenceType::Evidence => "EVIDENCE",
+                ReferenceType::Git => "GIT",
+            }
+        )
+    }
 }
 
 /// Reference to additional information about the vulnerability.

--- a/collector/osv/src/client/schema.rs
+++ b/collector/osv/src/client/schema.rs
@@ -231,7 +231,9 @@ pub enum ReferenceType {
 //impl ReferenceType {
 impl Display for ReferenceType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}",
+        write!(
+            f,
+            "{}",
             match self {
                 ReferenceType::Undefined => "NONE",
                 ReferenceType::Web => "WEB",

--- a/collector/osv/src/lib.rs
+++ b/collector/osv/src/lib.rs
@@ -147,7 +147,7 @@ impl From<Vulnerability> for v11y_client::Vulnerability {
 impl From<&Reference> for v11y_client::Reference {
     fn from(reference: &Reference) -> Self {
         Self {
-            r#type: serde_json::to_string(&reference.reference_type).unwrap_or("unknown".to_string()),
+            r#type: reference.reference_type.to_string(),
             url: reference.url.clone(),
         }
     }


### PR DESCRIPTION
when converting from OSV to v11y.