### PR TITLE
feat: support XDG_CONFIG_HOME environment variables.

### DIFF
--- a/trust/src/main.rs
+++ b/trust/src/main.rs
@@ -1,3 +1,6 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
 use std::process::{ExitCode, Termination};
 
 use clap::Parser;
@@ -75,5 +78,34 @@ impl Cli {
 
 #[tokio::main]
 async fn main() -> impl Termination {
+    load_xdg_config();
     Cli::parse().run().await
+}
+
+fn load_xdg_config() {
+    let config_dir = if let Ok(xdg_config_home) = std::env::var("XDG_CONFIG_HOME") {
+        Some(Path::new(&xdg_config_home).join("trustification"))
+    } else if let Ok(home) = std::env::var("HOME") {
+        Some(Path::new(&home).join(".config").join("trustification"))
+    } else {
+        None
+    };
+
+    if let Some(config_dir) = config_dir {
+        if config_dir.exists() && config_dir.is_dir() {
+            if let Ok(dir) = config_dir.read_dir() {
+                for entry in dir.flatten() {
+                    let var_name = entry.file_name().to_str().unwrap().to_string();
+                    if let Ok(mut file) = File::open(entry.path()) {
+                        let mut var_value = String::new();
+                        if file.read_to_string(&mut var_value).is_ok() {
+                            std::env::set_var(var_name, var_value.trim());
+                        }
+                    }
+                }
+            } else {
+                eprintln!("Warning: unable to read configuration directory: {:?}", config_dir);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Under $XDG_CONFIG_HOME/trustification/, each discovered file will be loaded as an environment variable prior to parsing a `trust` command-line.

Generally, XDG_CONFIG_HOME defaults to `$HOME/.config.`