### PR TITLE
Add options to search by time

### DIFF
--- a/spog/api/src/config/default.yaml
+++ b/spog/api/src/config/default.yaml
@@ -14,74 +14,146 @@ bombastic:
       - label: Products
         options:
 
-          - label: UBI 7
+          - type: check
+            label: UBI 7
             id: ubi7
             terms:
               - '"pkg:oci/redhat/ubi7"'
 
-          - label: UBI 8
+          - type: check
+            label: UBI 8
             id: ubi8
             terms:
               - '"pkg:oci/redhat/ubi8"'
 
-          - label: UBI 9
+          - type: check
+            label: UBI 9
             id: ubi9
             terms:
               - '"pkg:oci/redhat/ubi9"'
 
-          - divider: true
+          - type: divider
 
-          - label: Red Hat Enterprise Linux 7
+          - type: check
+            label: Red Hat Enterprise Linux 7
             id: rhel7
             terms:
               - '"cpe:/o:redhat:enterprise_linux:7"'
               - '"cpe:/o:redhat:rhel_aus:7"'
 
-          - label: Red Hat Enterprise Linux 8
+          - type: check
+            label: Red Hat Enterprise Linux 8
             id: rhel8
             terms:
               - '"cpe:/o:redhat:enterprise_linux:8"'
               - '"cpe:/o:redhat:rhel_e4s:8.1"'
 
-          - label: Red Hat Enterprise Linux 9
+          - type: check
+            label: Red Hat Enterprise Linux 9
             id: rhel9
             terms:
               - '"cpe:/o:redhat:enterprise_linux:9"'
 
-          - divider: true
+          - type: divider
 
-          - label: Ansible
+          - type: check
+            label: Ansible
             id: ansible
             terms:
               - '"cpe:/a:redhat:ansible_automation_platform"'
 
-          - label: AMQ
+          - type: check
+            label: AMQ
             id: amq
             terms:
               - '"cpe:/a:redhat:amq" OR "amq-"'
 
-          - label: Quarkus
+          - type: check
+            label: Quarkus
             id: quarkus
             terms:
               - '"quarkus"'
 
       - label: Type
         options:
-          - label: Container
+          - type: check
+            label: Container
             id: is_container
             terms:
               - 'type:oci'
-          - label: Product
+
+          - type: check
+            label: Product
             id: is_product
             terms:
               - 'NOT type:oci'
 
       - label: Suppliers
         options:
-          - label: Red Hat
+          - type: check
+            label: Red Hat
             id: supplier_redhat
             terms:
               - 'supplier:"Organization: Red Hat"'
+
+      - label: Created on
+        options:
+          - type: check
+            id: last-week
+            label: Last 7 days
+            script: |
+              const end = new Date();
+              const start = new Date(end.getTime() - (7 * 24 * 60 * 60 * 1000));
+              [
+                "created:" + 
+                start.toLocaleString("default", { year: "numeric" }) + "-" +
+                start.toLocaleString("default", { month: "2-digit" }) + "-" +
+                start.toLocaleString("default", { day: "2-digit" }) + ".." +
+                end.toLocaleString("default", { year: "numeric" }) + "-" +
+                end.toLocaleString("default", { month: "2-digit" }) + "-" +
+                end.toLocaleString("default", { day: "2-digit" })
+              ];
+          - type: check
+            id: last-month
+            label: Last 30 days
+            script: |
+              const end = new Date();
+              const start = new Date(end.getTime() - (30 * 24 * 60 * 60 * 1000));
+              [
+                "created:" + 
+                start.toLocaleString("default", { year: "numeric" }) + "-" +
+                start.toLocaleString("default", { month: "2-digit" }) + "-" +
+                start.toLocaleString("default", { day: "2-digit" }) + ".." +
+                end.toLocaleString("default", { year: "numeric" }) + "-" +
+                end.toLocaleString("default", { month: "2-digit" }) + "-" +
+                end.toLocaleString("default", { day: "2-digit" })
+              ];
+          - type: check
+            id: this-year
+            label: This year
+            script: |
+              const date = new Date();
+              const start = new Date(date.getFullYear(), 0, 1);
+              const end = new Date(date.getFullYear()+1, 0, 1);
+              [
+                "created:" + 
+                start.toLocaleString("default", { year: "numeric" }) + "-" +
+                start.toLocaleString("default", { month: "2-digit" }) + "-" +
+                start.toLocaleString("default", { day: "2-digit" }) + ".." +
+                end.toLocaleString("default", { year: "numeric" }) + "-" +
+                end.toLocaleString("default", { month: "2-digit" }) + "-" +
+                end.toLocaleString("default", { day: "2-digit" })
+              ];
+          - type: check
+            id: "2022"
+            label: "2022"
+            terms:
+              - 'created:2022-01-01..2023-01-01'
+          - type: check
+            id: "2021"
+            label: "2021"
+            terms:
+              - 'created:2021-01-01..2022-01-01'
 
 vexination:
 
@@ -89,7 +161,8 @@ vexination:
     categories:
       - label: Severity
         options:
-          - id: low
+          - type: check
+            id: low
             label: |
               <span class="tc-c-severity">
                   <span class="tc-c-severity__icon"> <span class="tc-m-severity-low"> <i class="fa fa-shield-halved"></i> </span></span>
@@ -97,7 +170,9 @@ vexination:
               </span>
             terms:
               - "severity:Low"
-          - id: moderate
+
+          - type: check
+            id: moderate
             label: |
               <span class="tc-c-severity">
                   <span class="tc-c-severity__icon"> <span class="tc-m-severity-moderate"> <i class="fa fa-shield-halved"></i> </span></span>
@@ -105,7 +180,9 @@ vexination:
               </span>
             terms:
               - "severity:Moderate"
-          - id: important
+
+          - type: check
+            id: important
             label: |
               <span class="tc-c-severity">
                   <span class="tc-c-severity__icon"> <span class="tc-m-severity-important"> <i class="fa fa-shield-halved"></i> </span></span>
@@ -113,7 +190,9 @@ vexination:
               </span>
             terms:
               - "severity:Important"
-          - id: critical
+
+          - type: check
+            id: critical
             label: |
               <span class="tc-c-severity">
                   <span class="tc-c-severity__icon"> <span class="tc-m-severity-critical"> <i class="fa fa-shield-halved"></i> </span></span>
@@ -124,32 +203,97 @@ vexination:
 
       - label: Products
         options:
-          - id: rhel7
+
+          - type: check
+            id: rhel7
             label: Red Hat Enterprise Linux 7
             terms:
               - '( "cpe:/o:redhat:rhel_eus:7" in:package )'
 
-          - id: rhel8
+          - type: check
+            id: rhel8
             label: Red Hat Enterprise Linux 8
             terms:
               - '( "cpe:/o:redhat:rhel_eus:8" in:package )'
 
-          - id: rhel9
+          - type: check
+            id: rhel9
             label: Red Hat Enterprise Linux 9
             terms:
               - '( "cpe:/a:redhat:enterprise_linux:9" in:package )'
 
-          - divider: true
+          - type: divider
 
-          - id: ocp3
+          - type: check
+            id: ocp3
             label: OpenShift Container Platform 3
             terms:
               - '( "cpe:/a:redhat:openshift:3" in:package )'
 
-          - id: ocp4
+          - type: check
+            id: ocp4
             label: OpenShift Container Platform 4
             terms:
               - '( "cpe:/a:redhat:openshift:4" in:package )'
+
+      - label: Revisions
+        options:
+          - type: check
+            id: last-week
+            label: Last 7 days
+            script: |
+              const end = new Date();
+              const start = new Date(end.getTime() - (7 * 24 * 60 * 60 * 1000));
+              [
+                "release:" + 
+                start.toLocaleString("default", { year: "numeric" }) + "-" +
+                start.toLocaleString("default", { month: "2-digit" }) + "-" +
+                start.toLocaleString("default", { day: "2-digit" }) + ".." +
+                end.toLocaleString("default", { year: "numeric" }) + "-" +
+                end.toLocaleString("default", { month: "2-digit" }) + "-" +
+                end.toLocaleString("default", { day: "2-digit" })
+              ];
+          - type: check
+            id: last-month
+            label: Last 30 days
+            script: |
+              const end = new Date();
+              const start = new Date(end.getTime() - (30 * 24 * 60 * 60 * 1000));
+              [
+                "release:" + 
+                start.toLocaleString("default", { year: "numeric" }) + "-" +
+                start.toLocaleString("default", { month: "2-digit" }) + "-" +
+                start.toLocaleString("default", { day: "2-digit" }) + ".." +
+                end.toLocaleString("default", { year: "numeric" }) + "-" +
+                end.toLocaleString("default", { month: "2-digit" }) + "-" +
+                end.toLocaleString("default", { day: "2-digit" })
+              ];
+          - type: check
+            id: this-year
+            label: This year
+            script: |
+              const date = new Date();
+              const start = new Date(date.getFullYear(), 0, 1);
+              const end = new Date(date.getFullYear()+1, 0, 1);
+              [
+                "release:" + 
+                start.toLocaleString("default", { year: "numeric" }) + "-" +
+                start.toLocaleString("default", { month: "2-digit" }) + "-" +
+                start.toLocaleString("default", { day: "2-digit" }) + ".." +
+                end.toLocaleString("default", { year: "numeric" }) + "-" +
+                end.toLocaleString("default", { month: "2-digit" }) + "-" +
+                end.toLocaleString("default", { day: "2-digit" })
+              ];
+          - type: check
+            id: "2022"
+            label: "2022"
+            terms:
+              - 'release:2022-01-01..2023-01-01'
+          - type: check
+            id: "2021"
+            label: "2021"
+            terms:
+              - 'release:2021-01-01..2022-01-01'
 
 scanner:
   documentationUrl: https://www.trustification.io/blog/

--- a/spog/api/src/config/mod.rs
+++ b/spog/api/src/config/mod.rs
@@ -70,3 +70,14 @@ pub(crate) async fn configurator(source: Option<PathBuf>) -> anyhow::Result<impl
             .service(web::resource("/api/v1/config").to(get_config));
     })
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    /// ensure that the default configuration parses
+    fn parse_default() {
+        let _config: Configuration = serde_yaml::from_slice(include_bytes!("default.yaml")).unwrap();
+    }
+}

--- a/spog/model/schema/config.json
+++ b/spog/model/schema/config.json
@@ -167,8 +167,89 @@
         }
       }
     },
-    "FilterCheckOption": {
-      "description": "Values for a filter option",
+    "FilterOption": {
+      "description": "The filter option element which can be added",
+      "oneOf": [
+        {
+          "description": "Add a checkbox option",
+          "type": "object",
+          "required": [
+            "id",
+            "label",
+            "terms",
+            "type"
+          ],
+          "properties": {
+            "id": {
+              "description": "Internal ID (must be unique)",
+              "type": "string"
+            },
+            "label": {
+              "description": "End-user friendly label",
+              "type": "string"
+            },
+            "terms": {
+              "description": "Search terms which will be added using an OR group",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "check"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Add a select/radio button",
+          "type": "object",
+          "required": [
+            "group",
+            "options",
+            "type"
+          ],
+          "properties": {
+            "group": {
+              "description": "Internal ID (groups radio options)",
+              "type": "string"
+            },
+            "options": {
+              "description": "Search terms which will be added using an OR group",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/FilterSelectItem"
+              }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "select"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Add a visual divider",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "divider"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "FilterSelectItem": {
+      "description": "Item of a [`FilterSelectOption`]",
       "type": "object",
       "required": [
         "id",
@@ -177,7 +258,7 @@
       ],
       "properties": {
         "id": {
-          "description": "Internal ID (must be unique)",
+          "description": "Internal ID (must be unique for a radio group)",
           "type": "string"
         },
         "label": {
@@ -192,23 +273,6 @@
           }
         }
       }
-    },
-    "FilterOption": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/FilterCheckOption"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "divider": {
-              "type": "boolean",
-              "const": true
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
     },
     "Filters": {
       "description": "A set of customizable filters",

--- a/spog/model/schema/config.json
+++ b/spog/model/schema/config.json
@@ -176,7 +176,6 @@
           "required": [
             "id",
             "label",
-            "terms",
             "type"
           ],
           "properties": {
@@ -188,8 +187,12 @@
               "description": "End-user friendly label",
               "type": "string"
             },
+            "script": {
+              "description": "A JavaScript snippet to execute, gathering search terms.\n\nThe result must be an array of strings. For example:\n\n```yaml script: | [\"foo:bar\", \"bar:baz\"] ```",
+              "type": "string"
+            },
             "terms": {
-              "description": "Search terms which will be added using an OR group",
+              "description": "A list of search terms",
               "type": "array",
               "items": {
                 "type": "string"
@@ -253,8 +256,7 @@
       "type": "object",
       "required": [
         "id",
-        "label",
-        "terms"
+        "label"
       ],
       "properties": {
         "id": {
@@ -265,8 +267,12 @@
           "description": "End-user friendly label",
           "type": "string"
         },
+        "script": {
+          "description": "A JavaScript snippet to execute, gathering search terms.\n\nThe result must be an array of strings. For example:\n\n```yaml script: | [\"foo:bar\", \"bar:baz\"] ```",
+          "type": "string"
+        },
         "terms": {
-          "description": "Search terms which will be added using an OR group",
+          "description": "A list of search terms",
           "type": "array",
           "items": {
             "type": "string"

--- a/spog/model/src/config.rs
+++ b/spog/model/src/config.rs
@@ -189,7 +189,7 @@ pub struct FilterCategory {
     pub options: Vec<FilterOption>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Terms {
     /// A list of search terms
@@ -267,7 +267,7 @@ mod test {
         FilterCheckOption {
             id: id.into(),
             label: label.into(),
-            terms: vec![],
+            terms: Terms::default(),
         }
     }
 
@@ -276,18 +276,17 @@ mod test {
     }
 
     fn mock_select(
-        id: impl Into<String>,
-        label: impl Into<String>,
+        group: impl Into<String>,
         options: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
     ) -> FilterOption {
         FilterOption::Select(FilterSelectOption {
-            id: id.into(),
+            group: group.into(),
             options: options
                 .into_iter()
                 .map(|(id, label)| FilterSelectItem {
                     id: id.into(),
                     label: label.into(),
-                    terms: vec![],
+                    terms: Terms::default(),
                 })
                 .collect(),
         })
@@ -399,7 +398,7 @@ mod test {
                         mock_check("id1", "label1"),
                         FilterOption::Divider,
                         mock_check("id2", "label2"),
-                        mock_select("id3", "label3", [("a", "A"), ("b", "B"), ("c", "C")])
+                        mock_select("id3", [("a", "A"), ("b", "B"), ("c", "C")])
                     ]
                 }]
             }

--- a/spog/model/src/config.rs
+++ b/spog/model/src/config.rs
@@ -189,6 +189,24 @@ pub struct FilterCategory {
     pub options: Vec<FilterOption>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Terms {
+    /// A list of search terms
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub terms: Vec<String>,
+    /// A JavaScript snippet to execute, gathering search terms.
+    ///
+    /// The result must be an array of strings. For example:
+    ///
+    /// ```yaml
+    /// script: |
+    ///   ["foo:bar", "bar:baz"]
+    /// ```
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub script: String,
+}
+
 /// Values for a filter option
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -197,8 +215,10 @@ pub struct FilterCheckOption {
     pub id: String,
     /// End-user friendly label
     pub label: String,
+
     /// Search terms which will be added using an OR group
-    pub terms: Vec<String>,
+    #[serde(flatten)]
+    pub terms: Terms,
 }
 
 /// Select style choice (one of)
@@ -219,8 +239,10 @@ pub struct FilterSelectItem {
     pub id: String,
     /// End-user friendly label
     pub label: String,
+
     /// Search terms which will be added using an OR group
-    pub terms: Vec<String>,
+    #[serde(flatten)]
+    pub terms: Terms,
 }
 
 /// The filter option element which can be added

--- a/spog/model/src/config.rs
+++ b/spog/model/src/config.rs
@@ -297,6 +297,7 @@ mod test {
         assert_eq!(
             serde_json::from_value::<Vec<FilterOption>>(json!([
                 {
+                    "type": "check",
                     "id": "id1",
                     "label": "label1",
                     "terms": [],
@@ -312,12 +313,14 @@ mod test {
         assert_eq!(
             serde_json::from_value::<Vec<FilterOption>>(json!([
                 {
+                    "type": "check",
                     "id": "id1",
                     "label": "label1",
                     "terms": [],
                 },
-                { "divider": true },
+                { "type": "divider" },
                 {
+                    "type": "check",
                     "id": "id2",
                     "label": "label2",
                     "terms": [],
@@ -330,24 +333,6 @@ mod test {
                 mock_check("id2", "label2")
             ],
         )
-    }
-
-    #[test]
-    fn test_deserialize_options_3() {
-        assert!(serde_json::from_value::<Vec<FilterOption>>(json!([
-            {
-                "id": "id1",
-                "label": "label1",
-                "terms": [],
-            },
-            { "divider": false }, // error
-            {
-                "id": "id2",
-                "label": "label2",
-                "terms": [],
-            },
-        ]))
-        .is_err(),)
     }
 
     /// ensure that re-encoding the content keeps it equal
@@ -369,8 +354,7 @@ mod test {
             },
             {
                 "type": "select",
-                "id": "id3",
-                "label": "label3",
+                "group": "id3",
                 "options": [
                     { "id": "a", "label": "A", "terms": [] },
                     { "id": "b", "label": "B", "terms": [] },

--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -2427,6 +2427,7 @@ dependencies = [
  "gloo-utils 0.1.7",
  "humansize",
  "itertools 0.11.0",
+ "js-sys",
  "log",
  "markdown",
  "monaco",

--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -39,8 +39,9 @@ dependencies = [
 
 [[package]]
 name = "analytics-next"
-version = "0.1.0-alpha.2"
-source = "git+https://github.com/ctron/analytics-next-rs?rev=9c95122f4e6dc308c90b945bd0f1925faf7cb828#9c95122f4e6dc308c90b945bd0f1925faf7cb828"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11ed5ffb460ae293f9039580e672e85b91a67669eefa38efafcf2ef3ea6c496"
 dependencies = [
  "analytics-next-sys",
  "gloo-utils 0.2.0",
@@ -53,8 +54,9 @@ dependencies = [
 
 [[package]]
 name = "analytics-next-sys"
-version = "0.1.0-alpha.2"
-source = "git+https://github.com/ctron/analytics-next-rs?rev=9c95122f4e6dc308c90b945bd0f1925faf7cb828#9c95122f4e6dc308c90b945bd0f1925faf7cb828"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb69a04d306a3d10dc33029a2ea21c70801d6265b1bdf4e11e7657db9d286a4"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1606,7 +1608,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 [[package]]
 name = "patternfly-yew"
 version = "0.5.0-alpha.3"
-source = "git+https://github.com/ctron/patternfly-yew?rev=5ca949a9ed37294a394f7d8f8bebd365a17426a8#5ca949a9ed37294a394f7d8f8bebd365a17426a8"
+source = "git+https://github.com/ctron/patternfly-yew?rev=2958f879b08fd265c3385ae889dfca5ed7b8103c#2958f879b08fd265c3385ae889dfca5ed7b8103c"
 dependencies = [
  "chrono",
  "gloo-events 0.1.2",

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -21,6 +21,7 @@ gloo-storage = "0.2.2"
 gloo-utils = { version = "0.1", features = ["serde"] }
 humansize = "2"
 itertools = "0.11"
+js-sys = "0.3"
 log = "0.4"
 markdown = "1.0.0-alpha.11"
 monaco = { version = "0.3", features = ["yew-components"] }

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2"
 description = "Single Pane of Glass"
 
 [dependencies]
-analytics-next = "0.1.0-alpha.2"
+analytics-next = "0.1.0"
 anyhow = "1"
 async-trait = "0.1"
 browser-panic-hook = "0.2.0"
@@ -73,10 +73,10 @@ features = [
 #yew-nested-router = { git = "https://github.com/ctron/yew-nested-router", rev = "9689db446dee7030325884df768d0c2e84f353d6" }
 #yew-more-hooks = { git = "https://github.com/ctron/yew-more-hooks", rev = "fc0af774aa925edcd5a544e562619ecb539942f8" }
 #yew-more-hooks = { path = "../../../yew-more-hooks" }
-patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "5ca949a9ed37294a394f7d8f8bebd365a17426a8" } # FIXME: awaiting release
+patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "2958f879b08fd265c3385ae889dfca5ed7b8103c" } # FIXME: awaiting release
 #patternfly-yew = { path = "../../../patternfly-yew" }
 
-analytics-next = { git = "https://github.com/ctron/analytics-next-rs", rev = "9c95122f4e6dc308c90b945bd0f1925faf7cb828" } # FIXME: awaiting release
+#analytics-next = { git = "https://github.com/ctron/analytics-next-rs", rev = "9c95122f4e6dc308c90b945bd0f1925faf7cb828" } # FIXME: awaiting release
 #analytics-next = { path = "../../../analytics-next" }
 
 csaf = { git = "https://github.com/voteblake/csaf-rs", rev = "76cb9ede10adb1fbb495b17e5fd8d95c5cf6c900" } # FIXME: waiting for release

--- a/spog/ui/src/components/search/simple.rs
+++ b/spog/ui/src/components/search/simple.rs
@@ -60,6 +60,7 @@ pub type SearchOptionSetter<T> = Rc<dyn Fn(&mut T, bool)>;
 #[derive(Clone)]
 pub enum SearchOption<T> {
     Check(SearchOptionCheck<T>),
+    Select(SearchOptionSelect<T>),
     Divider,
 }
 
@@ -68,6 +69,18 @@ pub struct SearchOptionCheck<T> {
     pub label: LabelProvider,
     pub getter: SearchOptionGetter<T>,
     pub setter: SearchOptionSetter<T>,
+}
+
+#[derive(Clone)]
+pub struct SearchOptionSelectItem<T> {
+    pub label: LabelProvider,
+    pub getter: SearchOptionGetter<T>,
+    pub setter: SearchOptionSetter<T>,
+}
+
+#[derive(Clone)]
+pub struct SearchOptionSelect<T> {
+    pub options: Vec<SearchOptionSelectItem<T>>,
 }
 
 impl<T> SearchOption<T> {
@@ -263,6 +276,27 @@ where
                     { &opt.label }
                 </Check>
             )
+        }
+        SearchOption::Select(select) => {
+            let active = props.search_params.is_simple();
+            let select = select.clone();
+
+            select
+                .options
+                .iter()
+                .map(|opt| {
+                    let opt = opt.clone();
+                    html!(
+                        <Radio
+                            checked={(*props.search_params).map_bool(|s|(opt.getter)(s))}
+                            onchange={search_set(props.search_params.clone(), move |s, _state|(opt.setter)(s, true)).reform(|_|true)}
+                            disabled={!active}
+                        >
+                            { &opt.label }
+                        </Radio>
+                    )
+                })
+                .collect::<Html>()
         }
     }
 }


### PR DESCRIPTION
This implements the missing "by time" filter options in the UI.

In contrast to the current sketches, this implementation uses checkboxes instead of radio buttons. This was decided after a chat with UX. Having radio buttons would actually limit the user into a single choice, and also create the problem of not being able to "unselect" a date range filter, unless we would add an "any" radio button. The resolution to those issues was to use checkboxes instead.

![image](https://github.com/trustification/trustification/assets/202474/70ebd113-aaf8-4409-855e-69bc6bb6d5ae)
