### PR TITLE
fix: retry objects that fail fetching to avoid failing retrieval process early

### DIFF
--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -149,7 +149,7 @@ async fn query_sbom(
         // otherwise, decode the stream
         None => Ok(HttpResponse::Ok()
             .content_type(ContentType::json())
-            .streaming(storage.get_decoded_stream(path).await.map_err(Error::Storage)?)),
+            .streaming(storage.get_decoded_stream(&path).await.map_err(Error::Storage)?)),
     }
 }
 

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -49,7 +49,7 @@ pub fn config(
 }
 
 async fn fetch_object(storage: &Storage, key: &str) -> HttpResponse {
-    match storage.get_decoded_stream(S3Path::from_key(key)).await {
+    match storage.get_decoded_stream(&S3Path::from_key(key)).await {
         Ok(stream) => HttpResponse::Ok().content_type(ContentType::json()).streaming(stream),
         Err(e) => {
             log::warn!("Unable to locate object with key {}: {:?}", key, e);


### PR DESCRIPTION
When walking a large number of objects, existing early because of a temporary network error
has some major implications on the rest of the system, such as needing to restart the process of walking the objects
or keeping tracked of the failed ones.

Instead, retry objects that failed to fetch a number of times before aborting.
