### PR TITLE
feat: add readiness probe for API search availability

### DIFF
--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -463,6 +463,7 @@ impl<INDEX: Index> IndexStore<INDEX> {
                 }
                 Err(e) => {
                     log::warn!("Error syncing index: {:?}, keeping old", e);
+                    return Err(e);
                 }
             }
             log::debug!("Index reloaded");


### PR DESCRIPTION
If the search index fails the initial sync, the readiness probe will not pass, which will
allow the previous instance of the API to continue working.

Issue #532
