### PR TITLE
feat: support different reindexing modes

### DIFF
--- a/bombastic/indexer/src/lib.rs
+++ b/bombastic/indexer/src/lib.rs
@@ -5,7 +5,7 @@ use tokio::sync::{mpsc, Mutex};
 use tokio::task::block_in_place;
 use trustification_event_bus::EventBusConfig;
 use trustification_index::{IndexConfig, IndexStore};
-use trustification_indexer::{actix::configure, Indexer, IndexerStatus};
+use trustification_indexer::{actix::configure, Indexer, IndexerStatus, ReindexMode};
 use trustification_infrastructure::{Infrastructure, InfrastructureConfig};
 use trustification_storage::{Storage, StorageConfig};
 
@@ -24,9 +24,8 @@ pub struct Run {
     #[arg(long = "devmode", default_value_t = false)]
     pub devmode: bool,
 
-    /// Reindex all documents at startup
-    #[arg(long = "reindex", default_value_t = false)]
-    pub reindex: bool,
+    #[arg(long = "reindex", default_value_t = ReindexMode::OnFailure)]
+    pub reindex: ReindexMode,
 
     #[command(flatten)]
     pub bus: EventBusConfig,
@@ -68,10 +67,6 @@ impl Run {
                         bus.create(&[self.stored_topic.as_str()]).await?;
                     }
 
-                    if self.reindex {
-                        let _ = c.send(trustification_indexer::IndexerCommand::Reindex).await;
-                    }
-
                     let mut indexer = Indexer {
                         index,
                         storage,
@@ -83,6 +78,7 @@ impl Run {
                         status: s.clone(),
                         commands: command_receiver,
                         command_sender: c,
+                        reindex: self.reindex,
                     };
                     indexer.run().await
                 },

--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -36,6 +36,12 @@ pub enum ReindexMode {
     Never,
 }
 
+impl Default for ReindexMode {
+    fn default() -> Self {
+        ReindexMode::OnFailure
+    }
+}
+
 impl fmt::Display for ReindexMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -26,20 +26,15 @@ pub enum IndexerCommand {
     Reindex,
 }
 
-#[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
+#[derive(clap::ValueEnum, Default, Clone, Debug, PartialEq)]
 pub enum ReindexMode {
     #[clap(name = "always")]
     Always,
+    #[default]
     #[clap(name = "on-failure")]
     OnFailure,
     #[clap(name = "never")]
     Never,
-}
-
-impl Default for ReindexMode {
-    fn default() -> Self {
-        ReindexMode::OnFailure
-    }
 }
 
 impl fmt::Display for ReindexMode {

--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -68,10 +68,8 @@ impl<'a, INDEX: Index> Indexer<'a, INDEX> {
             if self.reindex == ReindexMode::OnFailure || self.reindex == ReindexMode::Always {
                 self.command_sender.send(IndexerCommand::Reindex).await?;
             }
-        } else {
-            if self.reindex == ReindexMode::Always {
-                self.command_sender.send(IndexerCommand::Reindex).await?;
-            }
+        } else if self.reindex == ReindexMode::Always {
+            self.command_sender.send(IndexerCommand::Reindex).await?;
         }
 
         let mut interval = tokio::time::interval(self.sync_interval);

--- a/integration-tests/src/bom.rs
+++ b/integration-tests/src/bom.rs
@@ -162,7 +162,7 @@ fn bombastic_indexer() -> bombastic_indexer::Run {
         failed_topic: "sbom-failed".into(),
         indexed_topic: "sbom-indexed".into(),
         devmode: true,
-        reindex: false,
+        reindex: Default::default(),
         index: IndexConfig {
             index_dir: None,
             index_writer_memory_bytes: 32 * 1024 * 1024,

--- a/integration-tests/src/vex.rs
+++ b/integration-tests/src/vex.rs
@@ -137,7 +137,7 @@ fn vexination_indexer() -> vexination_indexer::Run {
         failed_topic: "vex-failed".into(),
         indexed_topic: "vex-indexed".into(),
         devmode: true,
-        reindex: false,
+        reindex: Default::default(),
         index: IndexConfig {
             index_dir: None,
             index_writer_memory_bytes: 32 * 1024 * 1024,


### PR DESCRIPTION
The reindexing behavior is currently hardcoded to always or never, but this introduces another mode where reindexing can happen only if the index fails to load, which is typical for schema changes.
