### PR TITLE
fix: fix license in test data

### DIFF
--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -9,7 +9,7 @@ use cyclonedx_bom::models::{
 use log::{debug, info, warn};
 use sikula::{mir::Direction, prelude::*};
 use spdx_rs::models::Algorithm;
-use tantivy::query::TermSetQuery;
+use tantivy::query::{TermQuery, TermSetQuery};
 use tantivy::{collector::TopDocs, Order};
 use tantivy::{
     query::{AllQuery, BooleanQuery},
@@ -307,6 +307,10 @@ impl Index {
         const PACKAGE_WEIGHT: f32 = 1.5;
         const CREATED_WEIGHT: f32 = 1.25;
         match resource {
+            Packages::Id(value) => Box::new(TermQuery::new(
+                Term::from_field_text(self.fields.sbom_id, value),
+                Default::default(),
+            )),
             Packages::Package(primary) => boost(
                 self.create_string_query(
                     &[

--- a/bombastic/model/src/search.rs
+++ b/bombastic/model/src/search.rs
@@ -3,6 +3,9 @@ use sikula::prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Search)]
 pub enum Packages<'a> {
+    /// Search by SBOM id
+    #[search]
+    Id(&'a str),
     /// Search package name and package reference.
     ///
     /// Example queries:

--- a/bombastic/model/src/search.rs
+++ b/bombastic/model/src/search.rs
@@ -4,7 +4,7 @@ use sikula::prelude::*;
 #[derive(Clone, Debug, PartialEq, Search)]
 pub enum Packages<'a> {
     /// Search by SBOM id
-    #[search]
+    #[search(default)]
     Id(&'a str),
     /// Search package name and package reference.
     ///

--- a/integration-tests/tests/spog.rs
+++ b/integration-tests/tests/spog.rs
@@ -113,10 +113,9 @@ async fn spog_crda_integration(context: &mut SpogContext) {
 #[test_context(SpogContext)]
 #[tokio::test]
 #[ntest::timeout(120_000)]
-#[ignore]
 async fn spog_search_correlation(context: &mut SpogContext) {
     let input = serde_json::from_str(include_str!("testdata/correlation/stf-1.5.json")).unwrap();
-    let sbom_id = "test-stf-1.5";
+    let sbom_id = "test-stf-1.5-correlation";
     upload_sbom(&context.bombastic, sbom_id, &input).await;
 
     let input = serde_json::from_str(include_str!("testdata/correlation/rhsa-2023_1529.json")).unwrap();
@@ -129,7 +128,7 @@ async fn spog_search_correlation(context: &mut SpogContext) {
     // indexer time to do its thing, so might need to retry
     loop {
         let response = client
-            .get(context.urlify("/api/v1/package/search?q=package%3Astf-1.5"))
+            .get(context.urlify("/api/v1/package/search?q=id%3Atest-stf-1.5-correlation"))
             .inject_token(&context.provider.provider_user)
             .await
             .unwrap()
@@ -166,7 +165,7 @@ async fn spog_search_correlation(context: &mut SpogContext) {
 #[ntest::timeout(30_000)]
 async fn spog_dependencies(context: &mut SpogContext) {
     let input = serde_json::from_str(include_str!("testdata/correlation/stf-1.5.json")).unwrap();
-    let sbom_id = "test-stf-1.5";
+    let sbom_id = "test-stf-1.5-guac";
     upload_sbom(&context.bombastic, sbom_id, &input).await;
 
     let client = reqwest::Client::new();

--- a/integration-tests/tests/testdata/correlation/stf-1.5.json
+++ b/integration-tests/tests/testdata/correlation/stf-1.5.json
@@ -17624,7 +17624,7 @@
       "homepage": "NOASSERTION",
       "licenseComments": "Licensing information is automatically generated and may be incomplete or incorrect.",
       "licenseConcluded": "NOASSERTION",
-      "licenseDeclared": "GPLV2+,-LGPLV2+,-MIT",
+      "licenseDeclared": "NOASSERTION",
       "name": "gobject-introspection",
       "originator": "NOASSERTION",
       "packageFileName": "gobject-introspection-1.56.1-1.el8.x86_64.rpm",


### PR DESCRIPTION
The malformed test data prevented the SBOM from being ingested.

Add the ability to lookup by the original ID in bombastic search to ensure tests retrieve the correct document.

Issue #589