### PR TITLE
fix: use the test context teardown fn to delete fixtures

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -37,10 +37,10 @@ clap = { version = "4", features = ["derive"] }
 
 prometheus = "0.13.3"
 uuid = { version = "1", features = ["v4"] }
+urlencoding = "2.1.2"
 
 [dev-dependencies]
 env_logger = "0.10"
-urlencoding = "2.1.2"
 spog-model = { path = "../spog/model" }
 
 [features]

--- a/integration-tests/src/spog.rs
+++ b/integration-tests/src/spog.rs
@@ -10,6 +10,10 @@ impl AsyncTestContext for SpogContext {
         let config = Config::new().await;
         start_spog(&config).await
     }
+    async fn teardown(self) {
+        self.bombastic.teardown().await;
+        self.vexination.teardown().await;
+    }
 }
 
 impl Urlifier for SpogContext {


### PR DESCRIPTION
Almost fixes #587 in that it will handle panics within the test bodies, but it will not handle a panic as a result of the `ntest::timeout` macro.