### PR TITLE
fix: make correlated doc id's truly unique

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,6 +3441,7 @@ dependencies = [
  "trustification-auth",
  "trustification-event-bus",
  "trustification-index",
+ "trustification-indexer",
  "trustification-infrastructure",
  "trustification-storage",
  "urlencoding",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -32,6 +32,7 @@ spog-api = { path = "../spog/api", optional = true }
 trustification-infrastructure = { path = "../infrastructure", optional = true }
 trustification-storage = { path = "../storage", optional = true }
 trustification-index = { path = "../index", optional = true }
+trustification-indexer = { path = "../indexer", optional = true }
 
 clap = { version = "4", features = ["derive"] }
 
@@ -45,4 +46,4 @@ spog-model = { path = "../spog/model" }
 
 [features]
 default = ["with-services"]
-with-services = ["bombastic-api", "bombastic-indexer", "vexination-api", "vexination-indexer", "spog-api", "trustification-storage", "trustification-index", "trustification-infrastructure" ]
+with-services = ["bombastic-api", "bombastic-indexer", "vexination-api", "vexination-indexer", "spog-api", "trustification-storage", "trustification-index", "trustification-indexer", "trustification-infrastructure" ]

--- a/integration-tests/src/vex.rs
+++ b/integration-tests/src/vex.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{config::Config, runner::Runner};
 use async_trait::async_trait;
 use test_context::AsyncTestContext;
+use trustification_indexer::ReindexMode;
 
 #[async_trait]
 impl AsyncTestContext for VexinationContext {
@@ -146,15 +147,14 @@ impl VexinationContext {
 fn vexination_indexer() -> vexination_indexer::Run {
     vexination_indexer::Run {
         stored_topic: "vex-stored".into(),
-        failed_topic: "vex-failed".into(),
         indexed_topic: "vex-indexed".into(),
+        failed_topic: "vex-failed".into(),
         devmode: true,
-        reindex: Default::default(),
-        index: IndexConfig {
-            index_dir: None,
-            index_writer_memory_bytes: 32 * 1024 * 1024,
-            mode: Default::default(),
-            sync_interval: Duration::from_secs(2).into(),
+        reindex: ReindexMode::Always,
+        bus: EventBusConfig {
+            event_bus: EventBusType::Kafka,
+            kafka_bootstrap_servers: KAFKA_BOOTSTRAP_SERVERS.into(),
+            ..Default::default()
         },
         storage: StorageConfig {
             region: None,
@@ -163,16 +163,17 @@ fn vexination_indexer() -> vexination_indexer::Run {
             access_key: Some("admin".into()),
             secret_key: Some("password".into()),
         },
-        bus: EventBusConfig {
-            event_bus: EventBusType::Kafka,
-            kafka_bootstrap_servers: KAFKA_BOOTSTRAP_SERVERS.into(),
-            ..Default::default()
-        },
         infra: InfrastructureConfig {
             infrastructure_enabled: false,
             infrastructure_bind: "127.0.0.1".into(),
             infrastructure_workers: 1,
             enable_tracing: false,
+        },
+        index: IndexConfig {
+            index_dir: None,
+            index_writer_memory_bytes: 32 * 1024 * 1024,
+            mode: Default::default(),
+            sync_interval: Duration::from_secs(2).into(),
         },
     }
 }


### PR DESCRIPTION
This requires the index to be "always" rebuilt. Otherwise, the stale data in the index increments the advisory count with each test invocation.