### PR TITLE
fix: add read:document scope to walker client

### DIFF
--- a/deploy/compose/container_files/init-sso/data/client-walker.json
+++ b/deploy/compose/container_files/init-sso/data/client-walker.json
@@ -13,7 +13,8 @@
     "profile",
     "roles",
     "web-origins",
-    "create:document"
+    "create:document",
+    "read:document"
   ],
   "optionalClientScopes": [
     "address",


### PR DESCRIPTION
This commit adds the read:document scope to the walker client.

The motivation for this change is that the walker client is used in the examples in DEVELOPING.md where it is used to create and read entries. Currently POSTing will work but trying to GET the same entry will result in an 403 forbidden error:
```console
$ curl -v -X POST --json @vexination/testdata/rhsa-2023_1441.json
   --oauth2-bearer ... http://localhost:8081/api/v1/vex
...
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 201 Created
< content-length: 37
<
* Connection #0 to host localhost left intact
VEX of size 43885 stored successfully

$ curl -v -X GET --oauth2-bearer 'http://localhost:8081/api/v1/vex?advisory=RHSA-2023:1441'
* Connected to localhost (127.0.0.1) port 8081 (#0)
* Server auth using Bearer with user ''
> GET /api/v1/vex?advisory=RHSA-2023:1441 HTTP/1.1
> ...
< HTTP/1.1 403 Forbidden
< content-length: 54
<
* Connection #0 to host localhost left intact
{"error":"Forbidden","message":"Authorization failed"}
```

I'm not sure if adding this scope is the correct thing to do or if if perhaps DEVELOPING.md should be updated not use the walker client, but I'm opening this pull request to get some feedback.