### PR TITLE
fix: remove with-services feature to avoid breaking CI

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -22,17 +22,17 @@ time = "0.3"
 trustification-event-bus = { path = "../event-bus" }
 trustification-auth = { path = "../auth", default-features = false, features = ["swagger"] }
 
-bombastic-api = { path = "../bombastic/api", optional = true }
-bombastic-indexer = { path = "../bombastic/indexer", optional = true }
+bombastic-api = { path = "../bombastic/api" }
+bombastic-indexer = { path = "../bombastic/indexer" }
 
-vexination-api = { path = "../vexination/api", optional = true }
-vexination-indexer = { path = "../vexination/indexer", optional = true }
+vexination-api = { path = "../vexination/api" }
+vexination-indexer = { path = "../vexination/indexer" }
 
-spog-api = { path = "../spog/api", optional = true }
-trustification-infrastructure = { path = "../infrastructure", optional = true }
-trustification-storage = { path = "../storage", optional = true }
-trustification-index = { path = "../index", optional = true }
-trustification-indexer = { path = "../indexer", optional = true }
+spog-api = { path = "../spog/api" }
+trustification-infrastructure = { path = "../infrastructure" }
+trustification-storage = { path = "../storage" }
+trustification-index = { path = "../index" }
+trustification-indexer = { path = "../indexer" }
 
 clap = { version = "4", features = ["derive"] }
 
@@ -43,7 +43,3 @@ urlencoding = "2.1.2"
 [dev-dependencies]
 env_logger = "0.10"
 spog-model = { path = "../spog/model" }
-
-[features]
-default = ["with-services"]
-with-services = ["bombastic-api", "bombastic-indexer", "vexination-api", "vexination-indexer", "spog-api", "trustification-storage", "trustification-index", "trustification-indexer", "trustification-infrastructure" ]

--- a/integration-tests/Containerfile
+++ b/integration-tests/Containerfile
@@ -18,7 +18,7 @@ COPY . /usr/src/project
 WORKDIR /usr/src/project
 
 ARG tag
-RUN TAG=$tag cargo test --no-run -p integration-tests --release --no-default-features
+RUN TAG=$tag cargo test --no-run -p integration-tests --release
 RUN mkdir -p test-binaries
 RUN find target/release/deps/ -type f ! -name "*.*" ! -name "integration_tests*" | xargs -I{} cp {} test-binaries/
 

--- a/integration-tests/src/bom.rs
+++ b/integration-tests/src/bom.rs
@@ -44,10 +44,6 @@ pub async fn start_bombastic(config: &Config) -> BombasticContext {
         };
     }
 
-    #[cfg(not(feature = "with-services"))]
-    panic!("Remote trustification server expected");
-
-    #[cfg(feature = "with-services")]
     {
         // No remote server requested, so fire up bombastic on ephemeral port
         let listener = TcpListener::bind("localhost:0").unwrap();
@@ -166,7 +162,6 @@ pub async fn wait_for_search_result<F: Fn(serde_json::Value) -> bool>(
 }
 
 // Configuration for the bombastic indexer
-#[cfg(feature = "with-services")]
 fn bombastic_indexer() -> bombastic_indexer::Run {
     bombastic_indexer::Run {
         stored_topic: "sbom-stored".into(),
@@ -201,7 +196,6 @@ fn bombastic_indexer() -> bombastic_indexer::Run {
     }
 }
 
-#[cfg(feature = "with-services")]
 fn bombastic_api() -> bombastic_api::Run {
     use trustification_storage::Region;
     bombastic_api::Run {

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -19,16 +19,13 @@ use tokio::select;
 use trustification_auth::{auth::AuthConfigArguments, client::TokenInjector, devmode};
 use trustification_event_bus::EventBusConfig;
 
-#[cfg(feature = "with-services")]
 use {
     spog_api::DEFAULT_CRDA_PAYLOAD_LIMIT, std::net::TcpListener, trustification_auth::swagger_ui::SwaggerUiOidcConfig,
     trustification_event_bus::EventBusType, trustification_index::IndexConfig,
     trustification_infrastructure::InfrastructureConfig, trustification_storage::StorageConfig,
 };
 
-#[cfg(feature = "with-services")]
 const STORAGE_ENDPOINT: &str = "http://localhost:9000";
-#[cfg(feature = "with-services")]
 const KAFKA_BOOTSTRAP_SERVERS: &str = "localhost:9092";
 
 pub async fn wait_for_event<F: Future>(events: &EventBusConfig, bus_name: &str, id: &str, f: F) {
@@ -89,7 +86,6 @@ pub trait Urlifier {
     }
 }
 
-#[cfg(feature = "with-services")]
 fn testing_auth() -> AuthConfigArguments {
     AuthConfigArguments {
         disabled: false,
@@ -98,7 +94,6 @@ fn testing_auth() -> AuthConfigArguments {
     }
 }
 
-#[cfg(feature = "with-services")]
 fn testing_swagger_ui_oidc() -> SwaggerUiOidcConfig {
     SwaggerUiOidcConfig {
         swagger_ui_oidc_issuer_url: Some(devmode::issuer_url()),

--- a/integration-tests/src/spog.rs
+++ b/integration-tests/src/spog.rs
@@ -45,10 +45,6 @@ pub async fn start_spog(config: &Config) -> SpogContext {
         };
     }
 
-    #[cfg(not(feature = "with-services"))]
-    panic!("Remote trustification server expected");
-
-    #[cfg(feature = "with-services")]
     {
         use trustification_infrastructure::endpoint;
         use trustification_infrastructure::endpoint::Endpoint;
@@ -115,7 +111,6 @@ pub async fn start_spog(config: &Config) -> SpogContext {
     }
 }
 
-#[cfg(feature = "with-services")]
 fn spog_api(bombastic_url: Url, vexination_url: Url, collectorist_url: Url, v11y_url: Url) -> spog_api::Run {
     use trustification_infrastructure::endpoint;
     use trustification_infrastructure::endpoint::Endpoint;

--- a/integration-tests/src/vex.rs
+++ b/integration-tests/src/vex.rs
@@ -43,10 +43,7 @@ pub async fn start_vexination(config: &Config) -> VexinationContext {
             fixtures: Vec::new(),
         };
     }
-    #[cfg(not(feature = "with-services"))]
-    panic!("Remote trustification server expected");
 
-    #[cfg(feature = "with-services")]
     {
         // No remote server requested, so fire up vexination on ephemeral port
         let listener = TcpListener::bind("localhost:0").unwrap();
@@ -143,7 +140,6 @@ impl VexinationContext {
     }
 }
 // Configuration for the vexination indexer
-#[cfg(feature = "with-services")]
 fn vexination_indexer() -> vexination_indexer::Run {
     vexination_indexer::Run {
         stored_topic: "vex-stored".into(),
@@ -178,7 +174,6 @@ fn vexination_indexer() -> vexination_indexer::Run {
     }
 }
 
-#[cfg(feature = "with-services")]
 fn vexination_api() -> vexination_api::Run {
     use trustification_storage::Region;
 


### PR DESCRIPTION
The feature flag is often forgotten and therefore breaks CI on some merges.