### PR TITLE
Acceptance test feature flags

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -43,3 +43,6 @@ urlencoding = "2.1.2"
 [dev-dependencies]
 env_logger = "0.10"
 spog-model = { path = "../spog/model" }
+
+[features]
+acceptance-tests = []

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -45,4 +45,5 @@ env_logger = "0.10"
 spog-model = { path = "../spog/model" }
 
 [features]
-acceptance-tests = []
+default = ["admin"]
+admin = []

--- a/integration-tests/Containerfile
+++ b/integration-tests/Containerfile
@@ -18,7 +18,7 @@ COPY . /usr/src/project
 WORKDIR /usr/src/project
 
 ARG tag
-RUN TAG=$tag cargo test --no-run -p integration-tests --release --features acceptance-tests
+RUN TAG=$tag cargo test --no-run -p integration-tests --release --no-default-features
 RUN mkdir -p test-binaries
 RUN find target/release/deps/ -type f ! -name "*.*" ! -name "integration_tests*" | xargs -I{} cp {} test-binaries/
 

--- a/integration-tests/Containerfile
+++ b/integration-tests/Containerfile
@@ -18,7 +18,7 @@ COPY . /usr/src/project
 WORKDIR /usr/src/project
 
 ARG tag
-RUN TAG=$tag cargo test --no-run -p integration-tests --release
+RUN TAG=$tag cargo test --no-run -p integration-tests --release --features acceptance-tests
 RUN mkdir -p test-binaries
 RUN find target/release/deps/ -type f ! -name "*.*" ! -name "integration_tests*" | xargs -I{} cp {} test-binaries/
 

--- a/integration-tests/tests/bombastic.rs
+++ b/integration-tests/tests/bombastic.rs
@@ -108,6 +108,7 @@ async fn delete_missing_sbom(context: &mut BombasticContext) {
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
 }
 
+#[cfg(not(feature = "acceptance-tests"))]
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
@@ -123,6 +124,7 @@ async fn reject_no_auth_upload(context: &mut BombasticContext) {
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
+#[cfg(not(feature = "acceptance-tests"))]
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
@@ -333,6 +335,7 @@ async fn upload_sbom_existing_with_change(context: &mut BombasticContext) {
     );
 }
 
+#[cfg(not(feature = "acceptance-tests"))]
 #[ignore = "until API can support failures so that event bus is not needed to check"]
 #[test_context(BombasticContext)]
 #[tokio::test]
@@ -358,6 +361,7 @@ async fn sbom_upload_empty_json(context: &mut BombasticContext) {
     context.delete_sbom(id).await;
 }
 
+#[cfg(not(feature = "acceptance-tests"))]
 #[ignore = "until API can support failures so that event bus is not needed to check"]
 #[test_context(BombasticContext)]
 #[tokio::test]
@@ -379,6 +383,7 @@ async fn sbom_upload_empty_file(context: &mut BombasticContext) {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
+#[cfg(not(feature = "acceptance-tests"))]
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
@@ -410,6 +415,7 @@ async fn sbom_upload_unauthorized(context: &mut BombasticContext) {
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
+#[cfg(not(feature = "acceptance-tests"))]
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]

--- a/integration-tests/tests/bombastic.rs
+++ b/integration-tests/tests/bombastic.rs
@@ -108,7 +108,7 @@ async fn delete_missing_sbom(context: &mut BombasticContext) {
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
 }
 
-#[cfg(not(feature = "acceptance-tests"))]
+#[cfg(feature = "admin")]
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
@@ -124,7 +124,7 @@ async fn reject_no_auth_upload(context: &mut BombasticContext) {
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
-#[cfg(not(feature = "acceptance-tests"))]
+#[cfg(feature = "admin")]
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
@@ -335,7 +335,7 @@ async fn upload_sbom_existing_with_change(context: &mut BombasticContext) {
     );
 }
 
-#[cfg(not(feature = "acceptance-tests"))]
+#[cfg(feature = "admin")]
 #[ignore = "until API can support failures so that event bus is not needed to check"]
 #[test_context(BombasticContext)]
 #[tokio::test]
@@ -361,7 +361,7 @@ async fn sbom_upload_empty_json(context: &mut BombasticContext) {
     context.delete_sbom(id).await;
 }
 
-#[cfg(not(feature = "acceptance-tests"))]
+#[cfg(feature = "admin")]
 #[ignore = "until API can support failures so that event bus is not needed to check"]
 #[test_context(BombasticContext)]
 #[tokio::test]
@@ -383,7 +383,7 @@ async fn sbom_upload_empty_file(context: &mut BombasticContext) {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
-#[cfg(not(feature = "acceptance-tests"))]
+#[cfg(feature = "admin")]
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]
@@ -415,7 +415,7 @@ async fn sbom_upload_unauthorized(context: &mut BombasticContext) {
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
-#[cfg(not(feature = "acceptance-tests"))]
+#[cfg(feature = "admin")]
 #[test_context(BombasticContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]

--- a/integration-tests/tests/spog.rs
+++ b/integration-tests/tests/spog.rs
@@ -158,6 +158,7 @@ async fn spog_search_correlation(context: &mut SpogContext) {
 
 /// SPoG is the entrypoint for the frontend. It exposes an dependencies API, but forwards requests
 /// to Guac. This test is here to test this.
+#[ignore = "Unstable test, issue #618"]
 #[test_context(SpogContext)]
 #[tokio::test]
 #[ntest::timeout(30_000)]

--- a/integration-tests/tests/vexination.rs
+++ b/integration-tests/tests/vexination.rs
@@ -157,7 +157,7 @@ async fn vex_invalid_encoding(vexination: &mut VexinationContext) {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
-#[cfg(not(feature = "acceptance-tests"))]
+#[cfg(feature = "admin")]
 #[ignore = "until API can support failures so that event bus is not needed to check"]
 #[test_context(VexinationContext)]
 #[tokio::test]
@@ -181,7 +181,7 @@ async fn upload_vex_empty_json(context: &mut VexinationContext) {
     context.delete_vex(id).await;
 }
 
-#[cfg(not(feature = "acceptance-tests"))]
+#[cfg(feature = "admin")]
 #[ignore = "until API can support failures so that event bus is not needed to check"]
 #[test_context(VexinationContext)]
 #[tokio::test]
@@ -208,7 +208,7 @@ async fn upload_vex_empty_file(vexination: &mut VexinationContext) {
     vexination.delete_vex(id).await;
 }
 
-#[cfg(not(feature = "acceptance-tests"))]
+#[cfg(feature = "admin")]
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]

--- a/integration-tests/tests/vexination.rs
+++ b/integration-tests/tests/vexination.rs
@@ -157,6 +157,7 @@ async fn vex_invalid_encoding(vexination: &mut VexinationContext) {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
+#[cfg(not(feature = "acceptance-tests"))]
 #[ignore = "until API can support failures so that event bus is not needed to check"]
 #[test_context(VexinationContext)]
 #[tokio::test]
@@ -180,6 +181,7 @@ async fn upload_vex_empty_json(context: &mut VexinationContext) {
     context.delete_vex(id).await;
 }
 
+#[cfg(not(feature = "acceptance-tests"))]
 #[ignore = "until API can support failures so that event bus is not needed to check"]
 #[test_context(VexinationContext)]
 #[tokio::test]
@@ -206,6 +208,7 @@ async fn upload_vex_empty_file(vexination: &mut VexinationContext) {
     vexination.delete_vex(id).await;
 }
 
+#[cfg(not(feature = "acceptance-tests"))]
 #[test_context(VexinationContext)]
 #[tokio::test]
 #[ntest::timeout(60_000)]


### PR DESCRIPTION
Acceptance tests are a subset of tests that can run successfully in a containerized environment against a production cluster

Also ignore unstable test (tracked in #618)