### PR TITLE
fix: improve handling of new type of VEX without advisory description

### DIFF
--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -525,8 +525,8 @@ impl trustification_index::Index for Index {
         options: &SearchOptions,
     ) -> Result<Self::MatchedDocument, SearchError> {
         let doc = searcher.doc(doc_address)?;
-        let id = field2str(&doc, self.fields.sbom_id)?;
-        let name = field2str(&doc, self.fields.sbom_name)?;
+        let id = field2str(&self.schema, &doc, self.fields.sbom_id)?;
+        let name = field2str(&self.schema, &doc, self.fields.sbom_name)?;
 
         let snippet_generator = SnippetGenerator::create(searcher, &query.query, self.fields.sbom.desc)?;
         let snippet = snippet_generator.snippet_from_doc(&doc).to_html();

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -842,7 +842,10 @@ mod tests {
             _options: &SearchOptions,
         ) -> Result<Self::MatchedDocument, Error> {
             let d = searcher.doc(doc)?;
-            let id = d.get_first(self.id).map(|v| v.as_text()).ok_or(Error::NotFound)?;
+            let id = d
+                .get_first(self.id)
+                .map(|v| v.as_text())
+                .ok_or(Error::FieldNotFound("id".to_string()))?;
             Ok(id.unwrap_or("").to_string())
         }
 

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -447,18 +447,18 @@ impl trustification_index::Index for Index {
         let snippet_generator = SnippetGenerator::create(searcher, &query.query, self.fields.advisory_description)?;
         let advisory_snippet = snippet_generator.snippet_from_doc(&doc).to_html();
 
-        let advisory_id = field2str(&doc, self.fields.advisory_id)?;
-        let advisory_title = field2str(&doc, self.fields.advisory_title)?;
-        let advisory_severity = field2str(&doc, self.fields.advisory_severity)?;
-        let advisory_date = field2date(&doc, self.fields.advisory_current)?;
-        let advisory_desc = field2str(&doc, self.fields.advisory_description)?;
+        let advisory_id = field2str(&self.schema, &doc, self.fields.advisory_id)?;
+        let advisory_title = field2str(&self.schema, &doc, self.fields.advisory_title)?;
+        let advisory_severity = field2str(&self.schema, &doc, self.fields.advisory_severity)?;
+        let advisory_date = field2date(&self.schema, &doc, self.fields.advisory_current)?;
+        let advisory_desc = field2str(&self.schema, &doc, self.fields.advisory_description).unwrap_or("");
 
         let cves = field2strvec(&doc, self.fields.cve_id)?
             .iter()
             .map(|s| s.to_string())
             .collect();
 
-        let cvss_max: Option<f64> = field2float(&doc, self.fields.cve_cvss_max).ok();
+        let cvss_max: Option<f64> = field2float(&self.schema, &doc, self.fields.cve_cvss_max).ok();
 
         let mut cve_severity_count: HashMap<String, u64> = HashMap::new();
         if let Some(Some(data)) = doc.get_first(self.fields.cve_severity_count).map(|d| d.as_json()) {


### PR DESCRIPTION
At present the new VEXes are not searchable because they are lacking a description.

Improve error message in log so it can be seen which field is missing