### PR TITLE
feat: enable ngram tokenizer for vexination

### DIFF
--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -13,7 +13,9 @@ use std::{
 use tantivy::{
     collector::TopDocs,
     query::{AllQuery, TermSetQuery},
+    schema::{IndexRecordOption, TextFieldIndexing},
     store::ZstdCompressor,
+    tokenizer::{NgramTokenizer, TokenizerManager},
     DocAddress, DocId, IndexSettings, Order, Score, Searcher, SegmentReader, SnippetGenerator,
 };
 use time::OffsetDateTime;
@@ -81,6 +83,12 @@ impl trustification_index::Index for Index {
     type MatchedDocument = SearchHit;
     type Document = Csaf;
     type QueryContext = VexQuery;
+
+    fn tokenizers(&self) -> Result<TokenizerManager, SearchError> {
+        let manager = TokenizerManager::default();
+        manager.register("ngram", NgramTokenizer::prefix_only(2, 64)?);
+        Ok(manager)
+    }
 
     fn settings(&self) -> IndexSettings {
         IndexSettings {
@@ -497,11 +505,20 @@ impl Index {
     pub fn new() -> Self {
         let mut schema = Schema::builder();
         let indexed_timestamp = schema.add_date_field("indexed_timestamp", STORED);
+        let text_options = TextFieldIndexing::default()
+            .set_tokenizer("ngram")
+            .set_index_option(IndexRecordOption::WithFreqsAndPositions);
 
         let advisory_id = schema.add_text_field("advisory_id", STRING | FAST | STORED);
         let advisory_status = schema.add_text_field("advisory_status", STRING);
-        let advisory_title = schema.add_text_field("advisory_title", TEXT | STORED);
-        let advisory_description = schema.add_text_field("advisory_description", TEXT | STORED);
+        let advisory_title = schema.add_text_field(
+            "advisory_title",
+            (TEXT | STORED).set_indexing_options(text_options.clone()),
+        );
+        let advisory_description = schema.add_text_field(
+            "advisory_description",
+            (TEXT | STORED).set_indexing_options(text_options.clone()),
+        );
         let advisory_revision = schema.add_text_field("advisory_revision", STRING | STORED);
         let advisory_severity = schema.add_text_field("advisory_severity", STRING | STORED);
         let advisory_initial = schema.add_date_field("advisory_initial_date", INDEXED);
@@ -509,8 +526,9 @@ impl Index {
         let advisory_severity_score = schema.add_f64_field("advisory_severity_score", FAST);
 
         let cve_id = schema.add_text_field("cve_id", STRING | FAST | STORED);
-        let cve_title = schema.add_text_field("cve_title", TEXT | STORED);
-        let cve_description = schema.add_text_field("cve_description", TEXT | STORED);
+        let cve_title = schema.add_text_field("cve_title", (TEXT | STORED).set_indexing_options(text_options.clone()));
+        let cve_description =
+            schema.add_text_field("cve_description", (TEXT | STORED).set_indexing_options(text_options));
         let cve_discovery = schema.add_date_field("cve_discovery_date", INDEXED);
         let cve_release = schema.add_date_field("cve_release_date", INDEXED | STORED);
         let cve_severity = schema.add_text_field("cve_severity", STRING | FAST);

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -15,10 +15,7 @@ use tantivy::{
     query::{AllQuery, TermSetQuery},
     schema::{IndexRecordOption, TextFieldIndexing},
     store::ZstdCompressor,
-    tokenizer::{
-        Language, LowerCaser, NgramTokenizer, RemoveLongFilter, SimpleTokenizer, Stemmer, TextAnalyzer, Tokenizer,
-        TokenizerManager,
-    },
+    tokenizer::{Language, LowerCaser, NgramTokenizer, RemoveLongFilter, Stemmer, TextAnalyzer, TokenizerManager},
     DocAddress, DocId, IndexSettings, Order, Score, Searcher, SegmentReader, SnippetGenerator,
 };
 use time::OffsetDateTime;

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -86,7 +86,7 @@ impl trustification_index::Index for Index {
 
     fn tokenizers(&self) -> Result<TokenizerManager, SearchError> {
         let manager = TokenizerManager::default();
-        let ngram = NgramTokenizer::all_ngrams(3, 40)?;
+        let ngram = NgramTokenizer::all_ngrams(3, 16)?;
         manager.register(
             "ngram",
             TextAnalyzer::builder(ngram)


### PR DESCRIPTION
* Allows each index to configure a tokenizer manager
* Enable an ngram (2, 64) tokenizer for vexination