### PR TITLE
Add related products table

### DIFF
--- a/spog/api/src/cve.rs
+++ b/spog/api/src/cve.rs
@@ -51,12 +51,12 @@ async fn cve_get(id: web::Path<String>, v11y: web::Data<V11yService>) -> actix_w
 
 // TODO remove this method using real data
 async fn cve_details_mock(
-    app_state: web::Data<AppState>,
-    guac: web::Data<GuacService>,
+    _app_state: web::Data<AppState>,
+    _guac: web::Data<GuacService>,
     id: web::Path<String>,
-    access_token: BearerAuth,
-    collectorist: web::Data<CollectoristService>,
-    v11y: web::Data<V11yService>,
+    _access_token: BearerAuth,
+    _collectorist: web::Data<CollectoristService>,
+    _v11y: web::Data<V11yService>,
 ) -> actix_web::Result<HttpResponse> {
     let mut products = BTreeMap::<ProductCveStatus, Vec<ProductRelatedToCve>>::new();
     products.insert(

--- a/spog/api/src/cve.rs
+++ b/spog/api/src/cve.rs
@@ -28,7 +28,8 @@ pub(crate) fn configure(auth: Option<Arc<Authenticator>>) -> impl FnOnce(&mut Se
             web::scope("/api/v1/cve")
                 .wrap(new_auth!(auth))
                 .service(web::resource("").to(cve_search))
-                .service(web::resource("/{id}").to(cve_get)),
+                .service(web::resource("/{id}").to(cve_get))
+                .service(web::resource("/{id}/related-products").to(cve_details_mock)),
         );
     }
 }

--- a/spog/api/src/cve.rs
+++ b/spog/api/src/cve.rs
@@ -10,10 +10,10 @@ use actix_web::{
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use bytes::BytesMut;
 use csaf::definitions::ProductIdT;
-use csaf::Csaf;
+use csaf::{Csaf, vulnerability};
 use futures::TryStreamExt;
 use spog_model::csaf::{find_product_relations, trace_product};
-use spog_model::cve::{AdvisoryOverview, CveDetails};
+use spog_model::cve::{AdvisoryOverview, CveDetails, PackageRelatedToProductCve, ProductCveStatus, ProductRelatedToCve};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 use trustification_auth::authenticator::Authenticator;
@@ -46,6 +46,118 @@ async fn cve_get(id: web::Path<String>, v11y: web::Data<V11yService>) -> actix_w
     Ok(HttpResponseBuilder::new(response.status()).streaming(response.bytes_stream()))
 }
 
+// TODO remove this method using real data
+async fn cve_details_mock(
+    app_state: web::Data<AppState>,
+    guac: web::Data<GuacService>,
+    id: web::Path<String>,
+    access_token: BearerAuth,
+    collectorist: web::Data<CollectoristService>,
+    v11y: web::Data<V11yService>,
+) -> actix_web::Result<HttpResponse> {
+    let mut products = BTreeMap::<ProductCveStatus, Vec<ProductRelatedToCve>>::new();
+    products.insert(ProductCveStatus::Fixed, vec![ProductRelatedToCve {
+        sbom_id: "3amp-2.json.bz2".to_string(),
+        packages: vec![
+            PackageRelatedToProductCve {
+                r#type: "Direct".to_string(),
+                purl: "pkg:rpm/redhat/3scale-amp-template".to_string(),
+            },
+            PackageRelatedToProductCve {
+                r#type: "Transitive".to_string(),
+                purl: "pkg:oci/redhat/3scale-rhel7-operator-metadata".to_string(),
+            },
+        ],
+    }]);
+    products.insert(ProductCveStatus::FirstFixed, vec![ProductRelatedToCve {
+        sbom_id: "amq-ic-1.json.bz2".to_string(),
+        packages: vec![
+            PackageRelatedToProductCve {
+                r#type: "Direct".to_string(),
+                purl: "pkg:npm/abab@2.0.4".to_string(),
+            },
+            PackageRelatedToProductCve {
+                r#type: "Transitive".to_string(),
+                purl: "pkg:npm/adjust-sourcemap-loader@2.0.0".to_string(),
+            },
+        ],
+    }]);
+    products.insert(ProductCveStatus::FirstAffected, vec![ProductRelatedToCve {
+        sbom_id: "ansible_automation_platform-1.2.json.bz2".to_string(),
+        packages: vec![
+            PackageRelatedToProductCve {
+                r#type: "Direct".to_string(),
+                purl: "pkg:rpm/redhat/PyYAML".to_string(),
+            },
+            PackageRelatedToProductCve {
+                r#type: "Transitive".to_string(),
+                purl: "pkg:rpm/redhat/acl".to_string(),
+            },
+        ],
+    }]);
+    products.insert(ProductCveStatus::KnownAffected, vec![ProductRelatedToCve {
+        sbom_id: "ceph-3.json.bz2".to_string(),
+        packages: vec![
+            PackageRelatedToProductCve {
+                r#type: "Direct".to_string(),
+                purl: "pkg:npm/JSV@4.0.2".to_string(),
+            },
+            PackageRelatedToProductCve {
+                r#type: "Transitive".to_string(),
+                purl: "pkg:npm/acorn-es7-plugin@1.1.7".to_string(),
+            },
+        ],
+    }]);
+    products.insert(ProductCveStatus::LastAffected, vec![ProductRelatedToCve {
+        sbom_id: "mtv-2.3.json.bz2".to_string(),
+        packages: vec![
+            PackageRelatedToProductCve {
+                r#type: "Direct".to_string(),
+                purl: "pkg:golang/github.com/petar/GoLLRB@v0.0.0-20130427215148-53be0d36a84c".to_string(),
+            },
+            PackageRelatedToProductCve {
+                r#type: "Transitive".to_string(),
+                purl: "pkg:npm/acorn-import-assertions@1.8.0".to_string(),
+            },
+        ],
+    }]);
+    products.insert(ProductCveStatus::KnownNotAffected, vec![ProductRelatedToCve {
+        sbom_id: "openjdk-1.8.json.bz2".to_string(),
+        packages: vec![
+            PackageRelatedToProductCve {
+                r#type: "Direct".to_string(),
+                purl: "git://pkgs.devel.redhat.com/rpms/java-1.8.0-openjdk".to_string(),
+            },
+        ],
+    }]);
+    products.insert(ProductCveStatus::Recommended, vec![ProductRelatedToCve {
+        sbom_id: "fuse-7.json.bz2".to_string(),
+        packages: vec![
+            PackageRelatedToProductCve {
+                r#type: "Direct".to_string(),
+                purl: "git+http://code.engineering.redhat.com/gerrit/jboss-fuse/modeshape.git#b8d75eee71a53f20b789eba8f003a9469f8bc9cd".to_string(),
+            },
+        ],
+    }]);
+    products.insert(ProductCveStatus::UnderInvestigation, vec![ProductRelatedToCve {
+        sbom_id: "fuse-7.json.bz2".to_string(),
+        packages: vec![
+            PackageRelatedToProductCve {
+                r#type: "Direct".to_string(),
+                purl: "git://pkgs.devel.redhat.com/rpms/java-1.8.0-openjdk".to_string(),
+            },
+        ],
+    }]);
+
+    let result = CveDetails {
+        id: id.to_string(),
+        details: vec![],
+        advisories: vec![],
+        products,
+    };
+    Ok(HttpResponse::Ok().json(result))
+}
+
 #[allow(unused)]
 async fn cve_details(
     app_state: web::Data<AppState>,
@@ -72,8 +184,8 @@ async fn build_cve_details<P>(
     collectorist: &CollectoristService,
     v11y: &V11yService,
 ) -> Result<CveDetails, Error>
-where
-    P: TokenProvider,
+    where
+        P: TokenProvider,
 {
     collectorist.trigger_vulnerability(&cve_id).await?;
     let details = v11y.fetch_by_alias(&cve_id).await?;
@@ -135,10 +247,11 @@ where
 
     Ok(CveDetails {
         id: cve_id,
-        products: products
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), v.into_iter().collect()))
-            .collect(),
+        // products: products
+        //     .into_iter()
+        //     .map(|(k, v)| (k.to_string(), v.into_iter().collect()))
+        //     .collect(),
+        products: BTreeMap::new(),
         advisories,
         details,
     })

--- a/spog/api/src/cve.rs
+++ b/spog/api/src/cve.rs
@@ -10,10 +10,12 @@ use actix_web::{
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use bytes::BytesMut;
 use csaf::definitions::ProductIdT;
-use csaf::{Csaf, vulnerability};
+use csaf::Csaf;
 use futures::TryStreamExt;
 use spog_model::csaf::{find_product_relations, trace_product};
-use spog_model::cve::{AdvisoryOverview, CveDetails, PackageRelatedToProductCve, ProductCveStatus, ProductRelatedToCve};
+use spog_model::cve::{
+    AdvisoryOverview, CveDetails, PackageRelatedToProductCve, ProductCveStatus, ProductRelatedToCve,
+};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 use trustification_auth::authenticator::Authenticator;
@@ -56,80 +58,96 @@ async fn cve_details_mock(
     v11y: web::Data<V11yService>,
 ) -> actix_web::Result<HttpResponse> {
     let mut products = BTreeMap::<ProductCveStatus, Vec<ProductRelatedToCve>>::new();
-    products.insert(ProductCveStatus::Fixed, vec![ProductRelatedToCve {
-        sbom_id: "3amp-2.json.bz2".to_string(),
-        packages: vec![
-            PackageRelatedToProductCve {
-                r#type: "Direct".to_string(),
-                purl: "pkg:rpm/redhat/3scale-amp-template".to_string(),
-            },
-            PackageRelatedToProductCve {
-                r#type: "Transitive".to_string(),
-                purl: "pkg:oci/redhat/3scale-rhel7-operator-metadata".to_string(),
-            },
-        ],
-    }]);
-    products.insert(ProductCveStatus::FirstFixed, vec![ProductRelatedToCve {
-        sbom_id: "amq-ic-1.json.bz2".to_string(),
-        packages: vec![
-            PackageRelatedToProductCve {
-                r#type: "Direct".to_string(),
-                purl: "pkg:npm/abab@2.0.4".to_string(),
-            },
-            PackageRelatedToProductCve {
-                r#type: "Transitive".to_string(),
-                purl: "pkg:npm/adjust-sourcemap-loader@2.0.0".to_string(),
-            },
-        ],
-    }]);
-    products.insert(ProductCveStatus::FirstAffected, vec![ProductRelatedToCve {
-        sbom_id: "ansible_automation_platform-1.2.json.bz2".to_string(),
-        packages: vec![
-            PackageRelatedToProductCve {
-                r#type: "Direct".to_string(),
-                purl: "pkg:rpm/redhat/PyYAML".to_string(),
-            },
-            PackageRelatedToProductCve {
-                r#type: "Transitive".to_string(),
-                purl: "pkg:rpm/redhat/acl".to_string(),
-            },
-        ],
-    }]);
-    products.insert(ProductCveStatus::KnownAffected, vec![ProductRelatedToCve {
-        sbom_id: "ceph-3.json.bz2".to_string(),
-        packages: vec![
-            PackageRelatedToProductCve {
-                r#type: "Direct".to_string(),
-                purl: "pkg:npm/JSV@4.0.2".to_string(),
-            },
-            PackageRelatedToProductCve {
-                r#type: "Transitive".to_string(),
-                purl: "pkg:npm/acorn-es7-plugin@1.1.7".to_string(),
-            },
-        ],
-    }]);
-    products.insert(ProductCveStatus::LastAffected, vec![ProductRelatedToCve {
-        sbom_id: "mtv-2.3.json.bz2".to_string(),
-        packages: vec![
-            PackageRelatedToProductCve {
-                r#type: "Direct".to_string(),
-                purl: "pkg:golang/github.com/petar/GoLLRB@v0.0.0-20130427215148-53be0d36a84c".to_string(),
-            },
-            PackageRelatedToProductCve {
-                r#type: "Transitive".to_string(),
-                purl: "pkg:npm/acorn-import-assertions@1.8.0".to_string(),
-            },
-        ],
-    }]);
-    products.insert(ProductCveStatus::KnownNotAffected, vec![ProductRelatedToCve {
-        sbom_id: "openjdk-1.8.json.bz2".to_string(),
-        packages: vec![
-            PackageRelatedToProductCve {
+    products.insert(
+        ProductCveStatus::Fixed,
+        vec![ProductRelatedToCve {
+            sbom_id: "3amp-2.json.bz2".to_string(),
+            packages: vec![
+                PackageRelatedToProductCve {
+                    r#type: "Direct".to_string(),
+                    purl: "pkg:rpm/redhat/3scale-amp-template".to_string(),
+                },
+                PackageRelatedToProductCve {
+                    r#type: "Transitive".to_string(),
+                    purl: "pkg:oci/redhat/3scale-rhel7-operator-metadata".to_string(),
+                },
+            ],
+        }],
+    );
+    products.insert(
+        ProductCveStatus::FirstFixed,
+        vec![ProductRelatedToCve {
+            sbom_id: "amq-ic-1.json.bz2".to_string(),
+            packages: vec![
+                PackageRelatedToProductCve {
+                    r#type: "Direct".to_string(),
+                    purl: "pkg:npm/abab@2.0.4".to_string(),
+                },
+                PackageRelatedToProductCve {
+                    r#type: "Transitive".to_string(),
+                    purl: "pkg:npm/adjust-sourcemap-loader@2.0.0".to_string(),
+                },
+            ],
+        }],
+    );
+    products.insert(
+        ProductCveStatus::FirstAffected,
+        vec![ProductRelatedToCve {
+            sbom_id: "ansible_automation_platform-1.2.json.bz2".to_string(),
+            packages: vec![
+                PackageRelatedToProductCve {
+                    r#type: "Direct".to_string(),
+                    purl: "pkg:rpm/redhat/PyYAML".to_string(),
+                },
+                PackageRelatedToProductCve {
+                    r#type: "Transitive".to_string(),
+                    purl: "pkg:rpm/redhat/acl".to_string(),
+                },
+            ],
+        }],
+    );
+    products.insert(
+        ProductCveStatus::KnownAffected,
+        vec![ProductRelatedToCve {
+            sbom_id: "ceph-3.json.bz2".to_string(),
+            packages: vec![
+                PackageRelatedToProductCve {
+                    r#type: "Direct".to_string(),
+                    purl: "pkg:npm/JSV@4.0.2".to_string(),
+                },
+                PackageRelatedToProductCve {
+                    r#type: "Transitive".to_string(),
+                    purl: "pkg:npm/acorn-es7-plugin@1.1.7".to_string(),
+                },
+            ],
+        }],
+    );
+    products.insert(
+        ProductCveStatus::LastAffected,
+        vec![ProductRelatedToCve {
+            sbom_id: "mtv-2.3.json.bz2".to_string(),
+            packages: vec![
+                PackageRelatedToProductCve {
+                    r#type: "Direct".to_string(),
+                    purl: "pkg:golang/github.com/petar/GoLLRB@v0.0.0-20130427215148-53be0d36a84c".to_string(),
+                },
+                PackageRelatedToProductCve {
+                    r#type: "Transitive".to_string(),
+                    purl: "pkg:npm/acorn-import-assertions@1.8.0".to_string(),
+                },
+            ],
+        }],
+    );
+    products.insert(
+        ProductCveStatus::KnownNotAffected,
+        vec![ProductRelatedToCve {
+            sbom_id: "openjdk-1.8.json.bz2".to_string(),
+            packages: vec![PackageRelatedToProductCve {
                 r#type: "Direct".to_string(),
                 purl: "git://pkgs.devel.redhat.com/rpms/java-1.8.0-openjdk".to_string(),
-            },
-        ],
-    }]);
+            }],
+        }],
+    );
     products.insert(ProductCveStatus::Recommended, vec![ProductRelatedToCve {
         sbom_id: "fuse-7.json.bz2".to_string(),
         packages: vec![
@@ -139,15 +157,16 @@ async fn cve_details_mock(
             },
         ],
     }]);
-    products.insert(ProductCveStatus::UnderInvestigation, vec![ProductRelatedToCve {
-        sbom_id: "fuse-7.json.bz2".to_string(),
-        packages: vec![
-            PackageRelatedToProductCve {
+    products.insert(
+        ProductCveStatus::UnderInvestigation,
+        vec![ProductRelatedToCve {
+            sbom_id: "fuse-7.json.bz2".to_string(),
+            packages: vec![PackageRelatedToProductCve {
                 r#type: "Direct".to_string(),
                 purl: "git://pkgs.devel.redhat.com/rpms/java-1.8.0-openjdk".to_string(),
-            },
-        ],
-    }]);
+            }],
+        }],
+    );
 
     let result = CveDetails {
         id: id.to_string(),
@@ -184,8 +203,8 @@ async fn build_cve_details<P>(
     collectorist: &CollectoristService,
     v11y: &V11yService,
 ) -> Result<CveDetails, Error>
-    where
-        P: TokenProvider,
+where
+    P: TokenProvider,
 {
     collectorist.trigger_vulnerability(&cve_id).await?;
     let details = v11y.fetch_by_alias(&cve_id).await?;

--- a/spog/model/src/cve.rs
+++ b/spog/model/src/cve.rs
@@ -34,7 +34,6 @@ pub struct PackageRelatedToProductCve {
     pub r#type: String,
 }
 
-
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct AdvisoryOverview {
     pub id: String,

--- a/spog/model/src/cve.rs
+++ b/spog/model/src/cve.rs
@@ -3,12 +3,37 @@ use std::collections::BTreeMap;
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CveDetails {
     pub id: String,
-    pub products: BTreeMap<String, Vec<String>>,
+    pub products: BTreeMap<ProductCveStatus, Vec<ProductRelatedToCve>>,
     pub advisories: Vec<AdvisoryOverview>,
 
     #[serde(default)]
     pub details: Vec<v11y_model::Vulnerability>,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, serde::Deserialize, serde::Serialize)]
+pub enum ProductCveStatus {
+    Fixed,
+    FirstFixed,
+    FirstAffected,
+    KnownAffected,
+    LastAffected,
+    KnownNotAffected,
+    Recommended,
+    UnderInvestigation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct ProductRelatedToCve {
+    pub sbom_id: String,
+    pub packages: Vec<PackageRelatedToProductCve>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct PackageRelatedToProductCve {
+    pub purl: String,
+    pub r#type: String,
+}
+
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct AdvisoryOverview {

--- a/spog/ui/crates/backend/src/cve.rs
+++ b/spog/ui/crates/backend/src/cve.rs
@@ -1,4 +1,5 @@
 use crate::{ApplyAccessToken, Backend, Endpoint, SearchParameters};
+use spog_model::prelude::CveDetails;
 use spog_ui_common::error::*;
 use std::rc::Rc;
 use trustification_api::search::SearchResult;
@@ -25,6 +26,25 @@ impl CveService {
         let url = self.backend.join(
             Endpoint::Api,
             &format!("/api/v1/cve/{id}", id = urlencoding::encode(id.as_ref())),
+        )?;
+
+        let response = self
+            .client
+            .get(url)
+            .latest_access_token(&self.access_token)
+            .send()
+            .await?;
+
+        Ok(response.api_error_for_status().await?.json().await?)
+    }
+
+    pub async fn get_related_products(&self, id: impl AsRef<str>) -> Result<CveDetails, ApiError> {
+        let url = self.backend.join(
+            Endpoint::Api,
+            &format!(
+                "/api/v1/cve/{id}/related-products",
+                id = urlencoding::encode(id.as_ref())
+            ),
         )?;
 
         let response = self

--- a/spog/ui/src/pages/cve/result/mod.rs
+++ b/spog/ui/src/pages/cve/result/mod.rs
@@ -124,6 +124,19 @@ pub fn result_view(props: &ResultViewProperties) -> Html {
     )
 }
 
+// Result content
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TabIndex {
+    RelatedProducts,
+    RelatedAdvisories,
+}
+
+#[derive(PartialEq, Properties)]
+pub struct ResultContentProperties {
+    details: Rc<CveDetails>,
+}
+
 fn cve_title(cve: &cve::Cve) -> Html {
     if let cve::Cve::Published(details) = cve {
         html!(<p>{ details.containers.cna.title.clone() }</p>)

--- a/spog/ui/src/pages/cve/result/mod.rs
+++ b/spog/ui/src/pages/cve/result/mod.rs
@@ -5,6 +5,7 @@ use advisories::RelatedAdvisories;
 use cve::published::Metric;
 use patternfly_yew::prelude::*;
 use products::RelatedProducts;
+use spog_model::prelude::CveDetails;
 use spog_ui_backend::{use_backend, CveService, SearchParameters, VexService};
 use spog_ui_components::cvss::Cvss3Label;
 use spog_ui_components::markdown::Markdown;
@@ -40,10 +41,17 @@ pub fn result_view(props: &ResultViewProperties) -> Html {
     };
 
     let products = {
-        let _backend = backend.clone();
-        let _access_token = access_token.clone();
+        let backend = backend.clone();
+        let access_token = access_token.clone();
         use_async_with_cloned_deps(
-            move |_id| async move { Ok::<_, String>(Rc::new(vec!["Product A".to_string(), "Product B".to_string()])) },
+            move |id| async move {
+                let service = CveService::new(backend.clone(), access_token.clone());
+                service
+                    .get_related_products(&id)
+                    .await
+                    .map(Rc::new)
+                    .map_err(|err| err.to_string())
+            },
             props.id.clone(),
         )
     };
@@ -113,7 +121,7 @@ pub fn result_view(props: &ResultViewProperties) -> Html {
             <PageSection>
                 <Tabs<TabIndex> r#box=true selected={page_state.tab} {onselect}>
                     <Tab<TabIndex> index={TabIndex::Products} title="Related Products">
-                        { async_content(&*products, |products| html!(<RelatedProducts {products} />)) }
+                        { async_content(&*products, |products| html!(<RelatedProducts cve_details={products} />)) }
                     </Tab<TabIndex>>
                     <Tab<TabIndex> index={TabIndex::Advisories} title="Related Advisories">
                         { async_content(&*advisories, |advisories| html!(<RelatedAdvisories {advisories} />)) }

--- a/spog/ui/src/pages/cve/result/mod.rs
+++ b/spog/ui/src/pages/cve/result/mod.rs
@@ -134,12 +134,6 @@ pub fn result_view(props: &ResultViewProperties) -> Html {
 
 // Result content
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum TabIndex {
-    RelatedProducts,
-    RelatedAdvisories,
-}
-
 #[derive(PartialEq, Properties)]
 pub struct ResultContentProperties {
     details: Rc<CveDetails>,

--- a/spog/ui/src/pages/cve/result/products.rs
+++ b/spog/ui/src/pages/cve/result/products.rs
@@ -1,5 +1,5 @@
 use patternfly_yew::prelude::*;
-use spog_model::prelude::{PackageRelatedToProductCve, ProductCveStatus, ProductRelatedToCve};
+use spog_model::prelude::{CveDetails, PackageRelatedToProductCve, ProductCveStatus, ProductRelatedToCve};
 use std::collections::BTreeMap;
 use std::rc::Rc;
 use yew::prelude::*;
@@ -83,12 +83,13 @@ impl TableEntryRenderer<Column> for TableData {
 
 #[derive(PartialEq, Properties)]
 pub struct RelatedProductsProperties {
-    pub products: Rc<BTreeMap<ProductCveStatus, Vec<ProductRelatedToCve>>>,
+    pub cve_details: Rc<CveDetails>,
+    // pub products: Rc<BTreeMap<ProductCveStatus, Vec<ProductRelatedToCve>>>,
 }
 
 #[function_component(RelatedProducts)]
 pub fn related_products(props: &RelatedProductsProperties) -> Html {
-    let table_data = use_memo(props.products.clone(), |map| {
+    let table_data = use_memo(props.cve_details.products.clone(), |map| {
         map.iter()
             .flat_map(|(map_key, map_value)| {
                 map_value
@@ -120,13 +121,15 @@ pub fn related_products(props: &RelatedProductsProperties) -> Html {
     let pagination = use_pagination(Some(total), || PaginationControl { page: 1, per_page: 10 });
 
     html!(
-        <PaginationWrapped pagination={pagination} total={10}>
-            <Table<Column, UseTableData<Column, MemoizedTableModel<TableData>>>
-                {header}
-                {entries}
-                // mode={TableMode::Expandable}
-                {onexpand}
-            />
-        </PaginationWrapped>
+        <div class="pf-v5-u-background-color-100">
+            <PaginationWrapped pagination={pagination} total={10}>
+                <Table<Column, UseTableData<Column, MemoizedTableModel<TableData>>>
+                    {header}
+                    {entries}
+                    // mode={TableMode::Expandable}
+                    {onexpand}
+                />
+            </PaginationWrapped>
+        </div>
     )
 }

--- a/spog/ui/src/pages/cve/result/products.rs
+++ b/spog/ui/src/pages/cve/result/products.rs
@@ -1,6 +1,5 @@
 use patternfly_yew::prelude::*;
-use spog_model::prelude::{CveDetails, PackageRelatedToProductCve, ProductCveStatus, ProductRelatedToCve};
-use std::collections::BTreeMap;
+use spog_model::prelude::{CveDetails, PackageRelatedToProductCve, ProductCveStatus};
 use std::rc::Rc;
 use yew::prelude::*;
 

--- a/spog/ui/src/pages/cve/result/products.rs
+++ b/spog/ui/src/pages/cve/result/products.rs
@@ -1,19 +1,132 @@
 use patternfly_yew::prelude::*;
+use spog_model::prelude::{PackageRelatedToProductCve, ProductCveStatus, ProductRelatedToCve};
+use std::collections::BTreeMap;
 use std::rc::Rc;
 use yew::prelude::*;
 
+use crate::pages::search::PaginationWrapped;
+
+struct TableData {
+    sbom_id: String,
+    status: ProductCveStatus,
+    packages: Vec<PackageRelatedToProductCve>,
+}
+
+trait StatusLabel {
+    fn label(&self) -> &'static str;
+    fn color(&self) -> Color;
+}
+
+impl StatusLabel for ProductCveStatus {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Fixed => "Fixed",
+            Self::FirstFixed => "First fixed",
+            Self::FirstAffected => "First Affected",
+            Self::KnownAffected => "Known affected",
+            Self::LastAffected => "Last affected",
+            Self::KnownNotAffected => "Knwon not affected",
+            Self::Recommended => "Recommended",
+            Self::UnderInvestigation => "Under investigation",
+        }
+    }
+
+    fn color(&self) -> Color {
+        match self {
+            Self::Fixed => Color::Green,
+            Self::FirstFixed => Color::Green,
+            Self::FirstAffected => Color::Red,
+            Self::KnownAffected => Color::Red,
+            Self::LastAffected => Color::Red,
+            Self::KnownNotAffected => Color::Blue,
+            Self::Recommended => Color::Orange,
+            Self::UnderInvestigation => Color::Grey,
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Column {
+    Name,
+    Version,
+    Status,
+    Dependencies,
+    Supplier,
+    ReleasedOn,
+}
+
+impl TableEntryRenderer<Column> for TableData {
+    fn render_cell(&self, context: CellContext<'_, Column>) -> Cell {
+        match context.column {
+            Column::Name => html!({
+                {
+                    &self.sbom_id
+                }
+            }),
+            Column::Version => html!(<></>),
+            Column::Status => html!(
+                <>
+                    <Label label={self.status.label().to_string()} color={self.status.color()}/>
+                </>
+            ),
+            Column::Dependencies => html!(
+                <>
+                    {&self.packages.len()}
+                </>
+            ),
+            Column::Supplier => html!(<></>),
+            Column::ReleasedOn => html!(<></>),
+        }
+        .into()
+    }
+}
+
 #[derive(PartialEq, Properties)]
 pub struct RelatedProductsProperties {
-    pub products: Rc<Vec<String>>,
+    pub products: Rc<BTreeMap<ProductCveStatus, Vec<ProductRelatedToCve>>>,
 }
 
 #[function_component(RelatedProducts)]
 pub fn related_products(props: &RelatedProductsProperties) -> Html {
+    let table_data = use_memo(props.products.clone(), |map| {
+        map.iter()
+            .flat_map(|(map_key, map_value)| {
+                map_value
+                    .iter()
+                    .map(|item| TableData {
+                        status: map_key.clone(),
+                        sbom_id: item.sbom_id.to_string(),
+                        packages: item.packages.clone(),
+                    })
+                    .collect::<Vec<TableData>>()
+            })
+            .collect::<Vec<TableData>>()
+    });
+
+    let total = table_data.len();
+    let (entries, onexpand) = use_table_data(MemoizedTableModel::new(table_data));
+
+    let header = html_nested! {
+        <TableHeader<Column>>
+            <TableColumn<Column> label="Name" index={Column::Name} />
+            <TableColumn<Column> label="Version" index={Column::Version} />
+            <TableColumn<Column> label="Status" index={Column::Status} />
+            <TableColumn<Column> label="Dependencies" index={Column::Dependencies} />
+            <TableColumn<Column> label="Supplier" index={Column::Supplier} />
+            <TableColumn<Column> label="Released on" index={Column::ReleasedOn} />
+        </TableHeader<Column>>
+    };
+
+    let pagination = use_pagination(Some(total), || PaginationControl { page: 1, per_page: 10 });
+
     html!(
-        <Content>
-            <List>
-                { for props.products.iter().map(Html::from) }
-            </List>
-        </Content>
+        <PaginationWrapped pagination={pagination} total={10}>
+            <Table<Column, UseTableData<Column, MemoizedTableModel<TableData>>>
+                {header}
+                {entries}
+                // mode={TableMode::Expandable}
+                {onexpand}
+            />
+        </PaginationWrapped>
     )
 }


### PR DESCRIPTION
The current endpoint `http://localhost:8083/api/v1/cve/{cve_id}` expects the following response body (this is mock data not real):

```
{
  "id": "CVE_1",
  "products": {
    "fixed": [],
    "first_fixed": [],
    "first_affected": [],
    "known_affected": [],
    "last_affected": [],
    "under_investigation": [
      {
        "sbom_id": "fuse-7.json.bz2",
        "packages": [
          {
            "purl": "pkg:npm/acorn-import-assertions@1.8.0",
            "type": "Direct"
          },
          {
            "purl": "pkg:golang/github.com/petar/GoLLRB@v0.0.0-20130427215148-53be0d36a84c",
            "type": "Transitive"
          }
        ]
      }
    ]
  }
}
```

- From that I saw in @ctron 's code, the decision of setting "fixed|known_affected|under_investigation" will be taken from Vexination so no need to Guac to deal with it (anyone feel free to correct my assumptions if they are wrong)
- @dejanb GUAC needs to have something like `given a CVE ID then return the *a list of objects*, each object must contain the sbom_id and a list of packages affected only by the CVE in context`. Eg.

![Screenshot from 2023-10-11 16-02-40](https://github.com/trustification/trustification/assets/2582866/2cfed7e4-4023-418e-9c4f-57ec3c52f578)

from the image above:
- The `CVE-1` affects a product (sbom) whose Id is `fuse-7.json.bz2` and the packages affected by `CVE-1` under the context of the SBOM `fuse-7.json.bz2` are:
  - pkg:npm/acorn-import-assertions@1.8.0
  - pkg:golang/github.com/petar/GoLLRB@v0.0.0-20130427215148-53be0d36a84c

- The package has a `type=Direct|Transitive`. I believe this depends on the position of the package under the tree (within the context of the SBOM)

@dejanb @mrizzi  is this something possible to do in GUAC?