### PR TITLE
Spog UI - minor changes to align it to the mockups

### DIFF
--- a/spog/ui/crates/components/src/cve/mod.rs
+++ b/spog/ui/crates/components/src/cve/mod.rs
@@ -139,7 +139,7 @@ pub fn cve_result(props: &CveResultProperties) -> Html {
         }),
         yew::props!(TableColumnProperties<Column> {
              index: Column::Related,
-             label: "Relations",
+             label: "Related products",
              width: ColumnWidth::Percent(10),
         }),
     ];

--- a/spog/ui/src/pages/cve/result/mod.rs
+++ b/spog/ui/src/pages/cve/result/mod.rs
@@ -197,8 +197,7 @@ pub fn cve_details(props: &CveDetailsViewProperties) -> Html {
                                     {
                                         if !*show_more && details.containers.cna.descriptions.iter()
                                             .map(|e| e.value.len())
-                                            .fold(0, |prev, current| prev + current)
-                                            > CVE_DESCRIPTION_MAX_LENGH
+                                            .sum::<usize>() > CVE_DESCRIPTION_MAX_LENGH
                                         {
                                             html!(
                                                 <>
@@ -244,8 +243,7 @@ pub fn cve_details(props: &CveDetailsViewProperties) -> Html {
                                     {
                                         if !*show_more && details.containers.cna.rejected_reasons.iter()
                                             .map(|e| e.value.len())
-                                            .fold(0, |prev, current| prev + current)
-                                            > CVE_DESCRIPTION_MAX_LENGH
+                                            .sum::<usize>() > CVE_DESCRIPTION_MAX_LENGH
                                         {
                                             html!(
                                                 <>

--- a/spog/ui/src/pages/cve/result/mod.rs
+++ b/spog/ui/src/pages/cve/result/mod.rs
@@ -18,6 +18,15 @@ use yew_more_hooks::hooks::use_page_state;
 use yew_more_hooks::{hooks::use_async_with_cloned_deps, prelude::UseAsyncState};
 use yew_oauth2::hook::use_latest_access_token;
 
+const CVE_DESCRIPTION_MAX_LENGH: usize = 180;
+
+fn truncate(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        None => s,
+        Some((idx, _)) => &s[..idx],
+    }
+}
+
 #[derive(PartialEq, Properties)]
 pub struct ResultViewProperties {
     /// the CVE id
@@ -170,22 +179,47 @@ pub struct CveDetailsViewProperties {
 
 #[function_component(CveDetailsView)]
 pub fn cve_details(props: &CveDetailsViewProperties) -> Html {
+    let show_more = use_state_eq(|| false);
+
+    let show_more_toggle = use_callback(show_more.clone(), |_, show_more| {
+        let current = **show_more;
+        show_more.set(!current);
+    });
+
     html!(
         <Grid gutter=true> {
-
             match &*props.details {
                 cve::Cve::Published(details) => {
                     html!(
                         <>
                             <GridItem cols={[6.lg(), 8.md(), 12.all()]}>
                                 <Content>
-                                    { for details.containers.cna.descriptions.iter().map(|desc|{
-                                        html!(
-                                            <div lang={desc.language.clone()}>
-                                                <Markdown content={Rc::new(desc.value.clone())} />
-                                            </div>
-                                        )
-                                    })}
+                                    {
+                                        if !*show_more && details.containers.cna.descriptions.iter()
+                                            .map(|e| e.value.len())
+                                            .fold(0, |prev, current| prev + current)
+                                            > CVE_DESCRIPTION_MAX_LENGH
+                                        {
+                                            html!(
+                                                <>
+                                                    {truncate(&details.containers.cna.descriptions[0].value, CVE_DESCRIPTION_MAX_LENGH)}{"..."}
+                                                    <Button variant={ButtonVariant::Link} onclick={show_more_toggle}>{ "More" }</Button>
+                                                </>
+                                            )
+                                        } else {
+                                            html!(
+                                                <>
+                                                    { for details.containers.cna.descriptions.iter().map(|desc|{
+                                                        html!(
+                                                            <div lang={desc.language.clone()}>
+                                                                <Markdown content={Rc::new(desc.value.clone())} />
+                                                            </div>
+                                                        )
+                                                    })}
+                                                </>
+                                            )
+                                        }
+                                    }
                                 </Content>
                             </GridItem>
 
@@ -207,13 +241,32 @@ pub fn cve_details(props: &CveDetailsViewProperties) -> Html {
                         <>
                             <GridItem cols={[6.lg(), 8.md(), 12.all()]}>
                                 <Content>
-                                    { for details.containers.cna.rejected_reasons.iter().map(|desc|{
-                                        html!(
-                                            <div lang={desc.language.clone()}>
-                                                <Markdown content={Rc::new(desc.value.clone())} />
-                                            </div>
-                                        )
-                                    })}
+                                    {
+                                        if !*show_more && details.containers.cna.rejected_reasons.iter()
+                                            .map(|e| e.value.len())
+                                            .fold(0, |prev, current| prev + current)
+                                            > CVE_DESCRIPTION_MAX_LENGH
+                                        {
+                                            html!(
+                                                <>
+                                                    {truncate(&details.containers.cna.rejected_reasons[0].value, CVE_DESCRIPTION_MAX_LENGH)}{"..."}
+                                                    <Button variant={ButtonVariant::Link} onclick={show_more_toggle}>{ "More" }</Button>
+                                                </>
+                                            )
+                                        } else {
+                                            html!(
+                                                <>
+                                                    { for details.containers.cna.rejected_reasons.iter().map(|desc|{
+                                                        html!(
+                                                            <div lang={desc.language.clone()}>
+                                                                <Markdown content={Rc::new(desc.value.clone())} />
+                                                            </div>
+                                                        )
+                                                    })}
+                                                </>
+                                            )
+                                        }
+                                    }
                                 </Content>
                             </GridItem>
 

--- a/spog/ui/src/pages/search.rs
+++ b/spog/ui/src/pages/search.rs
@@ -17,10 +17,10 @@ use yew_more_hooks::prelude::*;
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TabIndex {
-    #[default]
     Advisories,
     Sboms,
     SbomsByPackage,
+    #[default]
     Cves,
 }
 
@@ -230,10 +230,10 @@ pub fn search(props: &SearchProperties) -> Html {
                             selected={*tab} {onselect}
                             r#box=true
                         >
-                            <Tab<TabIndex> index={TabIndex::Advisories} title={count_tab_title("Advisories", &*advisory.state)} />
-                            <Tab<TabIndex> index={TabIndex::Sboms} title={count_tab_title("SBOMs", &*sbom.state)} />
-                            <Tab<TabIndex> index={TabIndex::SbomsByPackage} title={count_tab_title("SBOMs (by dependency)", &*sbom_by_dependency.state)} />
                             <Tab<TabIndex> index={TabIndex::Cves} title={count_tab_title("CVEs", &*cve.state)} />
+                            <Tab<TabIndex> index={TabIndex::Sboms} title={count_tab_title("Products and containers", &*sbom.state)} />
+                            <Tab<TabIndex> index={TabIndex::Advisories} title={count_tab_title("Advisories", &*advisory.state)} />
+                            // <Tab<TabIndex> index={TabIndex::SbomsByPackage} title={count_tab_title("SBOMs (by dependency)", &*sbom_by_dependency.state)} />
                         </Tabs<TabIndex>>
 
                         <div class="pf-v5-u-background-color-100">


### PR DESCRIPTION
- CVE table: rename "relations" by "Related products"
- Search view results: Move tab order to match mockups + hide "SbomsByPackage"
- CVE details page: Add "read more" link