### PR TITLE
Spog UI: Move "SbomReport" to "Sbom page"

### DIFF
--- a/spog/ui/src/pages/sbom/mod.rs
+++ b/spog/ui/src/pages/sbom/mod.rs
@@ -14,6 +14,8 @@ use yew::prelude::*;
 use yew_more_hooks::prelude::*;
 use yew_oauth2::prelude::*;
 
+use crate::pages::sbom_report::SbomReport;
+
 #[derive(Clone, Debug, PartialEq, Properties)]
 pub struct SBOMProperties {
     pub id: String,
@@ -45,7 +47,7 @@ pub fn sbom(props: &SBOMProperties) -> Html {
         ),
         UseAsyncState::Ready(Ok(Some(data))) => (
             html!(<PageHeading sticky=false subtitle="SBOM detail information">{ props.id.clone() } {" "} <Label label={data.type_name()} color={Color::Blue} /> </PageHeading>),
-            html!(<Details sbom={data.clone()}/> ),
+            html!(<Details id={props.id.clone()} sbom={data.clone()}/> ),
         ),
         UseAsyncState::Ready(Err(err)) => (
             html!(<PageHeading subtitle="SBOM detail information">{ props.id.clone() }</PageHeading>),
@@ -63,6 +65,7 @@ pub fn sbom(props: &SBOMProperties) -> Html {
 
 #[derive(Clone, PartialEq, Properties)]
 struct DetailsProps {
+    id: String,
     sbom: Rc<model::SBOM>,
 }
 
@@ -71,6 +74,7 @@ fn details(props: &DetailsProps) -> Html {
     #[derive(Copy, Clone, Eq, PartialEq)]
     enum TabIndex {
         Overview,
+        Info,
         Packages,
         Source,
     }
@@ -85,12 +89,17 @@ fn details(props: &DetailsProps) -> Html {
                     <PageSection r#type={PageSectionType::Tabs} variant={PageSectionVariant::Light} sticky={[PageSectionSticky::Top]}>
                         <Tabs<TabIndex> inset={TabInset::Page} detached=true selected={*tab} {onselect}>
                             <Tab<TabIndex> index={TabIndex::Overview} title="Overview" />
+                            <Tab<TabIndex> index={TabIndex::Info} title="Info" />
                             <Tab<TabIndex> index={TabIndex::Packages} title="Packages" />
                             <Tab<TabIndex> index={TabIndex::Source} title="Source" />
                         </Tabs<TabIndex>>
                     </PageSection>
 
                     <PageSection hidden={*tab != TabIndex::Overview} fill={PageSectionFill::Fill}>
+                        <SbomReport id={props.id.clone()} />
+                    </PageSection>
+
+                    <PageSection hidden={*tab != TabIndex::Info} fill={PageSectionFill::Fill}>
                         <Grid gutter=true>
                             <GridItem cols={[4]}>{spdx_meta(bom)}</GridItem>
                             <GridItem cols={[2]}>{spdx_creator(bom)}</GridItem>
@@ -115,11 +124,16 @@ fn details(props: &DetailsProps) -> Html {
                     <PageSection r#type={PageSectionType::Tabs} variant={PageSectionVariant::Light} sticky={[PageSectionSticky::Top]}>
                         <Tabs<TabIndex> inset={TabInset::Page} detached=true selected={*tab} {onselect}>
                             <Tab<TabIndex> index={TabIndex::Overview} title="Overview" />
+                            <Tab<TabIndex> index={TabIndex::Info} title="Info" />
                             <Tab<TabIndex> index={TabIndex::Source} title="Source" />
                         </Tabs<TabIndex>>
                     </PageSection>
 
                     <PageSection hidden={*tab != TabIndex::Overview} fill={PageSectionFill::Fill}>
+                        {"hello"}
+                    </PageSection>
+
+                    <PageSection hidden={*tab != TabIndex::Info} fill={PageSectionFill::Fill}>
                         <Grid gutter=true>
                             <GridItem cols={[2]}><Technical size={source.as_bytes().len()}/></GridItem>
                         </Grid>
@@ -137,11 +151,16 @@ fn details(props: &DetailsProps) -> Html {
                     <PageSection r#type={PageSectionType::Tabs} variant={PageSectionVariant::Light} sticky={[PageSectionSticky::Top]}>
                         <Tabs<TabIndex> inset={TabInset::Page} detached=true selected={*tab} {onselect}>
                             <Tab<TabIndex> index={TabIndex::Overview} title="Overview" />
+                            <Tab<TabIndex> index={TabIndex::Info} title="Info" />
                             <Tab<TabIndex> index={TabIndex::Source} title="Source" />
                         </Tabs<TabIndex>>
                     </PageSection>
 
                     <PageSection hidden={*tab != TabIndex::Overview} fill={PageSectionFill::Fill}>
+                        {"hello"}
+                    </PageSection>
+
+                    <PageSection hidden={*tab != TabIndex::Info} fill={PageSectionFill::Fill}>
                         <Grid gutter=true>
                             <GridItem cols={[2]}><Technical size={source.as_bytes().len()}/></GridItem>
                         </Grid>

--- a/spog/ui/src/pages/sbom_report/mod.rs
+++ b/spog/ui/src/pages/sbom_report/mod.rs
@@ -75,25 +75,31 @@ pub fn sbom(props: &SbomReportProperties) -> Html {
 
             html!(
                 <>
-                    <PageSection variant={PageSectionVariant::Light} r#type={PageSectionType::Breadcrumbs}>
-                        <Content>
-                            <Title>{ data.name.clone() }</Title>
-                        </Content>
-                    </PageSection>
-                    <PageSection variant={PageSectionVariant::Light} shadow={PageSectionShadow::Bottom}>
-                        <DescriptionList auto_fit=true>
-                            if let Some(version) = data.version.clone() {
-                                <DescriptionGroup term="Version">{ version }</DescriptionGroup>
-                            }
-                            if let Some(timestamp) = data.created {
-                                <DescriptionGroup term="Creation date"><Date {timestamp} /></DescriptionGroup>
-                            }
-                        </DescriptionList>
-                        <Donut {options} {labels} style="width: 350px;" />
-                    </PageSection>
-                    <PageSection>
-                        <Details sbom={data.clone()}/>
-                    </PageSection>
+                    // <PageSection variant={PageSectionVariant::Light} r#type={PageSectionType::Breadcrumbs}>
+                    //     <Content>
+                    //         <Title>{ data.name.clone() }</Title>
+                    //     </Content>
+                    // </PageSection>
+                    <Stack gutter=true>
+                        <StackItem>
+                            <Card>
+                                <CardBody>
+                                    <DescriptionList auto_fit=true>
+                                        if let Some(version) = data.version.clone() {
+                                            <DescriptionGroup term="Version">{ version }</DescriptionGroup>
+                                        }
+                                        if let Some(timestamp) = data.created {
+                                            <DescriptionGroup term="Creation date"><Date {timestamp} /></DescriptionGroup>
+                                        }
+                                    </DescriptionList>
+                                    <Donut {options} {labels} style="width: 350px;" />
+                                </CardBody>
+                            </Card>
+                        </StackItem>
+                        <StackItem>
+                            <Details sbom={data.clone()}/>
+                        </StackItem>
+                    </Stack>
                 </>
             )
         }

--- a/spog/ui/src/pages/sbom_report/mod.rs
+++ b/spog/ui/src/pages/sbom_report/mod.rs
@@ -60,7 +60,7 @@ pub fn sbom(props: &SbomReportProperties) -> Html {
     match &*info {
         UseAsyncState::Pending | UseAsyncState::Processing => html!(
             <>
-                <PageHeading>{ props.id.clone() }</PageHeading>
+                // <PageHeading>{ props.id.clone() }</PageHeading>
                 <PageSection fill={PageSectionFill::Fill}><Spinner/></PageSection>
             </>
         ),


### PR DESCRIPTION
- @ctron you created the "SbomReport" page which indeed follows the UX mockups. However, if we follow 100% the mockups we will trow away the other views that previously existed like "Sbom overview" + "Packages view" + "Source View"
- I don't think it is a good idea to throw away the good work done so far. So why don't we move the  "SbomReport" page you created and embedded it within the current "SbomPage" so it looks like the following image:

![Screenshot from 2023-10-19 10-59-10](https://github.com/trustification/trustification/assets/2582866/03dad9e0-ea0c-40e4-ad02-edfe7ce599f9)

This way we are compliant with UX + we don't throw away previous work. And to me it looks much better visually. We can then talk with UX to ask their blessing. What do you think?
