### PR TITLE
SpogUI: Align cards height to pretify visualization

### DIFF
--- a/spog/ui/crates/components/src/common.rs
+++ b/spog/ui/crates/components/src/common.rs
@@ -56,7 +56,7 @@ pub struct CardWrapperProperties {
 pub fn card_wrapper(props: &CardWrapperProperties) -> Html {
     let title = html!(<Title>{ props.title.clone() }</Title>);
     html!(
-        <Card plain={props.plain} {title}>
+        <Card plain={props.plain} {title} full_height=true>
             <CardBody>
                 { for props.children.iter() }
             </CardBody>

--- a/spog/ui/crates/components/src/spdx/mod.rs
+++ b/spog/ui/crates/components/src/spdx/mod.rs
@@ -23,7 +23,7 @@ pub fn spdx_creator(bom: &SPDX) -> Html {
     let title = html!(<Title>{"Creation"}</Title>);
 
     html!(
-        <Card {title}>
+        <Card {title} full_height=true>
             <CardBody>
                 <DescriptionList>
                     <DescriptionGroup term="Created">{ bom.document_creation_information.creation_info.created.to_string() }</DescriptionGroup>
@@ -63,7 +63,7 @@ pub fn spdx_meta(bom: &SPDX) -> Html {
     let title = html!(<Title>{"Metadata"}</Title>);
 
     html!(
-        <Card {title}>
+        <Card {title} full_height=true>
             <CardBody>
                 <DescriptionList>
                     <DescriptionGroup term="Name">{ bom.document_creation_information.document_name.clone() }</DescriptionGroup>
@@ -119,7 +119,7 @@ pub fn spdx_main(bom: &SPDX) -> Html {
             };
 
             html!(
-                <Card {title}>
+                <Card {title} full_height=true>
                     {
                         for content.into_iter()
                             .map(|content|html_nested!(<CardBody>{content}</CardBody>))
@@ -133,7 +133,7 @@ pub fn spdx_main(bom: &SPDX) -> Html {
 pub fn spdx_stats(size: usize, bom: &SPDX) -> Html {
     let title = html!(<Title>{"Statistics"}</Title>);
     html!(
-        <Card {title}>
+        <Card {title} full_height=true>
             <CardBody>
                 <DescriptionList>
                     <DescriptionGroup term="Size">{ format_size(size, BINARY) }</DescriptionGroup>

--- a/spog/ui/src/pages/sbom/mod.rs
+++ b/spog/ui/src/pages/sbom/mod.rs
@@ -111,7 +111,7 @@ fn details(props: &DetailsProps) -> Html {
                             <StackItem>
                                 <Grid gutter=true>
                                     <GridItem cols={[12]}>{spdx_main(bom)}</GridItem>
-                                </Grid>                                
+                                </Grid>
                             </StackItem>
                         </Stack>
                     </PageSection>

--- a/spog/ui/src/pages/sbom/mod.rs
+++ b/spog/ui/src/pages/sbom/mod.rs
@@ -100,12 +100,20 @@ fn details(props: &DetailsProps) -> Html {
                     </PageSection>
 
                     <PageSection hidden={*tab != TabIndex::Info} fill={PageSectionFill::Fill}>
-                        <Grid gutter=true>
-                            <GridItem cols={[4]}>{spdx_meta(bom)}</GridItem>
-                            <GridItem cols={[2]}>{spdx_creator(bom)}</GridItem>
-                            <GridItem cols={[2]}>{spdx_stats(source.as_bytes().len(), bom)}</GridItem>
-                            <GridItem cols={[4]}>{spdx_main(bom)}</GridItem>
-                        </Grid>
+                        <Stack gutter=true>
+                            <StackItem>
+                                <Grid gutter=true>
+                                    <GridItem cols={[6]}>{spdx_meta(bom)}</GridItem>
+                                    <GridItem cols={[3]}>{spdx_creator(bom)}</GridItem>
+                                    <GridItem cols={[3]}>{spdx_stats(source.as_bytes().len(), bom)}</GridItem>
+                                </Grid>
+                            </StackItem>
+                            <StackItem>
+                                <Grid gutter=true>
+                                    <GridItem cols={[12]}>{spdx_main(bom)}</GridItem>
+                                </Grid>                                
+                            </StackItem>
+                        </Stack>
                     </PageSection>
 
                     <PageSection hidden={*tab != TabIndex::Packages} fill={PageSectionFill::Fill}>


### PR DESCRIPTION
- Align card's height to make ui prettier
- SBOM "info" cards: order reorganized to allow card's full height

The following image is how it looks the current `main` branch, after this PR all cards' height should be the same.

![Screenshot from 2023-10-19 11-43-20](https://github.com/trustification/trustification/assets/2582866/9206787d-0725-4f97-b2b3-51204e894197)
