### PR TITLE
Product by CVE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "guac"
 version = "0.1.0"
-source = "git+https://github.com/trustification/guac-rs.git?branch=spog-api#d6fd307ca01df1b93410df0806ab0bb6276b5ea9"
+source = "git+https://github.com/trustification/guac-rs.git?rev=8450aecafdd65e9b5121fb29ca2af363808308ac#8450aecafdd65e9b5121fb29ca2af363808308ac"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "guac"
 version = "0.1.0"
-source = "git+https://github.com/trustification/guac-rs.git?rev=a5fad28fe4d59de7165b33d89f6d58aa7b553f05#a5fad28fe4d59de7165b33d89f6d58aa7b553f05"
+source = "git+https://github.com/trustification/guac-rs.git?branch=spog-api#0b356903f98db4f33573f71ef601f2977b260ddc"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "guac"
 version = "0.1.0"
-source = "git+https://github.com/trustification/guac-rs.git?branch=spog-api#0b356903f98db4f33573f71ef601f2977b260ddc"
+source = "git+https://github.com/trustification/guac-rs.git?branch=spog-api#d6fd307ca01df1b93410df0806ab0bb6276b5ea9"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ default-members = [
 ]
 
 [workspace.dependencies]
-guac = { git = "https://github.com/trustification/guac-rs.git", rev = "a5fad28fe4d59de7165b33d89f6d58aa7b553f05" }
+guac = { git = "https://github.com/trustification/guac-rs.git", branch="spog-api" }
 #guac = { path = "../guac-rs/lib" }
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ default-members = [
 ]
 
 [workspace.dependencies]
-guac = { git = "https://github.com/trustification/guac-rs.git", branch="spog-api" }
+guac = { git = "https://github.com/trustification/guac-rs.git", rev="8450aecafdd65e9b5121fb29ca2af363808308ac" }
 #guac = { path = "../guac-rs/lib" }
 
 [patch.crates-io]

--- a/spog/api/src/cve.rs
+++ b/spog/api/src/cve.rs
@@ -86,7 +86,6 @@ async fn cve_get(id: web::Path<String>, v11y: web::Data<V11yService>) -> actix_w
     Ok(HttpResponseBuilder::new(response.status()).streaming(response.bytes_stream()))
 }
 
-
 async fn cve_related_product(
     _app_state: web::Data<AppState>,
     guac: web::Data<GuacService>,

--- a/spog/api/src/cve.rs
+++ b/spog/api/src/cve.rs
@@ -101,6 +101,7 @@ async fn cve_related_product(
     Ok(HttpResponse::Ok().json(result))
 }
 // TODO remove this method using real data
+#[allow(dead_code)]
 async fn cve_details_mock(
     _app_state: web::Data<AppState>,
     _guac: web::Data<GuacService>,

--- a/spog/api/src/guac/service.rs
+++ b/spog/api/src/guac/service.rs
@@ -1,6 +1,8 @@
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use actix_web::{http::header::ContentType, HttpResponse};
+use guac::client::intrinsic::certify_vex::VexStatus;
 use guac::client::intrinsic::certify_vuln::{CertifyVuln, CertifyVulnSpec};
 use guac::client::intrinsic::vulnerability::{Vulnerability, VulnerabilitySpec};
 use guac::client::{Error as GuacError, GuacClient};
@@ -8,7 +10,7 @@ use http::StatusCode;
 use packageurl::PackageUrl;
 use tracing::instrument;
 
-use spog_model::prelude::{PackageDependencies, PackageDependents, PackageRefList};
+use spog_model::prelude::{PackageDependencies, PackageDependents, PackageRefList, ProductCveStatus, ProductRelatedToCve, PackageRelatedToProductCve, CveDetails};
 use trustification_common::error::ErrorInformation;
 
 #[derive(Clone)]
@@ -131,4 +133,76 @@ impl GuacService {
             })
             .await?)
     }
+
+    pub async fn product_by_cve(&self, id: String) -> Result<CveDetails, Error> {
+        let result = self.client.intrinsic().product_by_cve(&id).await;
+        let data = match result {
+            Ok(res) => {
+                res
+            },
+            Err(_err) => {
+                // TODO filter error
+                Vec::new()
+            }
+        };
+        let mut products = BTreeMap::<ProductCveStatus, Vec<ProductRelatedToCve>>::new();
+
+        for product in data {
+            let id = product.root.try_as_purls()?[0].name().to_string();
+
+            let mut packages: Vec<PackageRelatedToProductCve> = Vec::new();
+
+            for package in product.path {
+                let p = package.try_as_purls()?[0].to_string();
+                packages.push(PackageRelatedToProductCve { purl: p, r#type: "Direct".to_string() })
+            }
+
+            let pr = ProductRelatedToCve {
+                sbom_id: id,
+                packages,
+            };
+
+            let status = match product.vex.status {
+                VexStatus::Affected => {
+                    ProductCveStatus::KnownAffected
+                },
+                VexStatus::Fixed => {
+                    ProductCveStatus::Fixed
+                },
+                VexStatus::UnderInvestigation => {
+                    ProductCveStatus::UnderInvestigation
+                },
+                VexStatus::NotAffected => {
+                    ProductCveStatus::KnownNotAffected
+                }
+            };
+
+            products.entry(status).or_insert(vec![]).push(pr);
+        }
+
+        Ok(CveDetails {
+            id,
+            products,
+            details: vec![],
+            advisories: vec![],
+        })
+    }
+
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // TODO do proper testing
+    // ./bin/guacone collect files --gql-addr http://localhost:8085/query ./rhel-7.9.z.json
+    // ./bin/guacone collect files --gql-addr http://localhost:8085/query ./cve-2022-2284.json
+    #[tokio::test]
+    #[ignore]
+    async fn test_product_by_cve() {
+        let guac = GuacService::new("http://localhost:8085/query");
+        let res = guac.product_by_cve("cve-2022-2284".to_string()).await.unwrap();
+        println!("{}", serde_json::to_string_pretty(&res).unwrap());
+    }
+
 }


### PR DESCRIPTION
Here's the draft PR for a replacing mock data with data from Guac.

It needs more testing, but for `rhel-7.9.z.json` sbom and `cve-2022-2284.json` vex it should return something like

```
{
  "id": "cve-2022-2284",
  "products": {
    "KnownAffected": [
      {
        "sbom_id": "rhel-7.9.z",
        "packages": [
          {
            "purl": "pkg:rpm/vim@7.4.629-8.el7_9?arch=src&epoch=2",
            "type": "Direct"
          }
        ]
      }
    ]
  },
  "advisories": [],
  "details": []
}
```

We should start testing it further and see what's still need to fixed for this.

To reproduce:

* Start trustification with with bombastic-api validator turned off (remove `--validator sbom`)
* Obtain the token
```
TOKEN=$(curl -s -d "client_id=walker" -d "client_secret=ZVzq9AMOVUdMY1lSohpx1jI3aW56QDPS" -d 'grant_type=client_credentials' \
  'http://localhost:8090/realms/chicken/protocol/openid-connect/token' | jq -r .access_token)
```
* Ingest SBOM
```
curl -v -H "transfer-encoding: chunked" -H "content-encoding: bzip2" --json @rhel-7.9.z.json.bz2 --oauth2-bearer $TOKEN  "http://localhost:8082/api/v1/sbom?id=rhel-7.9.z.json.bz2"
```
* Ingest VEX
```
curl -v -X POST --oauth2-bearer $TOKEN --json @cve-2022-2284.json http://localhost:8081/api/v1/vex
```
* Make a query
```
curl -v -X GET --oauth2-bearer $TOKEN "http://localhost:8083/api/v1/cve/cve-2022-2284/related-products" | jq
```


