### PR TITLE
feat: featurize integs that require guac

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -72,8 +72,8 @@ jobs:
 
       - name: Test
         run: |
-          #RUST_LOG=tantivy=off,info cargo xtask test --ui --webdriver none --nocapture
-          RUST_LOG=tantivy=off,info cargo xtask test --nocapture
+          #RUST_LOG=tantivy=off,info cargo xtask test --guac --ui --webdriver none --nocapture
+          RUST_LOG=tantivy=off,info cargo xtask test --guac --nocapture
           docker-compose ${files} ps
 
       - name: Print logs

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -55,3 +55,5 @@ default = ["admin"]
 admin = []
 # UI tests
 ui = []
+# guac tests
+guac = []

--- a/integration-tests/tests/spog.rs
+++ b/integration-tests/tests/spog.rs
@@ -180,7 +180,7 @@ async fn spog_search_correlation(context: &mut SpogContext) {
 
 /// SPoG is the entrypoint for the frontend. It exposes an dependencies API, but forwards requests
 /// to Guac. This test is here to test this.
-#[ignore = "Unstable test, issue #618"]
+#[cfg_attr(not(feature = "guac"), ignore = "guac tests are not enabled")]
 #[test_context(SpogContext)]
 #[tokio::test]
 #[ntest::timeout(30_000)]

--- a/xtask/src/task/test.rs
+++ b/xtask/src/task/test.rs
@@ -24,6 +24,10 @@ pub struct Test {
     #[arg(long, env)]
     ui: bool,
 
+    /// Enable guac tests
+    #[arg(long, env)]
+    guac: bool,
+
     /// Port of the (chrome/gecko)driver
     #[arg(long, env, default_value_t = 4444)]
     webdriver_port: u16,
@@ -61,6 +65,10 @@ impl Test {
 
         let port = self.webdriver_port;
         let mut features = vec![];
+
+        if self.guac {
+            features.extend(["--features", "guac"]);
+        }
 
         // don't drop this until we're done with it
         let _webdriver = Shutdown(match self.ui {


### PR DESCRIPTION
Fixes #618

I'm not sure why the test is unstable exactly, but I'm guessing it might be because guac isn't running? So we'll hide the guac-dependent integs behind a feature in the hope that whoever is intentionally running them, e.g. CI, has also run guac.