### PR TITLE
Spog UI: Related products - fetch sbom index info for each related product

### DIFF
--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -767,6 +767,7 @@ checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -788,6 +789,17 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -2689,6 +2701,7 @@ dependencies = [
  "cvss",
  "cyclonedx-bom",
  "exhort-model",
+ "futures",
  "gloo-events 0.2.0",
  "gloo-net 0.4.0",
  "gloo-storage 0.3.0",

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -66,6 +66,7 @@ spog-ui-components = { path = "crates/components" }
 spog-ui-common = { path = "crates/common" }
 spog-ui-utils = { path = "crates/utils" }
 spog-ui-donut = { path = "crates/donut" }
+futures = "0.3.28"
 
 [build-dependencies]
 trustification-version = { path = "../../version", features = ["build"] }

--- a/spog/ui/crates/backend/src/pkg.rs
+++ b/spog/ui/crates/backend/src/pkg.rs
@@ -102,6 +102,19 @@ impl PackageService {
         Ok(response.error_for_status()?.json().await?)
     }
 
+    pub async fn get_package(&self, id: &str) -> Result<SearchResult<Vec<PackageSummary>>, Error> {
+        let q = format!("id:{id}");
+        let response = self
+            .client
+            .get(self.backend.join(Endpoint::Api, "/api/v1/package/search")?)
+            .query(&[("q", q)])
+            .latest_access_token(&self.access_token)
+            .send()
+            .await?;
+
+        Ok(response.error_for_status()?.json().await?)
+    }
+
     /// common call of getting some refs for a batch of purls
     async fn batch_to_refs<'a, I, R>(&self, path: &str, purls: I) -> Result<R, Error>
     where

--- a/spog/ui/src/pages/cve/result/products.rs
+++ b/spog/ui/src/pages/cve/result/products.rs
@@ -223,7 +223,6 @@ pub fn related_products(props: &RelatedProductsProperties) -> Html {
 #[derive(PartialEq, Properties)]
 pub struct RelatedProductsTableProperties {
     pub table_data: Rc<Vec<TableData>>,
-    // pub sboms: Rc<Vec<SearchResult<Vec<PackageSummary>>>>,
     pub sboms: Rc<Vec<Option<PackageSummary>>>,
 }
 
@@ -237,12 +236,6 @@ pub fn related_products_table(props: &RelatedProductsTableProperties) -> Html {
                 .enumerate()
                 .map(|(index, item)| {
                     let sbom_by_index = &sboms[index];
-                    // let sbom = if sbom_by_index.result.len() == 1 {
-                    //     let i = &sbom_by_index.result[0];
-                    //     Some(i.clone())
-                    // } else {
-                    //     None
-                    // };
 
                     TableData {
                         status: item.status.clone(),

--- a/spog/ui/src/pages/cve/result/products.rs
+++ b/spog/ui/src/pages/cve/result/products.rs
@@ -1,16 +1,27 @@
+use futures::future::try_join_all;
 use patternfly_yew::prelude::*;
-use spog_model::prelude::{CveDetails, PackageRelatedToProductCve, ProductCveStatus};
+use spog_model::{
+    prelude::{CveDetails, PackageRelatedToProductCve, ProductCveStatus},
+    search::PackageSummary,
+};
+use spog_ui_backend::{use_backend, PackageService};
+use spog_ui_common::utils::time::date;
+use spog_ui_components::async_state_renderer::async_content;
 use spog_ui_navigation::{AppRoute, View};
 use std::rc::Rc;
 use yew::prelude::*;
+use yew_more_hooks::prelude::use_async_with_cloned_deps;
 use yew_nested_router::components::Link;
+use yew_oauth2::prelude::use_latest_access_token;
 
 use crate::pages::{cve::result::packages::PackagesTable, search::PaginationWrapped};
 
-struct TableData {
+#[derive(PartialEq)]
+pub struct TableData {
     sbom_id: String,
     status: ProductCveStatus,
     packages: Vec<PackageRelatedToProductCve>,
+    sbom: Option<PackageSummary>,
 }
 
 trait StatusLabel {
@@ -53,7 +64,7 @@ pub enum Column {
     Status,
     Dependencies,
     Supplier,
-    ReleasedOn,
+    Created,
 }
 
 impl TableEntryRenderer<Column> for TableData {
@@ -66,7 +77,20 @@ impl TableEntryRenderer<Column> for TableData {
                     { self.sbom_id.clone() }
                 </Link<AppRoute>>
             ),
-            Column::Version => html!(<></>),
+            Column::Version => html!(
+                <>
+                    {
+                        match &self.sbom {
+                            Some(val) => html!(
+                                <>
+                                    {&val.version}
+                                </>
+                            ),
+                            None => html!(<></>),
+                        }
+                    }
+                </>
+            ),
             Column::Status => html!(
                 <>
                     <Label label={self.status.label().to_string()} color={self.status.color()}/>
@@ -77,8 +101,30 @@ impl TableEntryRenderer<Column> for TableData {
                     {&self.packages.len()}
                 </>
             ),
-            Column::Supplier => html!(<></>),
-            Column::ReleasedOn => html!(<></>),
+            Column::Supplier => html!(
+                <>
+                    {
+                        match &self.sbom {
+                            Some(val) => html!(
+                                <>
+                                    {&val.supplier}
+                                </>
+                            ),
+                            None => html!(<></>),
+                        }
+                    }
+                </>
+            ),
+            Column::Created => html!(
+                <>
+                    {
+                        match &self.sbom {
+                            Some(val) => date(val.created).into(),
+                            None => html!(<></>),
+                        }
+                    }
+                </>
+            ),
         }
         .into()
     }
@@ -90,7 +136,7 @@ impl TableEntryRenderer<Column> for TableData {
             Column::Status => html!({ "Status" }),
             Column::Dependencies => html!(<PackagesTable packages={self.packages.clone()} />),
             Column::Supplier => html!({ "Supplier" }),
-            Column::ReleasedOn => html!({ "ReleasedOn" }),
+            Column::Created => html!({ "Created" }),
         })]
     }
 }
@@ -98,11 +144,13 @@ impl TableEntryRenderer<Column> for TableData {
 #[derive(PartialEq, Properties)]
 pub struct RelatedProductsProperties {
     pub cve_details: Rc<CveDetails>,
-    // pub products: Rc<BTreeMap<ProductCveStatus, Vec<ProductRelatedToCve>>>,
 }
 
 #[function_component(RelatedProducts)]
 pub fn related_products(props: &RelatedProductsProperties) -> Html {
+    let backend = use_backend();
+    let access_token = use_latest_access_token();
+
     let table_data = use_memo(props.cve_details.products.clone(), |map| {
         map.iter()
             .flat_map(|(map_key, map_value)| {
@@ -112,27 +160,40 @@ pub fn related_products(props: &RelatedProductsProperties) -> Html {
                         status: map_key.clone(),
                         sbom_id: item.sbom_id.to_string(),
                         packages: item.packages.clone(),
+                        sbom: None,
                     })
                     .collect::<Vec<TableData>>()
             })
-            .collect::<Vec<TableData>>()
+            .collect::<Vec<_>>()
     });
 
-    let total = table_data.len();
-    let (entries, onexpand) = use_table_data(MemoizedTableModel::new(table_data));
-
-    let header = html_nested! {
-        <TableHeader<Column>>
-            <TableColumn<Column> label="Name" index={Column::Name} />
-            <TableColumn<Column> label="Version" index={Column::Version} />
-            <TableColumn<Column> label="Status" index={Column::Status} />
-            <TableColumn<Column> label="Dependencies" index={Column::Dependencies} expandable=true />
-            <TableColumn<Column> label="Supplier" index={Column::Supplier} />
-            <TableColumn<Column> label="Released on" index={Column::ReleasedOn} />
-        </TableHeader<Column>>
+    let sboms = {
+        let backend = backend.clone();
+        let access_token = access_token.clone();
+        use_async_with_cloned_deps(
+            move |rows| async move {
+                let service = PackageService::new(backend.clone(), access_token.clone());
+                let futures = rows.iter().map(|row| service.get_package(&row.sbom_id));
+                try_join_all(futures)
+                    .await
+                    .map(|vec| {
+                        vec.iter()
+                            .map(|search_result| {
+                                if search_result.result.len() == 1 {
+                                    let sbom = &search_result.result[0];
+                                    Some(sbom.clone())
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .map(Rc::new)
+                    .map_err(|err| err.to_string())
+            },
+            table_data.clone(),
+        )
     };
-
-    let pagination = use_pagination(Some(total), || PaginationControl { page: 1, per_page: 10 });
 
     match props.cve_details.products.is_empty() {
         true => html!(
@@ -150,16 +211,76 @@ pub fn related_products(props: &RelatedProductsProperties) -> Html {
             </Panel>
         ),
         false => html!(
-            <div class="pf-v5-u-background-color-100">
-                <PaginationWrapped pagination={pagination} total={10}>
-                    <Table<Column, UseTableData<Column, MemoizedTableModel<TableData>>>
-                        mode={TableMode::Expandable}
-                        {header}
-                        {entries}
-                        {onexpand}
-                    />
-                </PaginationWrapped>
-            </div>
+            <>
+                { async_content(&*sboms, |sboms| html!(<RelatedProductsTable {sboms} {table_data} />)) }
+            </>
         ),
     }
+}
+
+///
+
+#[derive(PartialEq, Properties)]
+pub struct RelatedProductsTableProperties {
+    pub table_data: Rc<Vec<TableData>>,
+    // pub sboms: Rc<Vec<SearchResult<Vec<PackageSummary>>>>,
+    pub sboms: Rc<Vec<Option<PackageSummary>>>,
+}
+
+#[function_component(RelatedProductsTable)]
+pub fn related_products_table(props: &RelatedProductsTableProperties) -> Html {
+    let table_data = use_memo(
+        (props.table_data.clone(), props.sboms.clone()),
+        |(table_data, sboms)| {
+            table_data
+                .iter()
+                .enumerate()
+                .map(|(index, item)| {
+                    let sbom_by_index = &sboms[index];
+                    // let sbom = if sbom_by_index.result.len() == 1 {
+                    //     let i = &sbom_by_index.result[0];
+                    //     Some(i.clone())
+                    // } else {
+                    //     None
+                    // };
+
+                    TableData {
+                        status: item.status.clone(),
+                        sbom_id: item.sbom_id.clone(),
+                        packages: item.packages.clone(),
+                        sbom: sbom_by_index.clone(),
+                    }
+                })
+                .collect::<Vec<_>>()
+        },
+    );
+
+    let total = table_data.len();
+    let (entries, onexpand) = use_table_data(MemoizedTableModel::new(table_data));
+
+    let header = html_nested! {
+        <TableHeader<Column>>
+            <TableColumn<Column> label="Name" index={Column::Name} />
+            <TableColumn<Column> label="Version" index={Column::Version} />
+            <TableColumn<Column> label="Status" index={Column::Status} />
+            <TableColumn<Column> label="Dependencies" index={Column::Dependencies} expandable=true />
+            <TableColumn<Column> label="Supplier" index={Column::Supplier} />
+            <TableColumn<Column> label="Created on" index={Column::Created} />
+        </TableHeader<Column>>
+    };
+
+    let pagination = use_pagination(Some(total), || PaginationControl { page: 1, per_page: 10 });
+
+    html!(
+        <div class="pf-v5-u-background-color-100">
+            <PaginationWrapped pagination={pagination} total={10}>
+                <Table<Column, UseTableData<Column, MemoizedTableModel<TableData>>>
+                    mode={TableMode::Expandable}
+                    {header}
+                    {entries}
+                    {onexpand}
+                />
+            </PaginationWrapped>
+        </div>
+    )
 }


### PR DESCRIPTION
In the related-products table we need to render `Version`, `Supplier`, and `Created on` columns which come from the SBOM index. This PR allows to fetch the SBOM index info for each row and render the corresponding data

![Screenshot from 2023-10-24 09-38-15](https://github.com/trustification/trustification/assets/2582866/823bb8ef-4ff0-496a-bf72-63a2c663b165)
