### PR TITLE
refactor(spog): replace custom logic with `find_vulnerability`

### DIFF
--- a/spog/api/src/guac/service.rs
+++ b/spog/api/src/guac/service.rs
@@ -188,7 +188,7 @@ impl GuacService {
     /// Later on, this will be replaced with the SPDX namespace, or the CycloneDX serial.
     ///
     /// The result is `map<cve, set<purls>>`.
-    #[instrument(skip(self), err)]
+    #[instrument(skip(self), ret, err)]
     pub async fn find_vulnerability(
         &self,
         id: GuacSbomIdentifier<'_>,

--- a/spog/api/src/server.rs
+++ b/spog/api/src/server.rs
@@ -1,7 +1,7 @@
-use crate::app_state::AppState;
 use crate::{
     advisory,
     analyze::{self, CrdaClient},
+    app_state::AppState,
     config, cve, endpoints,
     guac::service::GuacService,
     index, package, sbom,

--- a/spog/api/src/utils/spdx.rs
+++ b/spog/api/src/utils/spdx.rs
@@ -3,6 +3,7 @@ use spdx_rs::models::SPDX;
 /// find all PURLs in the package information
 ///
 /// This walks through all package information entries, returning a tuple of (purl, id).
+#[allow(unused)]
 pub fn find_purls(spdx: &SPDX) -> impl Iterator<Item = (&str, &str)> {
     spdx.package_information.iter().flat_map(|pi| {
         pi.external_reference


### PR DESCRIPTION
This PR changes the custom logic of extracting all PURLs and fetching information from GUAC one by one with the `find_vulnerabilities` method from guac-rs.