### PR TITLE
task: Rename /package-info by /package

### DIFF
--- a/spog/api/src/package.rs
+++ b/spog/api/src/package.rs
@@ -13,7 +13,7 @@ use trustification_infrastructure::new_auth;
 pub(crate) fn configure(auth: Option<Arc<Authenticator>>) -> impl FnOnce(&mut ServiceConfig) {
     |config: &mut ServiceConfig| {
         config.service(
-            web::scope("/api/v1/package_info")
+            web::scope("/api/v1/package")
                 .wrap(new_auth!(auth))
                 .service(web::resource("/search").to(packages_search_mock))
                 .service(web::resource("/{id}").to(package_get_mock))
@@ -24,7 +24,7 @@ pub(crate) fn configure(auth: Option<Arc<Authenticator>>) -> impl FnOnce(&mut Se
 
 #[utoipa::path(
     get,
-    path = "/api/v1/package_info/search",
+    path = "/api/v1/package/search",
     responses(
         (status = 200, description = "packages was found"),
         (status = NOT_FOUND, description = "packages was not found")

--- a/spog/ui/crates/backend/src/package_info.rs
+++ b/spog/ui/crates/backend/src/package_info.rs
@@ -25,7 +25,7 @@ impl PackageInfoService {
     pub async fn get(&self, id: impl AsRef<str>) -> Result<PackageInfoSummary, ApiError> {
         let url = self.backend.join(
             Endpoint::Api,
-            &format!("/api/v1/package_info/{id}", id = urlencoding::encode(id.as_ref())),
+            &format!("/api/v1/package/{id}", id = urlencoding::encode(id.as_ref())),
         )?;
 
         let response = self
@@ -42,7 +42,7 @@ impl PackageInfoService {
         let url = self.backend.join(
             Endpoint::Api,
             &format!(
-                "/api/v1/package_info/{id}/related-products",
+                "/api/v1/package/{id}/related-products",
                 id = urlencoding::encode(id.as_ref())
             ),
         )?;
@@ -64,7 +64,7 @@ impl PackageInfoService {
     ) -> Result<SearchResult<Vec<PackageInfoSummary>>, Error> {
         let response = self
             .client
-            .get(self.backend.join(Endpoint::Api, "/api/v1/package_info/search")?)
+            .get(self.backend.join(Endpoint::Api, "/api/v1/package/search")?)
             .query(&[("q", q)])
             .apply(options)
             .latest_access_token(&self.access_token)


### PR DESCRIPTION
https://github.com/trustification/trustification/pull/754 introduced `/api/v1/package_info` due to the fact that previously, we had the path `/api/v1/package` taken by other endpoints

- https://github.com/trustification/trustification/pull/776 renamed `/api/v1/package` by `/api/v1/sbom`
- This PR renames `/api/v1/package_info` by `/api/v1/package`