### PR TITLE
feat: support multiple index stores in indexer

### DIFF
--- a/bombastic/indexer/src/lib.rs
+++ b/bombastic/indexer/src/lib.rs
@@ -1,10 +1,11 @@
 use std::process::ExitCode;
 
+use bombastic_model::prelude::SBOM;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use tokio::task::block_in_place;
 use trustification_event_bus::EventBusConfig;
-use trustification_index::{IndexConfig, IndexStore};
+use trustification_index::{IndexConfig, IndexStore, WriteIndex};
 use trustification_indexer::{actix::configure, Indexer, IndexerStatus, ReindexMode};
 use trustification_infrastructure::{Infrastructure, InfrastructureConfig};
 use trustification_storage::{Storage, StorageConfig};
@@ -52,13 +53,10 @@ impl Run {
                 "bombastic-indexer",
                 |_context| async { Ok(()) },
                 |context| async move {
+                    let sbom_index: Box<dyn WriteIndex<Document = (SBOM, String)>> =
+                        Box::new(bombastic_index::Index::new());
                     let index = block_in_place(|| {
-                        IndexStore::new(
-                            &self.storage,
-                            &self.index,
-                            bombastic_index::Index::new(),
-                            context.metrics.registry(),
-                        )
+                        IndexStore::new(&self.storage, &self.index, sbom_index, context.metrics.registry())
                     })?;
                     let storage = Storage::new(storage.process("bombastic", self.devmode), context.metrics.registry())?;
 
@@ -68,7 +66,7 @@ impl Run {
                     }
 
                     let mut indexer = Indexer {
-                        index,
+                        indexes: vec![index],
                         storage,
                         bus,
                         stored_topic: self.stored_topic.as_str(),

--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc::Sender;
 use tokio::task::block_in_place;
 use tokio::{select, sync::Mutex};
 use trustification_event_bus::{Error as BusError, EventBus};
-use trustification_index::{Index, IndexStore, IndexWriter};
+use trustification_index::{IndexStore, IndexWriter, WriteIndex};
 use trustification_storage::ContinuationToken;
 use trustification_storage::{EventType, Storage};
 
@@ -47,12 +47,12 @@ impl fmt::Display for ReindexMode {
     }
 }
 
-pub struct Indexer<'a, INDEX: Index> {
+pub struct Indexer<'a, DOC> {
     pub stored_topic: &'a str,
     pub indexed_topic: &'a str,
     pub failed_topic: &'a str,
     pub sync_interval: Duration,
-    pub index: IndexStore<INDEX>,
+    pub indexes: Vec<IndexStore<Box<dyn WriteIndex<Document = DOC>>>>,
     pub storage: Storage,
     pub bus: EventBus,
     pub status: Arc<Mutex<IndexerStatus>>,
@@ -61,20 +61,32 @@ pub struct Indexer<'a, INDEX: Index> {
     pub reindex: ReindexMode,
 }
 
-impl<'a, INDEX: Index> Indexer<'a, INDEX> {
+impl<'a, DOC> Indexer<'a, DOC> {
     pub async fn run(&mut self) -> Result<(), anyhow::Error> {
-        // Load initial index from storage.
-        if let Err(e) = self.index.sync(&self.storage).await {
-            log::info!("Error loading initial index: {:?}", e);
-            if self.reindex == ReindexMode::OnFailure || self.reindex == ReindexMode::Always {
+        // Load initial indexes from storage.
+        if self.reindex == ReindexMode::Always {
+            self.command_sender.send(IndexerCommand::Reindex).await?;
+        } else {
+            let mut failed = false;
+            for index in &self.indexes {
+                if let Err(e) = index.sync(&self.storage).await {
+                    log::info!("Error loading initial index: {:?}", e);
+                    if self.reindex == ReindexMode::OnFailure {
+                        failed = true;
+                    }
+                }
+            }
+
+            if (failed && self.reindex == ReindexMode::OnFailure) || self.reindex == ReindexMode::Always {
                 self.command_sender.send(IndexerCommand::Reindex).await?;
             }
-        } else if self.reindex == ReindexMode::Always {
-            self.command_sender.send(IndexerCommand::Reindex).await?;
         }
 
         let mut interval = tokio::time::interval(self.sync_interval);
-        let mut writer = Some(block_in_place(|| self.index.writer())?);
+        let mut writers = Vec::new();
+        for index in &mut self.indexes {
+            writers.push(block_in_place(|| index.writer())?);
+        }
         let consumer = self.bus.subscribe("indexer", &[self.stored_topic]).await?;
         let mut processed_events = Vec::new();
         let mut indexed_events = Vec::new();
@@ -87,25 +99,31 @@ impl<'a, INDEX: Index> Indexer<'a, INDEX> {
             select! {
                 command = self.commands.recv() => {
                     if let Some(IndexerCommand::Reindex) = command {
-                        self.index.reset()?;
+                        for index in &mut self.indexes {
+                            index.reset()?;
+                        }
                         log::info!("Reindexing all documents");
                         const MAX_RETRIES: usize = 3;
                         let mut retries = MAX_RETRIES;
                         let mut token = ContinuationToken::default();
                         loop {
                             retries -= 1;
-                            match self.reindex(&mut writer, token).await {
+                            match self.reindex(&mut writers, token).await {
                                 Ok(_) => {
                                     log::info!("Reindexing finished");
-                                    match self.index.snapshot(writer.take().unwrap(), &self.storage, true).await {
-                                        Ok(_) => {
-                                            log::info!("Reindexed index published");
-                                        }
-                                        Err(e) => {
-                                            log::warn!("(Ignored) Error publishing index: {:?}", e);
+                                    for (index, writer) in self.indexes.iter_mut().zip(writers.drain(..)) {
+                                        match index.snapshot(writer, &self.storage, true).await {
+                                            Ok(_) => {
+                                                log::info!("Reindexed index published");
+                                            }
+                                            Err(e) => {
+                                                log::warn!("(Ignored) Error publishing index: {:?}", e);
+                                            }
                                         }
                                     }
-                                    writer.replace(block_in_place(|| self.index.writer())?);
+                                    for index in self.indexes.iter_mut() {
+                                        writers.push(block_in_place(|| index.writer())?);
+                                    }
                                     *self.status.lock().await = IndexerStatus::Running;
                                     break;
                                 }
@@ -137,8 +155,10 @@ impl<'a, INDEX: Index> Indexer<'a, INDEX> {
                                             EventType::Put => {
                                                 match self.storage.get_for_event(&data, true).await {
                                                     Ok(res) => {
-                                                        if let Err(e) = self.index_doc(self.index.index(), writer.as_mut().unwrap(), &res.key, &res.data).await {
-                                                            log::warn!("(Ignored) Internal error when indexing {}: {:?}", res.key, e);
+                                                        for (index, writer) in self.indexes.iter().zip(writers.iter_mut()) {
+                                                            if let Err(e) = self.index_doc(index.index(), writer, &res.key, &res.data).await {
+                                                                log::warn!("(Ignored) Internal error when indexing {}: {:?}", res.key, e);
+                                                            }
                                                         }
                                                         events += 1;
                                                         indexed += 1;
@@ -150,7 +170,9 @@ impl<'a, INDEX: Index> Indexer<'a, INDEX> {
                                             },
                                             EventType::Delete => {
                                                 let (_, key) = Storage::key_from_event(&data)?;
-                                                block_in_place(|| writer.as_mut().unwrap().delete_document(self.index.index(), key.as_str()));
+                                                for (index, writer) in self.indexes.iter().zip(writers.iter_mut()) {
+                                                    block_in_place(|| writer.delete_document(index.index(), key.as_str()));
+                                                }
                                                 log::info!("Deleted entry '{key}' from index");
                                                 events += 1;
                                             }
@@ -184,7 +206,15 @@ impl<'a, INDEX: Index> Indexer<'a, INDEX> {
                 },
                 _ = tick => {
                     log::trace!("{} new events added, pushing new index to storage", events);
-                    match self.index.snapshot(writer.take().unwrap(), &self.storage, events > 0).await {
+                    let mut result = Ok(());
+                    for (index, writer) in self.indexes.iter_mut().zip(writers.drain(..)) {
+                        if let Err(e) = index.snapshot(writer, &self.storage, events > 0).await {
+                            result = Err(e);
+                            break;
+                        }
+                    }
+
+                    match result {
                         Ok(_) => {
                             log::trace!("Index updated successfully");
                             match consumer.commit(&processed_events[..]).await {
@@ -210,7 +240,9 @@ impl<'a, INDEX: Index> Indexer<'a, INDEX> {
                             log::warn!("Error taking index snapshot: {:?}", e);
                         }
                     }
-                    writer.replace(block_in_place(|| self.index.writer())?);
+                    for index in self.indexes.iter_mut() {
+                        writers.push(block_in_place(|| index.writer())?);
+                    }
                 }
             }
         }
@@ -218,7 +250,7 @@ impl<'a, INDEX: Index> Indexer<'a, INDEX> {
 
     async fn reindex(
         &mut self,
-        writer: &mut Option<IndexWriter>,
+        writers: &mut Vec<IndexWriter>,
         resume_token: ContinuationToken,
     ) -> Result<(), (IndexerError, ContinuationToken)> {
         let mut progress = 0;
@@ -238,12 +270,13 @@ impl<'a, INDEX: Index> Indexer<'a, INDEX> {
                             let key = path.key();
                             log::info!("Reindexing {:?}", key);
                             // Not sending notifications for reindexing
-                            if let Err(e) = self.index_doc(self.index.index(), writer.as_mut().unwrap(), key, &obj).await {
-                                log::warn!("(Ignored) Internal error when indexing {}: {:?}", key, e);
-                            } else {
-                                progress += 1;
-                                *self.status.lock().await = IndexerStatus::Reindexing { progress };
+                            for (index, writer) in self.indexes.iter().zip(writers.iter_mut()) {
+                                if let Err(e) = self.index_doc(index.index(), writer, key, &obj).await {
+                                    log::warn!("(Ignored) Internal error when indexing {}: {:?}", key, e);
+                                }
                             }
+                            progress += 1;
+                            *self.status.lock().await = IndexerStatus::Reindexing { progress };
                         }
                         Some(Err((e, resume_token))) => {
                             log::warn!("Error reindexing: {:?}", e);
@@ -256,15 +289,20 @@ impl<'a, INDEX: Index> Indexer<'a, INDEX> {
                     }
                 }
                 _ = tick => {
-                    match self.index.commit(writer.take().unwrap()) {
-                        Ok(_) => {
-                            log::trace!("Index committed");
-                        }
-                        Err(e) => {
-                            log::warn!("(Ignored) Error committing index: {:?}", e);
+                    for (index, writer) in self.indexes.iter().zip(writers.drain(..)) {
+                        match index.commit(writer) {
+                            Ok(_) => {
+                                log::trace!("Index committed");
+                            }
+                            Err(e) => {
+                                log::warn!("(Ignored) Error committing index: {:?}", e);
+                            }
                         }
                     }
-                    writer.replace(block_in_place(|| self.index.writer()).map_err(|e| (e.into(), resume_token.clone()))?);
+
+                    for index in self.indexes.iter_mut() {
+                        writers.push(block_in_place(|| index.writer()).map_err(|e| (e.into(), resume_token.clone()))?);
+                    }
                 }
             }
         }
@@ -272,7 +310,7 @@ impl<'a, INDEX: Index> Indexer<'a, INDEX> {
 
     async fn index_doc(
         &self,
-        index: &INDEX,
+        index: &dyn WriteIndex<Document = DOC>,
         writer: &mut IndexWriter,
         key: &str,
         data: &[u8],

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -73,6 +73,157 @@ struct ProductPackage {
 
 impl trustification_index::Index for Index {
     type MatchedDocument = SearchHit;
+
+    fn prepare_query(&self, q: &str) -> Result<SearchQuery, SearchError> {
+        let mut query = Vulnerabilities::parse(q).map_err(|err| SearchError::QueryParser(err.to_string()))?;
+
+        query.term = query.term.compact();
+
+        debug!("Query: {query:?}");
+
+        let sort_by = query.sorting.first().map(|f| match f.qualifier {
+            VulnerabilitiesSortable::Severity => sort_by(f.direction, self.fields.advisory_severity_score),
+            VulnerabilitiesSortable::Release => sort_by(f.direction, self.fields.advisory_current),
+        });
+
+        let query = if query.term.is_empty() {
+            Box::new(AllQuery)
+        } else {
+            term2query(&query.term, &|resource| self.resource2query(resource))
+        };
+
+        debug!("Processed query: {:?}", query);
+        Ok(SearchQuery { query, sort_by })
+    }
+
+    fn search(
+        &self,
+        searcher: &Searcher,
+        query: &dyn Query,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(f32, DocAddress)>, usize), SearchError> {
+        let severity_field = self
+            .schema
+            .get_field_name(self.fields.advisory_severity_score)
+            .to_string();
+        let date_field = self.schema.get_field_name(self.fields.advisory_current).to_string();
+        let now = tantivy::DateTime::from_utc(OffsetDateTime::now_utc());
+        Ok(searcher.search(
+            query,
+            &(
+                TopDocs::with_limit(limit)
+                    .and_offset(offset)
+                    .tweak_score(move |segment_reader: &SegmentReader| {
+                        let severity_reader = segment_reader.fast_fields().f64(&severity_field);
+
+                        let date_reader = segment_reader.fast_fields().date(&date_field);
+
+                        move |doc: DocId, original_score: Score| {
+                            let severity_reader = severity_reader.clone();
+                            let date_reader = date_reader.clone();
+                            let mut tweaked = original_score;
+                            if let Ok(Some(score)) = severity_reader.map(|s| s.first(doc)) {
+                                log::trace!("CVSS score impact {} -> {}", tweaked, (score as f32) * tweaked);
+                                tweaked *= score as f32;
+
+                                // Now look at the date, normalize score between 0 and 1 (baseline 1970)
+                                if let Ok(Some(date)) = date_reader.map(|s| s.first(doc)) {
+                                    if date < now {
+                                        let mut normalized = 2.0
+                                            * (date.into_timestamp_secs() as f64 / now.into_timestamp_secs() as f64);
+                                        // If it's the past month, boost it more.
+                                        if (now.into_utc() - date.into_utc()) < Duration::from_secs(30 * 24 * 3600) {
+                                            normalized *= 4.0;
+                                        }
+                                        log::trace!(
+                                            "DATE score impact {} -> {}",
+                                            tweaked,
+                                            tweaked * (normalized as f32)
+                                        );
+                                        tweaked *= normalized as f32;
+                                    }
+                                }
+                            }
+                            log::trace!("Tweaking from {} to {}", original_score, tweaked);
+                            tweaked
+                        }
+                    }),
+                tantivy::collector::Count,
+            ),
+        )?)
+    }
+
+    fn process_hit(
+        &self,
+        doc_address: DocAddress,
+        score: f32,
+        searcher: &Searcher,
+        query: &dyn Query,
+        options: &SearchOptions,
+    ) -> Result<Self::MatchedDocument, SearchError> {
+        let doc = searcher.doc(doc_address)?;
+        let snippet_generator = SnippetGenerator::create(searcher, query, self.fields.advisory_description)?;
+        let advisory_snippet = snippet_generator.snippet_from_doc(&doc).to_html();
+
+        let advisory_id = field2str(&self.schema, &doc, self.fields.advisory_id)?;
+        let advisory_title = field2str(&self.schema, &doc, self.fields.advisory_title)?;
+        let advisory_severity = field2str(&self.schema, &doc, self.fields.advisory_severity)?;
+        let advisory_date = field2date(&self.schema, &doc, self.fields.advisory_current)?;
+        let advisory_desc = field2str(&self.schema, &doc, self.fields.advisory_description).unwrap_or("");
+
+        let cves = field2strvec(&doc, self.fields.cve_id)?
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let cvss_max: Option<f64> = field2float(&self.schema, &doc, self.fields.cve_cvss_max).ok();
+
+        let mut cve_severity_count: HashMap<String, u64> = HashMap::new();
+        if let Some(Some(data)) = doc.get_first(self.fields.cve_severity_count).map(|d| d.as_json()) {
+            for (key, value) in data.iter() {
+                if let Value::Number(value) = value {
+                    cve_severity_count.insert(key.clone(), value.as_u64().unwrap_or(0));
+                }
+            }
+        }
+
+        let document = SearchDocument {
+            advisory_id: advisory_id.to_string(),
+            advisory_title: advisory_title.to_string(),
+            advisory_date,
+            advisory_snippet,
+            advisory_severity: advisory_severity.to_string(),
+            advisory_desc: advisory_desc.to_string(),
+            cves,
+            cvss_max,
+            cve_severity_count,
+        };
+
+        let explanation: Option<serde_json::Value> = if options.explain {
+            match query.explain(searcher, doc_address) {
+                Ok(explanation) => Some(serde_json::to_value(explanation).ok()).unwrap_or(None),
+                Err(e) => {
+                    warn!("Error producing explanation for document {:?}: {:?}", doc_address, e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let metadata = options.metadata.then(|| doc2metadata(&self.schema, &doc));
+
+        Ok(SearchHit {
+            document,
+            score,
+            explanation,
+            metadata,
+        })
+    }
+}
+
+impl trustification_index::WriteIndex for Index {
     type Document = Csaf;
 
     fn tokenizers(&self) -> Result<TokenizerManager, SearchError> {
@@ -96,7 +247,7 @@ impl trustification_index::Index for Index {
         }
     }
 
-    fn parse_doc(data: &[u8]) -> Result<Csaf, SearchError> {
+    fn parse_doc(&self, data: &[u8]) -> Result<Csaf, SearchError> {
         serde_json::from_slice::<csaf::Csaf>(data).map_err(|e| SearchError::DocParser(e.to_string()))
     }
 
@@ -306,154 +457,6 @@ impl trustification_index::Index for Index {
 
     fn schema(&self) -> Schema {
         self.schema.clone()
-    }
-
-    fn prepare_query(&self, q: &str) -> Result<SearchQuery, SearchError> {
-        let mut query = Vulnerabilities::parse(q).map_err(|err| SearchError::QueryParser(err.to_string()))?;
-
-        query.term = query.term.compact();
-
-        debug!("Query: {query:?}");
-
-        let sort_by = query.sorting.first().map(|f| match f.qualifier {
-            VulnerabilitiesSortable::Severity => sort_by(f.direction, self.fields.advisory_severity_score),
-            VulnerabilitiesSortable::Release => sort_by(f.direction, self.fields.advisory_current),
-        });
-
-        let query = if query.term.is_empty() {
-            Box::new(AllQuery)
-        } else {
-            term2query(&query.term, &|resource| self.resource2query(resource))
-        };
-
-        debug!("Processed query: {:?}", query);
-        Ok(SearchQuery { query, sort_by })
-    }
-
-    fn search(
-        &self,
-        searcher: &Searcher,
-        query: &dyn Query,
-        offset: usize,
-        limit: usize,
-    ) -> Result<(Vec<(f32, DocAddress)>, usize), SearchError> {
-        let severity_field = self
-            .schema
-            .get_field_name(self.fields.advisory_severity_score)
-            .to_string();
-        let date_field = self.schema.get_field_name(self.fields.advisory_current).to_string();
-        let now = tantivy::DateTime::from_utc(OffsetDateTime::now_utc());
-        Ok(searcher.search(
-            query,
-            &(
-                TopDocs::with_limit(limit)
-                    .and_offset(offset)
-                    .tweak_score(move |segment_reader: &SegmentReader| {
-                        let severity_reader = segment_reader.fast_fields().f64(&severity_field);
-
-                        let date_reader = segment_reader.fast_fields().date(&date_field);
-
-                        move |doc: DocId, original_score: Score| {
-                            let severity_reader = severity_reader.clone();
-                            let date_reader = date_reader.clone();
-                            let mut tweaked = original_score;
-                            if let Ok(Some(score)) = severity_reader.map(|s| s.first(doc)) {
-                                log::trace!("CVSS score impact {} -> {}", tweaked, (score as f32) * tweaked);
-                                tweaked *= score as f32;
-
-                                // Now look at the date, normalize score between 0 and 1 (baseline 1970)
-                                if let Ok(Some(date)) = date_reader.map(|s| s.first(doc)) {
-                                    if date < now {
-                                        let mut normalized = 2.0
-                                            * (date.into_timestamp_secs() as f64 / now.into_timestamp_secs() as f64);
-                                        // If it's the past month, boost it more.
-                                        if (now.into_utc() - date.into_utc()) < Duration::from_secs(30 * 24 * 3600) {
-                                            normalized *= 4.0;
-                                        }
-                                        log::trace!(
-                                            "DATE score impact {} -> {}",
-                                            tweaked,
-                                            tweaked * (normalized as f32)
-                                        );
-                                        tweaked *= normalized as f32;
-                                    }
-                                }
-                            }
-                            log::trace!("Tweaking from {} to {}", original_score, tweaked);
-                            tweaked
-                        }
-                    }),
-                tantivy::collector::Count,
-            ),
-        )?)
-    }
-
-    fn process_hit(
-        &self,
-        doc_address: DocAddress,
-        score: f32,
-        searcher: &Searcher,
-        query: &dyn Query,
-        options: &SearchOptions,
-    ) -> Result<Self::MatchedDocument, SearchError> {
-        let doc = searcher.doc(doc_address)?;
-        let snippet_generator = SnippetGenerator::create(searcher, query, self.fields.advisory_description)?;
-        let advisory_snippet = snippet_generator.snippet_from_doc(&doc).to_html();
-
-        let advisory_id = field2str(&self.schema, &doc, self.fields.advisory_id)?;
-        let advisory_title = field2str(&self.schema, &doc, self.fields.advisory_title)?;
-        let advisory_severity = field2str(&self.schema, &doc, self.fields.advisory_severity)?;
-        let advisory_date = field2date(&self.schema, &doc, self.fields.advisory_current)?;
-        let advisory_desc = field2str(&self.schema, &doc, self.fields.advisory_description).unwrap_or("");
-
-        let cves = field2strvec(&doc, self.fields.cve_id)?
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-
-        let cvss_max: Option<f64> = field2float(&self.schema, &doc, self.fields.cve_cvss_max).ok();
-
-        let mut cve_severity_count: HashMap<String, u64> = HashMap::new();
-        if let Some(Some(data)) = doc.get_first(self.fields.cve_severity_count).map(|d| d.as_json()) {
-            for (key, value) in data.iter() {
-                if let Value::Number(value) = value {
-                    cve_severity_count.insert(key.clone(), value.as_u64().unwrap_or(0));
-                }
-            }
-        }
-
-        let document = SearchDocument {
-            advisory_id: advisory_id.to_string(),
-            advisory_title: advisory_title.to_string(),
-            advisory_date,
-            advisory_snippet,
-            advisory_severity: advisory_severity.to_string(),
-            advisory_desc: advisory_desc.to_string(),
-            cves,
-            cvss_max,
-            cve_severity_count,
-        };
-
-        let explanation: Option<serde_json::Value> = if options.explain {
-            match query.explain(searcher, doc_address) {
-                Ok(explanation) => Some(serde_json::to_value(explanation).ok()).unwrap_or(None),
-                Err(e) => {
-                    warn!("Error producing explanation for document {:?}: {:?}", doc_address, e);
-                    None
-                }
-            }
-        } else {
-            None
-        };
-
-        let metadata = options.metadata.then(|| doc2metadata(&self.schema, &doc));
-
-        Ok(SearchHit {
-            document,
-            score,
-            explanation,
-            metadata,
-        })
     }
 }
 


### PR DESCRIPTION
Supporting multiple index stores allows a single indexer process to consume
a single document and index into separate index stores.

This PR has no changes to the existing behavior, and is a prereq for further work.

Issue #786, #784
