### PR TITLE
fix: support storing/loading multiple indexes from storage

### DIFF
--- a/bombastic/index/src/lib.rs
+++ b/bombastic/index/src/lib.rs
@@ -615,6 +615,10 @@ impl trustification_index::Index for Index {
 impl trustification_index::WriteIndex for Index {
     type Document = (SBOM, String);
 
+    fn name(&self) -> &str {
+        "sbom"
+    }
+
     fn index_doc(&self, id: &str, (doc, sha256): &Self::Document) -> Result<Document, SearchError> {
         let mut doc = match doc {
             SBOM::CycloneDX(bom) => self.index_cyclonedx(id, bom)?,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -290,7 +290,7 @@ impl Storage {
     }
 
     pub fn is_index(&self, key: &str) -> bool {
-        format!("/{}", key) == INDEX_PATH
+        format!("/{}", key).starts_with(INDEX_PATH)
     }
 
     pub fn key_from_event(record: &Record) -> Result<(Cow<str>, String), Error> {
@@ -422,14 +422,16 @@ impl Storage {
         }
     }
 
-    pub async fn put_index(&self, index: &[u8]) -> Result<(), Error> {
-        self.bucket.put_object(INDEX_PATH, index).await?;
+    pub async fn put_index(&self, name: &str, index: &[u8]) -> Result<(), Error> {
+        let index_path = format!("{}{}", INDEX_PATH, name);
+        self.bucket.put_object(index_path, index).await?;
         self.metrics.index_puts_total.inc();
         Ok(())
     }
 
-    pub async fn get_index(&self) -> Result<Vec<u8>, Error> {
-        let data = self.bucket.get_object(INDEX_PATH).await?;
+    pub async fn get_index(&self, name: &str) -> Result<Vec<u8>, Error> {
+        let index_path = format!("{}{}", INDEX_PATH, name);
+        let data = self.bucket.get_object(index_path).await?;
         Ok(data.to_vec())
     }
 

--- a/v11y/index/src/lib.rs
+++ b/v11y/index/src/lib.rs
@@ -343,6 +343,10 @@ impl trustification_index::Index for Index {
 impl trustification_index::WriteIndex for Index {
     type Document = Cve;
 
+    fn name(&self) -> &str {
+        "cve"
+    }
+
     fn index_doc(&self, _id: &str, doc: &Cve) -> Result<Document, SearchError> {
         match doc {
             Cve::Published(cve) => self.index_published_cve(cve),

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -226,6 +226,10 @@ impl trustification_index::Index for Index {
 impl trustification_index::WriteIndex for Index {
     type Document = Csaf;
 
+    fn name(&self) -> &str {
+        "vex"
+    }
+
     fn tokenizers(&self) -> Result<TokenizerManager, SearchError> {
         let manager = TokenizerManager::default();
         let ngram = NgramTokenizer::all_ngrams(3, 8)?;


### PR DESCRIPTION
NOTE: This is a breaking change that will need a full reindex during update. The API should still serve the old index until the new is published.

Issue #784, #788

Requires #787  to be merged first.