### PR TITLE
refactor: allow using a relative path

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -153,6 +153,17 @@ set -gx TRACING enabled
 set -gx OTEL_TRACES_SAMPLER_ARG 1
 ```
 
+## All-in-one
+
+When using KDE's `konsole`, you can start all processes in multiple tabs using:
+
+```shell
+konsole --tabs-from-file deploy/konsole.tabs
+```
+
+> [!NOTE]
+> You still need to [start the dependencies first](#dependencies).
+
 ## APIs
 
 To run the API processes, you can use cargo:
@@ -188,7 +199,7 @@ RUST_LOG=info cargo run -p trust -- v11y walker --devmode --source ../cvelistV5/
 ```
 
 > [!NOTE]
-> For this to work, you need to clone the repository: <https://github.com/CVEProject/cvelistV5> 
+> For this to work, you need to clone the repository: <https://github.com/CVEProject/cvelistV5>
 
 ## Ingesting VEX
 
@@ -215,7 +226,7 @@ RUST_LOG=info cargo run -p trust -- vexination walker --devmode --sink http://lo
 If you have a local copy of the data, you can also run:
 
 ```shell
-RUST_LOG=info cargo run -p trust -- vexination walker --devmode -3 --sink http://localhost:8081/api/v1/vex --source file:///path/to/data
+RUST_LOG=info cargo run -p trust -- vexination walker --devmode -3 --sink http://localhost:8081/api/v1/vex --source /path/to/data
 ```
 
 You can create/sync a local copy of the data using [csaf-walker](https://github.com/ctron/csaf-walker#installation):

--- a/deploy/konsole.tabs
+++ b/deploy/konsole.tabs
@@ -1,0 +1,21 @@
+# start with: konsole --tabs-from-file deploy/konsole.tabs --workdir ~/git/trustification
+# you can also use --hold to keep tabs with terminated processed open
+
+title: vexination api;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- vexination api --devmode
+title: bombastic api;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- bombastic api --devmode
+title: spog api;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- spog api --devmode
+title: v11y api;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- v11y api --devmode
+title: exhort api;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- exhort api --devmode
+
+title: collectorist api;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- collectorist api --devmode
+title: collector osv;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- collector osv --devmode
+title: collector nvd;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- collector nvd --devmode
+title: collector snyk;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- collector snyk --devmode
+
+title: vexination indexer;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- vexination indexer --devmode
+title: bombastic indexer;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- bombastic indexer --devmode
+title: v11y indexer;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- v11y indexer --devmode
+
+title: v11y walker;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- v11y walker --devmode --source ../cvelistV5/
+title: vexination walker;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust -- vexination walker --devmode -3 --sink http://localhost:8081/api/v1/vex --source ../csaf-walker/data/vex/
+title: bombastic walker;; command: /usr/bin/env TRACING=enabled OTEL_TRACES_SAMPLER_ARG=1 RUST_LOG=info cargo run -p trust bombastic walker --sink http://localhost:8082 --devmode -3

--- a/vexination/walker/src/lib.rs
+++ b/vexination/walker/src/lib.rs
@@ -20,9 +20,9 @@ mod server;
 #[derive(clap::Args, Debug)]
 #[command(about = "Run the api server", args_conflicts_with_subcommands = true)]
 pub struct Run {
-    /// Source URL
+    /// Source URL or path
     #[arg(short, long)]
-    pub(crate) source: Url,
+    pub(crate) source: String,
 
     /// Vexination upload url
     #[arg(short = 'S', long)]

--- a/vexination/walker/src/server.rs
+++ b/vexination/walker/src/server.rs
@@ -2,10 +2,9 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
-use csaf_walker::discover::DiscoveredAdvisory;
-use csaf_walker::retrieve::RetrievedAdvisory;
 use csaf_walker::{
-    retrieve::RetrievingVisitor,
+    discover::DiscoveredAdvisory,
+    retrieve::{RetrievedAdvisory, RetrievingVisitor},
     source::{FileSource, HttpSource},
     validation::{ValidatedAdvisory, ValidationError, ValidationVisitor},
     walker::Walker,
@@ -13,21 +12,21 @@ use csaf_walker::{
 use reqwest::{header, StatusCode};
 use serde::Deserialize;
 use tokio::sync::{Mutex, RwLock};
-use trustification_auth::client::TokenInjector;
-use trustification_auth::client::TokenProvider;
-use walker_common::since::Since;
+use trustification_auth::client::{TokenInjector, TokenProvider};
+use url::Url;
 use walker_common::{
     fetcher::{Fetcher, FetcherOptions},
+    since::Since,
     validate::ValidationOptions,
 };
 
 pub async fn run(
     workers: usize,
-    source: url::Url,
-    sink: url::Url,
+    source: String,
+    sink: Url,
     provider: Arc<dyn TokenProvider>,
     options: ValidationOptions,
-    ignore_distributions: Vec<url::Url>,
+    ignore_distributions: Vec<Url>,
     since_file: Option<PathBuf>,
 ) -> Result<(), anyhow::Error> {
     let fetcher = Fetcher::new(Default::default()).await?;
@@ -87,19 +86,11 @@ pub async fn run(
     })
     .with_options(options);
 
-    if let Ok(path) = source.to_file_path() {
-        let source = FileSource::new(path, None)?;
-        Walker::new(source.clone())
-            .with_distribution_filter(Box::new(move |distribution| {
-                !ignore_distributions.contains(&distribution.directory_url)
-            }))
-            .walk(RetrievingVisitor::new(source.clone(), validation))
-            .await?;
-    } else {
+    if let Ok(url) = Url::parse(&source) {
         let since = Since::new(None::<SystemTime>, since_file, Default::default())?;
         log::info!("Walking VEX docs: source='{source}' workers={workers}");
         let source = HttpSource {
-            url: source,
+            url,
             fetcher,
             options: csaf_walker::source::HttpOptions { since: *since },
         };
@@ -111,6 +102,15 @@ pub async fn run(
             .await?;
 
         since.store()?;
+    } else {
+        log::info!("Walking VEX docs: path='{source}' workers={workers}");
+        let source = FileSource::new(source, None)?;
+        Walker::new(source.clone())
+            .with_distribution_filter(Box::new(move |distribution| {
+                !ignore_distributions.contains(&distribution.directory_url)
+            }))
+            .walk(RetrievingVisitor::new(source.clone(), validation))
+            .await?;
     }
 
     Ok(())


### PR DESCRIPTION
Also, add a KDE console tab-file, for starting up all services in a single step.

BREAKING-CHANGE: This no longer accepts `file:///` as a source URL but treats every non-URL as a path. Which allows using relative paths too.