### PR TITLE
fix: show package information even in any case

### DIFF
--- a/spog/ui/src/console/mod.rs
+++ b/spog/ui/src/console/mod.rs
@@ -231,11 +231,11 @@ fn render(route: AppRoute, config: &spog_model::config::Configuration) -> Html {
             html!(<pages::PackageSearchPage {query} />)
         }
 
-        AppRoute::Packages(View::Content { id }) if config.features.dedicated_search => {
+        AppRoute::Packages(View::Content { id }) => {
             html!(<pages::Packages {id} />)
         }
 
-        AppRoute::Package { id } if config.features.dedicated_search => {
+        AppRoute::Package { id } => {
             let id = match id.is_empty() {
                 true => None,
                 false => Some(id),


### PR DESCRIPTION
When dedicated search is disabled, we still link to the details page from the unified search.