### PR TITLE
fix: don't let the default override any use made changes on "back"

### DIFF
--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -2882,7 +2882,6 @@ dependencies = [
  "itertools 0.11.0",
  "js-sys",
  "log",
- "markdown",
  "monaco",
  "openidconnect",
  "packageurl",

--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -1873,7 +1873,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 [[package]]
 name = "patternfly-yew"
 version = "0.5.0-rc.1"
-source = "git+https://github.com/ctron/patternfly-yew?rev=4b5025843efe1c9fce5c85168f5f5971005a0886#4b5025843efe1c9fce5c85168f5f5971005a0886"
+source = "git+https://github.com/ctron/patternfly-yew?rev=30b31e36120d3efc609f84e21a2baa208905a4e9#30b31e36120d3efc609f84e21a2baa208905a4e9"
 dependencies = [
  "chrono",
  "gloo-events 0.2.0",

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -94,7 +94,7 @@ members = [
 #yew-more-hooks = { git = "https://github.com/ctron/yew-more-hooks", rev = "fc0af774aa925edcd5a544e562619ecb539942f8" }
 #yew-more-hooks = { path = "../../../yew-more-hooks" }
 
-patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "4b5025843efe1c9fce5c85168f5f5971005a0886" } # FIXME: awaiting release
+patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "30b31e36120d3efc609f84e21a2baa208905a4e9" } # FIXME: awaiting release
 #patternfly-yew = { path = "../../../patternfly-yew" }
 
 #analytics-next = { git = "https://github.com/ctron/analytics-next-rs", rev = "9c95122f4e6dc308c90b945bd0f1925faf7cb828" } # FIXME: awaiting release

--- a/spog/ui/crates/common/src/components/markdown.rs
+++ b/spog/ui/crates/common/src/components/markdown.rs
@@ -1,4 +1,4 @@
-use spog_ui_common::components::SafeHtml;
+use crate::components::SafeHtml;
 use std::rc::Rc;
 use yew::prelude::*;
 

--- a/spog/ui/crates/common/src/components/mod.rs
+++ b/spog/ui/crates/common/src/components/mod.rs
@@ -1,3 +1,5 @@
 mod html;
+mod markdown;
 
+pub use self::markdown::*;
 pub use html::*;

--- a/spog/ui/crates/components/Cargo.toml
+++ b/spog/ui/crates/components/Cargo.toml
@@ -20,7 +20,6 @@ humansize = "2"
 itertools = "0.11"
 js-sys = "0.3"
 log = "0.4"
-markdown = "1.0.0-alpha.11"
 monaco = { version = "0.5", features = ["yew-components"] }
 openidconnect = "3"
 packageurl = "0.3"

--- a/spog/ui/crates/components/src/advisory/mod.rs
+++ b/spog/ui/crates/components/src/advisory/mod.rs
@@ -4,10 +4,7 @@ mod search;
 pub use details::*;
 pub use search::*;
 
-use crate::{
-    common::CardWrapper, cvss::CvssMap, download::Download, markdown::Markdown, severity::Severity,
-    table_wrapper::TableWrapper,
-};
+use crate::{common::CardWrapper, cvss::CvssMap, download::Download, severity::Severity, table_wrapper::TableWrapper};
 use csaf::{
     definitions::{Branch, Note, NoteCategory, ProductIdT, Reference, ReferenceCategory},
     document::{PublisherCategory, Status},
@@ -18,9 +15,12 @@ use csaf::{
 use patternfly_yew::prelude::*;
 use spog_model::prelude::*;
 use spog_ui_backend::{use_backend, Endpoint};
-use spog_ui_common::utils::{
-    csaf::{find_product_relations, has_product, trace_product},
-    time::date,
+use spog_ui_common::{
+    components::Markdown,
+    utils::{
+        csaf::{find_product_relations, has_product, trace_product},
+        time::date,
+    },
 };
 use spog_ui_navigation::{AppRoute, View};
 use std::borrow::Cow;

--- a/spog/ui/crates/components/src/advisory/search.rs
+++ b/spog/ui/crates/components/src/advisory/search.rs
@@ -16,7 +16,7 @@ use yew_more_hooks::prelude::*;
 
 #[derive(PartialEq, Properties)]
 pub struct AdvisorySearchControlsProperties {
-    pub search_params: UseReducerHandle<SearchMode<DynamicSearchParameters>>,
+    pub search_params: UseReducerHandle<SearchState<DynamicSearchParameters>>,
 }
 
 #[function_component(AdvisorySearchControls)]
@@ -39,7 +39,7 @@ pub fn advisory_search_controls(props: &AdvisorySearchControlsProperties) -> Htm
 
 #[hook]
 pub fn use_advisory_search(
-    search_params: UseReducerHandle<SearchMode<DynamicSearchParameters>>,
+    search_params: UseReducerHandle<SearchState<DynamicSearchParameters>>,
     pagination: UsePagination,
     callback: Callback<UseAsyncHandleDeps<SearchResult<Rc<Vec<AdvisorySummary>>>, String>>,
 ) -> UseStandardSearch {
@@ -78,7 +78,7 @@ pub struct AdvisorySearchProperties {
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 struct PageState {
     pagination: PaginationControl,
-    search_params: SearchMode<DynamicSearchParameters>,
+    search_params: HistorySearchState<DynamicSearchParameters>,
 }
 
 #[function_component(AdvisorySearch)]
@@ -87,11 +87,12 @@ pub fn advisory_search(props: &AdvisorySearchProperties) -> Html {
         search_params: match props.query.as_ref().filter(|s| !s.is_empty()) {
             Some(terms) => SearchMode::Complex(terms.clone()),
             None => Default::default(),
-        },
+        }
+        .into(),
         ..Default::default()
     });
 
-    let search_params = use_reducer_eq(|| page_state.search_params.clone());
+    let search_params = use_reducer_eq(|| SearchState::from(page_state.search_params.clone()));
     let total = use_state_eq(|| None);
     let pagination = use_pagination(*total, || page_state.pagination);
     let state = use_state_eq(UseAsyncState::default);
@@ -117,7 +118,7 @@ pub fn advisory_search(props: &AdvisorySearchProperties) -> Html {
         page_state,
         PageState {
             pagination: **pagination,
-            search_params: (*search_params).clone(),
+            search_params: (*search_params).clone().into(),
         },
     );
 

--- a/spog/ui/crates/components/src/common.rs
+++ b/spog/ui/crates/components/src/common.rs
@@ -85,31 +85,3 @@ pub fn ext_nav_link(props: &ExternalNavLinkProperties) -> Html {
 pub fn ext_link_marker() -> Html {
     html!({ Icon::ExternalLinkAlt.with_classes(classes!("pf-v5-u-ml-sm", "pf-v5-u-color-200")) })
 }
-
-#[derive(PartialEq, Properties)]
-pub struct VisibleProperties {
-    pub visible: bool,
-    #[prop_or_default]
-    pub children: Children,
-
-    #[prop_or_default]
-    pub class: Classes,
-    #[prop_or_default]
-    pub style: Option<AttrValue>,
-}
-
-#[function_component(Visible)]
-pub fn visible(props: &VisibleProperties) -> Html {
-    let mut class = match props.visible {
-        true => classes!(),
-        false => classes!("pf-v5-u-display-none"),
-    };
-
-    class.extend(&props.class);
-
-    html!(
-        <div {class} style={props.style.clone()}>
-            { for props.children.iter() }
-        </div>
-    )
-}

--- a/spog/ui/crates/components/src/hooks/search.rs
+++ b/spog/ui/crates/components/src/hooks/search.rs
@@ -1,4 +1,4 @@
-use crate::search::{DynamicSearchParameters, SearchMode, SearchModeAction};
+use crate::search::{DynamicSearchParameters, SearchMode, SearchModeAction, SearchState};
 use patternfly_yew::prelude::*;
 use spog_model::config::Filters;
 use spog_ui_backend::{use_backend, Backend};
@@ -11,7 +11,7 @@ use yew_oauth2::prelude::{use_latest_access_token, LatestAccessToken};
 
 #[derive(Clone)]
 pub struct UseStandardSearch {
-    pub search_params: UseReducerHandle<SearchMode<DynamicSearchParameters>>,
+    pub search_params: UseReducerHandle<SearchState<DynamicSearchParameters>>,
     pub filter_input_state: Rc<InputState>,
     pub onclear: Callback<()>,
     pub onset: Callback<()>,
@@ -21,14 +21,14 @@ pub struct UseStandardSearch {
 
 #[hook]
 pub fn use_standard_search<S>(
-    search_params: UseReducerHandle<SearchMode<DynamicSearchParameters>>,
+    search_params: UseReducerHandle<SearchState<DynamicSearchParameters>>,
     context: Rc<Filters>,
 ) -> UseStandardSearch
 where
     S: sikula::prelude::Search,
 {
     // the current value in the text input field
-    let text = use_state_eq(|| match &*search_params {
+    let text = use_state_eq(|| match &**search_params {
         SearchMode::Complex(s) => s.clone(),
         SearchMode::Simple(s) => s.terms().join(" "),
     });
@@ -52,7 +52,7 @@ where
     let onclear = use_callback((text.clone(), search_params.clone()), |_, (text, search_params)| {
         text.set(String::new());
         // trigger empty search
-        match **search_params {
+        match ***search_params {
             SearchMode::Complex(_) => search_params.dispatch(SearchModeAction::Clear),
             SearchMode::Simple(_) => search_params.dispatch(SearchModeAction::Clear),
         }
@@ -94,13 +94,13 @@ pub struct SearchOperationContext {
     pub access_token: Option<LatestAccessToken>,
     pub page: usize,
     pub per_page: usize,
-    pub search_params: SearchMode<DynamicSearchParameters>,
+    pub search_params: SearchState<DynamicSearchParameters>,
     pub filters: Rc<Filters>,
 }
 
 #[hook]
 pub fn use_generic_search<S, R, F, Fut, IF>(
-    search_params: UseReducerHandle<SearchMode<DynamicSearchParameters>>,
+    search_params: UseReducerHandle<SearchState<DynamicSearchParameters>>,
     pagination: UsePagination,
     callback: Callback<UseAsyncHandleDeps<R, String>>,
     init_filter: IF,

--- a/spog/ui/crates/components/src/lib.rs
+++ b/spog/ui/crates/components/src/lib.rs
@@ -10,7 +10,6 @@ pub mod cvss;
 pub mod download;
 pub mod editor;
 pub mod hooks;
-pub mod markdown;
 pub mod packages;
 pub mod pagination;
 pub mod sbom;

--- a/spog/ui/crates/components/src/packages/search.rs
+++ b/spog/ui/crates/components/src/packages/search.rs
@@ -16,7 +16,7 @@ use yew_more_hooks::prelude::*;
 
 #[derive(PartialEq, Properties)]
 pub struct PackageSearchControlsProperties {
-    pub search_params: UseReducerHandle<SearchMode<DynamicSearchParameters>>,
+    pub search_params: UseReducerHandle<SearchState<DynamicSearchParameters>>,
 }
 
 #[function_component(PackageSearchControls)]
@@ -39,7 +39,7 @@ pub fn packages_search_controls(props: &PackageSearchControlsProperties) -> Html
 
 #[hook]
 pub fn use_package_search(
-    search_params: UseReducerHandle<SearchMode<DynamicSearchParameters>>,
+    search_params: UseReducerHandle<SearchState<DynamicSearchParameters>>,
     pagination: UsePagination,
     callback: Callback<UseAsyncHandleDeps<SearchResult<Rc<Vec<PackageInfoSummary>>>, String>>,
 ) -> UseStandardSearch {
@@ -78,7 +78,7 @@ pub struct PackageSearchProperties {
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 struct PageState {
     pagination: PaginationControl,
-    search_params: SearchMode<DynamicSearchParameters>,
+    search_params: HistorySearchState<DynamicSearchParameters>,
 }
 
 #[function_component(PackagesSearch)]
@@ -87,11 +87,14 @@ pub fn packages_search(props: &PackageSearchProperties) -> Html {
         search_params: match props.query.as_ref().filter(|s| !s.is_empty()) {
             Some(terms) => SearchMode::Complex(terms.clone()),
             None => Default::default(),
-        },
+        }
+        .into(),
         ..Default::default()
     });
 
-    let search_params = use_reducer_eq::<SearchMode<DynamicSearchParameters>, _>(|| page_state.search_params.clone());
+    let search_params = use_reducer_eq::<SearchState<DynamicSearchParameters>, _>(|| {
+        SearchState::from(page_state.search_params.clone())
+    });
     let total = use_state_eq(|| None);
     let pagination = use_pagination(*total, || page_state.pagination);
     let state = use_state_eq(UseAsyncState::default);
@@ -117,7 +120,7 @@ pub fn packages_search(props: &PackageSearchProperties) -> Html {
         page_state,
         PageState {
             pagination: **pagination,
-            search_params: (*search_params).clone(),
+            search_params: (*search_params).clone().into(),
         },
     );
 

--- a/spog/ui/crates/components/src/sbom/search.rs
+++ b/spog/ui/crates/components/src/sbom/search.rs
@@ -16,7 +16,7 @@ use yew_more_hooks::prelude::*;
 
 #[derive(PartialEq, Properties)]
 pub struct SbomSearchControlsProperties {
-    pub search_params: UseReducerHandle<SearchMode<DynamicSearchParameters>>,
+    pub search_params: UseReducerHandle<SearchState<DynamicSearchParameters>>,
 }
 
 #[function_component(SbomSearchControls)]
@@ -36,7 +36,7 @@ pub fn sbom_search_controls(props: &SbomSearchControlsProperties) -> Html {
 
 #[hook]
 pub fn use_sbom_search<S>(
-    search_params: UseReducerHandle<SearchMode<DynamicSearchParameters>>,
+    search_params: UseReducerHandle<SearchState<DynamicSearchParameters>>,
     pagination: UsePagination,
     callback: Callback<UseAsyncHandleDeps<SearchResult<Rc<Vec<SbomSummary>>>, String>>,
     f: S,
@@ -80,7 +80,7 @@ pub struct SbomSearchProperties {
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 struct PageState {
     pagination: PaginationControl,
-    search_params: SearchMode<DynamicSearchParameters>,
+    search_params: HistorySearchState<DynamicSearchParameters>,
 }
 
 #[function_component(SbomSearch)]
@@ -89,11 +89,14 @@ pub fn sbom_search(props: &SbomSearchProperties) -> Html {
         search_params: match props.query.as_ref().filter(|s| !s.is_empty()) {
             Some(terms) => SearchMode::Complex(terms.clone()),
             None => Default::default(),
-        },
+        }
+        .into(),
         ..Default::default()
     });
 
-    let search_params = use_reducer_eq::<SearchMode<DynamicSearchParameters>, _>(|| page_state.search_params.clone());
+    let search_params = use_reducer_eq::<SearchState<DynamicSearchParameters>, _>(|| {
+        SearchState::from(page_state.search_params.clone())
+    });
     let total = use_state_eq(|| None);
     let pagination = use_pagination(*total, || page_state.pagination);
     let state = use_state_eq(UseAsyncState::default);
@@ -121,7 +124,7 @@ pub fn sbom_search(props: &SbomSearchProperties) -> Html {
         page_state,
         PageState {
             pagination: **pagination,
-            search_params: (*search_params).clone(),
+            search_params: (*search_params).clone().into(),
         },
     );
 

--- a/spog/ui/crates/components/src/search/simple.rs
+++ b/spog/ui/crates/components/src/search/simple.rs
@@ -2,21 +2,22 @@ use crate::search::DynamicSearchParameters;
 use patternfly_yew::prelude::*;
 use spog_ui_common::utils::search::*;
 use std::collections::HashSet;
+use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 use yew::html::{ChildrenRenderer, IntoPropValue};
 use yew::prelude::*;
 use yew::virtual_dom::VNode;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SearchDefaults(pub Vec<DefaultEntry>);
 
 impl SearchDefaults {
-    pub fn apply_defaults<T>(self, state: &mut SearchMode<T>)
+    pub fn apply_defaults<T>(self, mode: &mut SearchMode<T>)
     where
         T: ToFilterExpression + SimpleProperties<Defaults = SearchDefaults> + Default + Clone,
     {
-        if let SearchMode::Simple(state) = state {
-            state.apply_defaults(self);
+        if let SearchMode::Simple(mode) = mode {
+            mode.apply_defaults(self);
         }
     }
 }
@@ -133,12 +134,12 @@ impl SearchOption {
     }
 }
 
-fn search_set<F>(search: UseReducerHandle<SearchMode<DynamicSearchParameters>>, f: F) -> Callback<bool>
+fn search_set<F>(search: UseReducerHandle<SearchState<DynamicSearchParameters>>, f: F) -> Callback<bool>
 where
     F: Fn(&mut DynamicSearchParameters, bool) + 'static,
 {
     Callback::from(move |state| {
-        if let SearchMode::Simple(simple) = &*search {
+        if let SearchMode::Simple(simple) = &**search {
             let mut simple = simple.clone();
             f(&mut simple, state);
             search.dispatch(SearchModeAction::SetSimple(simple));
@@ -147,59 +148,174 @@ where
 }
 
 pub enum SearchModeAction {
+    /// Set new search terms for either complex or simple mode
     SetTerms(String),
+    /// When in simple mode, set new search terms
     SetSimpleTerms(Vec<String>),
+    /// Apply the defaults, if no user interaction has taken place yet
     ApplyDefault(SearchDefaults),
     /// Clear the search, keeping the same search mode
     Clear,
+    /// Set complex mode, with provided query
     SetComplex(String),
-    SetSimpleSort((String, Order)),
+    /// Set simple mode, with provided state
     SetSimple(DynamicSearchParameters),
+    /// When in simple mode, set sort order
+    SetSimpleSort((String, Order)),
 }
 
-impl Reducible for SearchMode<DynamicSearchParameters> {
+impl Reducible for SearchState<DynamicSearchParameters> {
     type Action = SearchModeAction;
 
     fn reduce(self: Rc<Self>, action: Self::Action) -> Rc<Self> {
         match action {
-            Self::Action::SetTerms(terms) => match (*self).clone() {
-                SearchMode::Complex(_) => Rc::new(SearchMode::Complex(terms)),
-                SearchMode::Simple(mut s) => {
+            Self::Action::SetTerms(terms) => Rc::new(self.update(|mode| match mode {
+                SearchMode::Complex(_) => SearchMode::Complex(terms),
+                SearchMode::Simple(s) => {
+                    let mut s = s.clone();
                     *s.terms_mut() = terms.split(' ').map(|s| s.to_string()).collect();
-                    Rc::new(SearchMode::Simple(s))
+                    SearchMode::Simple(s)
                 }
-            },
+            })),
             Self::Action::ApplyDefault(defaults) => {
                 let mut new = (*self).clone();
-                defaults.apply_defaults(&mut new);
+                new.defaults = Some(defaults.clone());
+                if !new.modified {
+                    defaults.apply_defaults(&mut new);
+                }
                 Rc::new(new)
             }
-            Self::Action::Clear => match *self {
-                SearchMode::Simple(_) => Rc::new(SearchMode::Simple(DynamicSearchParameters::default())),
-                SearchMode::Complex(_) => Rc::new(SearchMode::Complex(String::new())),
-            },
-            Self::Action::SetComplex(terms) => Rc::new(SearchMode::Complex(terms)),
-            Self::Action::SetSimple(t) => Rc::new(SearchMode::Simple(t)),
-            Self::Action::SetSimpleSort(sort_by) => match &*self {
-                Self::Complex(_) => self,
-                Self::Simple(s) => {
+            Self::Action::Clear => {
+                let mut new = self.update(|mode| mode.reset()).unmodified();
+                if let Some(defaults) = self.defaults.clone() {
+                    defaults.apply_defaults(&mut new.mode);
+                }
+                Rc::new(new)
+            }
+            Self::Action::SetComplex(terms) => Rc::new(self.replace(SearchMode::Complex(terms))),
+            Self::Action::SetSimple(t) => Rc::new(self.replace(SearchMode::Simple(t))),
+            Self::Action::SetSimpleSort(sort_by) => Rc::new(self.update(|mode| match mode {
+                SearchMode::Complex(_) => mode.clone(),
+                SearchMode::Simple(s) => {
                     let mut s = (*s).clone();
                     s.set_sort_by(sort_by);
-                    Rc::new(Self::Simple(s))
+                    SearchMode::Simple(s)
                 }
-            },
-            Self::Action::SetSimpleTerms(terms) => match &*self {
-                Self::Complex(_) => self,
-                Self::Simple(s) => {
+            })),
+            Self::Action::SetSimpleTerms(terms) => Rc::new(self.update(|mode| match mode {
+                SearchMode::Complex(_) => mode.clone(),
+                SearchMode::Simple(s) => {
                     let mut s = (*s).clone();
                     (*s.terms_mut()) = terms;
-                    Rc::new(Self::Simple(s))
+                    SearchMode::Simple(s)
                 }
-            },
+            })),
         }
     }
 }
 
+/// The persisted search state
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct HistorySearchState<T> {
+    /// the current search mode and its options
+    pub mode: SearchMode<T>,
+    /// a flag indicating if the user modified the search options
+    pub modified: bool,
+}
+
+impl<T> From<HistorySearchState<T>> for SearchState<T> {
+    fn from(value: HistorySearchState<T>) -> Self {
+        Self {
+            mode: value.mode,
+            modified: value.modified,
+            defaults: None,
+        }
+    }
+}
+
+impl<T> From<SearchState<T>> for HistorySearchState<T> {
+    fn from(value: SearchState<T>) -> Self {
+        Self {
+            mode: value.mode,
+            modified: value.modified,
+        }
+    }
+}
+
+impl<T> From<SearchMode<T>> for HistorySearchState<T> {
+    fn from(mode: SearchMode<T>) -> Self {
+        Self { modified: false, mode }
+    }
+}
+
+/// Tracking the full search state
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SearchState<T> {
+    /// the current search mode and its options
+    pub mode: SearchMode<T>,
+    /// the registered defaults
+    pub defaults: Option<SearchDefaults>,
+    /// a flag indicating if the user modified the search options
+    pub modified: bool,
+}
+
+impl<T> SearchState<T> {
+    /// Mutate the current search state and mark as modified
+    pub fn update<F>(&self, f: F) -> Self
+    where
+        F: FnOnce(&SearchMode<T>) -> SearchMode<T>,
+    {
+        Self {
+            mode: f(&self.mode),
+            defaults: self.defaults.clone(),
+            modified: true,
+        }
+    }
+
+    /// Replace the current search mode and mark as modified
+    pub fn replace(&self, mode: SearchMode<T>) -> Self {
+        Self {
+            mode,
+            defaults: self.defaults.clone(),
+            modified: true,
+        }
+    }
+
+    /// mark the state as "unmodifed"
+    pub fn unmodified(mut self) -> Self {
+        self.modified = false;
+        self
+    }
+}
+
+impl<T> Deref for SearchState<T> {
+    type Target = SearchMode<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.mode
+    }
+}
+
+impl<T> DerefMut for SearchState<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.mode
+    }
+}
+
+impl<T> From<SearchMode<T>> for SearchState<T> {
+    fn from(mode: SearchMode<T>) -> Self {
+        Self {
+            mode,
+            defaults: None,
+            modified: false,
+        }
+    }
+}
+
+/// The mode the search is in.
+///
+/// * Complex: the user specifies a full search string
+/// * Simple: the user may choose from some options, and enter some search terms
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SearchMode<T> {
     Complex(String),
@@ -243,6 +359,14 @@ where
         *new.terms_mut() = new_terms;
         Self::Simple(new)
     }
+
+    /// Reset filters, but keep mode
+    pub fn reset(&self) -> Self {
+        match self {
+            Self::Complex(_) => Self::Complex(Default::default()),
+            Self::Simple(_) => Self::Simple(Default::default()),
+        }
+    }
 }
 
 impl<T> Default for SearchMode<T>
@@ -257,7 +381,7 @@ where
 #[derive(Properties)]
 pub struct SimpleSearchProperties {
     pub search: Rc<Search>,
-    pub search_params: UseReducerHandle<SearchMode<DynamicSearchParameters>>,
+    pub search_params: UseReducerHandle<SearchState<DynamicSearchParameters>>,
 }
 
 impl PartialEq for SimpleSearchProperties {
@@ -303,7 +427,7 @@ pub fn simple_search(props: &SimpleSearchProperties) -> Html {
     };
 
     let onclear = use_callback(props.search_params.clone(), |_, search_params| {
-        if let SearchMode::Simple(_) = &**search_params {
+        if let SearchMode::Simple(_) = &***search_params {
             search_params.dispatch(SearchModeAction::Clear);
         }
     });

--- a/spog/ui/src/console/mod.rs
+++ b/spog/ui/src/console/mod.rs
@@ -231,11 +231,11 @@ fn render(route: AppRoute, config: &spog_model::config::Configuration) -> Html {
             html!(<pages::PackageSearchPage {query} />)
         }
 
-        AppRoute::Packages(View::Content { id }) if config.features.dedicated_search => {
+        AppRoute::Packages(View::Content { id }) => {
             html!(<pages::Packages {id} />)
         }
 
-        AppRoute::Package { id } if config.features.dedicated_search => {
+        AppRoute::Package { id } => {
             let id = match id.is_empty() {
                 true => None,
                 false => Some(id),

--- a/spog/ui/src/pages/cve/result/mod.rs
+++ b/spog/ui/src/pages/cve/result/mod.rs
@@ -9,9 +9,8 @@ use patternfly_yew::prelude::*;
 use products::RelatedProducts;
 use spog_model::prelude::CveDetails;
 use spog_ui_backend::{use_backend, CveService};
-use spog_ui_components::{
-    async_state_renderer::async_content, cvss::Cvss3Label, editor::ReadonlyEditor, markdown::Markdown, time::Date,
-};
+use spog_ui_common::components::Markdown;
+use spog_ui_components::{async_state_renderer::async_content, cvss::Cvss3Label, editor::ReadonlyEditor, time::Date};
 use std::rc::Rc;
 use std::str::FromStr;
 use yew::prelude::*;

--- a/spog/ui/src/pages/cve/result/mod.rs
+++ b/spog/ui/src/pages/cve/result/mod.rs
@@ -10,8 +10,7 @@ use products::RelatedProducts;
 use spog_model::prelude::CveDetails;
 use spog_ui_backend::{use_backend, CveService};
 use spog_ui_components::{
-    async_state_renderer::async_content, common::Visible, cvss::Cvss3Label, editor::ReadonlyEditor, markdown::Markdown,
-    time::Date,
+    async_state_renderer::async_content, cvss::Cvss3Label, editor::ReadonlyEditor, markdown::Markdown, time::Date,
 };
 use std::rc::Rc;
 use std::str::FromStr;

--- a/spog/ui/src/pages/search.rs
+++ b/spog/ui/src/pages/search.rs
@@ -4,7 +4,6 @@ use patternfly_yew::prelude::*;
 use spog_ui_common::utils::count::count_tab_title;
 use spog_ui_components::{
     advisory::{use_advisory_search, AdvisoryResult, AdvisorySearchControls},
-    common::Visible,
     cve::{use_cve_search, CveResult, CveSearchControls},
     hooks::UseStandardSearch,
     packages::{use_package_search, PackagesResult},

--- a/spog/ui/src/pages/search.rs
+++ b/spog/ui/src/pages/search.rs
@@ -9,7 +9,7 @@ use spog_ui_components::{
     packages::{use_package_search, PackagesResult},
     pagination::PaginationWrapped,
     sbom::{use_sbom_search, SbomResult, SbomSearchControls},
-    search::{DynamicSearchParameters, SearchMode, SearchModeAction},
+    search::{DynamicSearchParameters, HistorySearchState, SearchModeAction, SearchState},
 };
 use std::ops::Deref;
 use trustification_api::search::SearchResult;
@@ -31,6 +31,7 @@ pub struct SearchProperties {
     pub terms: String,
 }
 
+/// The state of the page, stored in the history
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct PageState {
     pub terms: Vec<String>,
@@ -43,10 +44,11 @@ pub struct PageState {
     pub package: TabState,
 }
 
+/// The state of a single tab, stored in the history
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TabState {
     pub pagination: PaginationControl,
-    pub search_params: SearchMode<DynamicSearchParameters>,
+    pub search_params: HistorySearchState<DynamicSearchParameters>,
 }
 
 #[function_component(Search)]
@@ -160,23 +162,23 @@ pub fn search(props: &SearchProperties) -> Html {
             tab: *tab,
             advisory: TabState {
                 pagination: **advisory.pagination,
-                search_params: (*advisory.search_params).clone(),
+                search_params: (*advisory.search_params).clone().into(),
             },
             sbom: TabState {
                 pagination: **sbom.pagination,
-                search_params: (*sbom.search_params).clone(),
+                search_params: (*sbom.search_params).clone().into(),
             },
             sbom_by_dependency: TabState {
                 pagination: **sbom_by_dependency.pagination,
-                search_params: (*sbom_by_dependency.search_params).clone(),
+                search_params: (*sbom_by_dependency.search_params).clone().into(),
             },
             cve: TabState {
                 pagination: **cve.pagination,
-                search_params: (*cve.search_params).clone(),
+                search_params: (*cve.search_params).clone().into(),
             },
             package: TabState {
                 pagination: **package.pagination,
-                search_params: (*package.search_params).clone(),
+                search_params: (*package.search_params).clone().into(),
             },
         },
     );
@@ -323,16 +325,16 @@ fn use_unified_search<R, IS, IP, FH, H>(
 ) -> UseUnifiedSearch<R>
 where
     R: Clone + PartialEq + 'static,
-    IS: FnOnce(&PageState) -> SearchMode<DynamicSearchParameters>,
+    IS: FnOnce(&PageState) -> HistorySearchState<DynamicSearchParameters>,
     IP: FnOnce(&PageState) -> PaginationControl,
     FH: FnOnce(
-        UseReducerHandle<SearchMode<DynamicSearchParameters>>,
+        UseReducerHandle<SearchState<DynamicSearchParameters>>,
         UsePagination,
         Callback<UseAsyncHandleDeps<SearchResult<R>, String>>,
     ) -> H,
     H: Hook<Output = UseStandardSearch>,
 {
-    let search_params = use_reducer_eq::<SearchMode<DynamicSearchParameters>, _>(|| init_search(page_state));
+    let search_params = use_reducer_eq::<SearchState<DynamicSearchParameters>, _>(|| init_search(page_state).into());
     let state = use_state_eq(UseAsyncState::default);
     let callback = use_callback(
         state.clone(),


### PR DESCRIPTION
So far, we did store the page state in the browser history. However,
when unpacking it (on hitting "back"), the defaults did override any
selection made by the user so far.

This change fixes this by tracking both the "modification" state as well
as the "defaults" which need to get applied. Also when the user
resets the search.