### PR TITLE
feat: add devmode to upload and delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7543,6 +7543,7 @@ dependencies = [
  "tokio",
  "trustification-auth",
  "trustification-common",
+ "trustification-infrastructure",
  "url",
  "urlencoding",
  "vexination-model",

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -20,5 +20,6 @@ regex = "1.9.5"
 url = { version = "2.3.1", features = ["serde"] }
 trustification-auth = { path = "../auth" }
 trustification-common = { path = "../common" }
+trustification-infrastructure = { path = "../infrastructure" }
 bombastic-model = { path = "../bombastic/model" }
 vexination-model = { path = "../vexination/model" }

--- a/admin/src/upload.rs
+++ b/admin/src/upload.rs
@@ -1,10 +1,13 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use reqwest::header::HeaderMap;
 use reqwest::StatusCode;
 use trustification_auth::client::OpenIdTokenProviderConfigArguments;
 use trustification_auth::client::TokenInjector;
 use trustification_auth::client::TokenProvider;
+use trustification_infrastructure::endpoint;
+use trustification_infrastructure::endpoint::Endpoint;
 use url::Url;
 
 /// Uplaod documents to trustification
@@ -27,29 +30,38 @@ impl Upload {
 #[command(about = "Upload documents to Bombastic", args_conflicts_with_subcommands = true)]
 pub struct BombasticUpload {
     /// URL of the Bombastic instance
-    #[arg(short = 'u', long = "url", default_value = "http://localhost:8080/api/v1/sbom")]
+    #[arg(short = 'u', long = "url", default_value_t = endpoint::Bombastic::url())]
     pub url: Url,
 
     /// Path to SBOM file
     #[arg(short = 'f', long = "file")]
     pub file: PathBuf,
 
+    /// Additional headers
+    #[arg(short = 'H', long = "header")]
+    pub headers: Option<Vec<String>>,
+
     /// OIDC parameters
     #[command(flatten)]
     pub oidc: OpenIdTokenProviderConfigArguments,
+
+    /// Development mode
+    #[arg(long = "devmode", default_value_t = false)]
+    pub devmode: bool,
 }
 
 impl BombasticUpload {
     pub async fn run(self) -> anyhow::Result<ExitCode> {
         let client = reqwest::Client::new();
-        let provider = self.oidc.clone().into_provider_or_devmode(false).await?;
+        let provider = self.oidc.clone().into_provider_or_devmode(self.devmode).await?;
 
         let data = std::fs::read(&self.file)?;
         upload(
-            &self.url,
+            &format!("{}api/v1/sbom", self.url),
             &client,
             &provider,
             data,
+            self.headers.unwrap_or_default(),
             self.file.file_name().map(|s| s.to_string_lossy().to_string()),
         )
         .await?;
@@ -61,36 +73,53 @@ impl BombasticUpload {
 #[derive(clap::Args, Debug)]
 #[command(about = "Upload documents to Vexination", args_conflicts_with_subcommands = true)]
 pub struct VexinationUpload {
-    /// URL of the Bombastic instance
-    #[arg(short = 'u', long = "url", default_value = "http://localhost:8080/api/v1/vex")]
+    /// URL of the Vexination instance
+    #[arg(short = 'u', long = "url", default_value_t = endpoint::Vexination::url())]
     pub url: Url,
 
     /// Path to VEX file
     #[arg(short = 'f', long = "file")]
     pub file: PathBuf,
 
+    /// Additional headers
+    #[arg(short = 'H', long = "header")]
+    pub headers: Option<Vec<String>>,
+
     /// OIDC parameters
     #[command(flatten)]
     pub oidc: OpenIdTokenProviderConfigArguments,
+
+    /// Development mode
+    #[arg(long = "devmode", default_value_t = false)]
+    pub devmode: bool,
 }
 
 impl VexinationUpload {
     pub async fn run(self) -> anyhow::Result<ExitCode> {
         let client = reqwest::Client::new();
-        let provider = self.oidc.clone().into_provider_or_devmode(false).await?;
+        let provider = self.oidc.clone().into_provider_or_devmode(self.devmode).await?;
 
         let data = std::fs::read(&self.file)?;
-        upload(&self.url, &client, &provider, data, None).await?;
+        upload(
+            &format!("{}api/v1/vex", self.url),
+            &client,
+            &provider,
+            data,
+            self.headers.unwrap_or_default(),
+            None,
+        )
+        .await?;
 
         Ok(ExitCode::SUCCESS)
     }
 }
 
 async fn upload(
-    url: &url::Url,
+    url: &str,
     client: &reqwest::Client,
     provider: &impl TokenProvider,
     data: Vec<u8>,
+    headers: Vec<String>,
     id: Option<String>,
 ) -> anyhow::Result<()> {
     let mut builder = client.post(url.clone());
@@ -98,6 +127,17 @@ async fn upload(
         builder = builder.query(&[("id", id)]);
     }
     builder = builder.inject_token(provider).await?;
+
+    let headers: HeaderMap = headers
+        .iter()
+        .map(|s| {
+            let mut parts = s.splitn(2, ':');
+            let key = parts.next().unwrap().trim();
+            let value = parts.next().unwrap().trim();
+            (key.parse().unwrap(), value.parse().unwrap())
+        })
+        .collect();
+    builder = builder.headers(headers);
     builder = builder.body(data);
 
     let r = builder.send().await?;

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -54,7 +54,7 @@ pub struct IndexConfig {
     pub sync_interval: humantime::Duration,
 
     /// Memory available to index writerl
-    #[arg(env = "INDEX_WRITER_MEMORY_BYTES", long = "index-writer-memory-bytes", default_value_t = ByteSize::mb(64))]
+    #[arg(env = "INDEX_WRITER_MEMORY_BYTES", long = "index-writer-memory-bytes", default_value_t = ByteSize::mb(256))]
     pub index_writer_memory_bytes: ByteSize,
 
     /// Synchronization interval for index persistence.


### PR DESCRIPTION
* Add devmode to simplify usage of admin upload and admin delete
* Add ability to pass custom headers when uploading
* Bump default memory available to index when running locally


@ctron just a few convenience changes as I was trying out the quarkus sbom/vex data