### PR TITLE
refactor: some package index improvements

### DIFF
--- a/bombastic/index/src/packages/mod.rs
+++ b/bombastic/index/src/packages/mod.rs
@@ -276,6 +276,9 @@ impl Index {
                 create_date_query(&self.schema, self.fields.indexed_timestamp, ordered),
                 CREATED_WEIGHT,
             ),
+
+            PackageInfo::Name(value) => self.create_string_query(&[self.fields.purl_name], value),
+            PackageInfo::Namespace(value) => self.create_string_query(&[self.fields.purl_namespace], value),
         }
     }
 

--- a/bombastic/model/src/packages/mod.rs
+++ b/bombastic/model/src/packages/mod.rs
@@ -15,6 +15,10 @@ pub enum PackageInfo<'a> {
     Type(&'a str),
     #[search(default)]
     Version(Primary<'a>),
+    #[search(scope)]
+    Name(Primary<'a>),
+    #[search(scope)]
+    Namespace(Primary<'a>),
     #[search(sort)]
     Created(Ordered<time::OffsetDateTime>),
     #[search(scope)]

--- a/spog/api/src/endpoints/package.rs
+++ b/spog/api/src/endpoints/package.rs
@@ -8,7 +8,6 @@ use actix_web::{
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use spog_model::package_info::{PackageInfo, V11yRef};
 use spog_model::prelude::{PackageProductDetails, ProductRelatedToPackage};
-use spog_model::search::PackageInfoSummary;
 use std::sync::Arc;
 use trustification_api::search::{SearchOptions, SearchResult};
 use trustification_auth::authenticator::Authenticator;
@@ -56,18 +55,18 @@ pub async fn package_search(
             &access_token,
         )
         .await?;
-    let mut m: Vec<PackageInfoSummary> = Vec::with_capacity(data.result.len());
+    let mut m: Vec<PackageInfo> = Vec::with_capacity(data.result.len());
     for item in data.result {
         let item = item.document;
-        m.push(PackageInfoSummary {
+        m.push(PackageInfo {
             purl: item.purl.into(),
-            name: item.name,
-            version: item.purl_version,
-            package_type: item.purl_type,
-            description: item.description,
-            supplier: item.supplier,
-            href: "".to_string(),
-            sbom: "".to_string(),
+            name: item.purl_name.into(),
+            namespace: item.purl_namespace.into(),
+            version: item.purl_version.into(),
+            package_type: item.purl_type.into(),
+            supplier: item.supplier.into(),
+            href: None,
+            sbom: None,
             vulnerabilities: vec![],
         });
     }
@@ -150,10 +149,10 @@ pub async fn package_related_products(path: web::Path<String>) -> actix_web::Res
 fn make_mock_data() -> Vec<PackageInfo> {
     let packages = vec![
         PackageInfo {
-            name: "io.quarkus.arc:arc".to_string().into(),
+            name: ":arc".to_string().into(),
+            namespace: "io.quarkus.arc".to_string().into(),
             version: "2.16.2.Final".to_string().into(),
             package_type: "maven".to_string().into(),
-            description: "case one".to_string().into(),
             purl: "pkg:maven/io.quarkus.arc/arc@2.16.2.Final?type=jar".to_string().into(),
             href: Some(format!(
                 "/api/package?purl={}",
@@ -188,10 +187,10 @@ fn make_mock_data() -> Vec<PackageInfo> {
             ],
         },
         PackageInfo {
-            name: "redhat:openssl".to_string().into(),
+            name: "openssl".to_string().into(),
+            namespace: "redhat".to_string().into(),
             version: "1.1.1k-7.el8_6".to_string().into(),
             package_type: "rpm".to_string().into(),
-            description: "case two".to_string().into(),
             purl: Some("pkg:rpm/redhat/openssl@1.1.1k-7.el8_6".to_string()),
             href: Some(format!(
                 "/api/package?purl={}",

--- a/spog/model/src/package_info.rs
+++ b/spog/model/src/package_info.rs
@@ -5,7 +5,10 @@ use utoipa::ToSchema;
 #[derive(Clone, Debug, PartialEq, Eq, ToSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[schema(example = json!(PackageInfo {
-    name: Some("redhat:openssl".to_string()), version: Some("1.1.1k-7.el8_6".to_string()), description: Some("show case".to_string()),package_type: Some("rpm".to_string()),
+    name: Some("redhat:openssl".to_string()),
+    namespace: Some("redhat".to_string()),
+    version: Some("1.1.1k-7.el8_6".to_string()),
+    package_type: Some("rpm".to_string()),
     purl: Some("pkg:rpm/redhat/openssl@1.1.1k-7.el8_6".to_string()), href: Some(format!("/api/package?purl={}", &urlencoding::encode("pkg:rpm/redhat/openssl@1.1.1k-7.el8_6"))),
     sbom: Some(format!("/api/package/sbom?purl={}", &urlencoding::encode("pkg:rpm/redhat/openssl@1.1.1k-7.el8_6"))),
     supplier: "Organization: Red Hat".to_string().into(),
@@ -19,9 +22,9 @@ pub struct PackageInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
+    pub namespace: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    pub version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/spog/model/src/search.rs
+++ b/spog/model/src/search.rs
@@ -1,4 +1,3 @@
-use crate::package_info::V11yRef;
 use serde_json::Value;
 use std::collections::HashMap;
 use time::OffsetDateTime;
@@ -68,25 +67,5 @@ impl SbomSummary {
             true => None,
             false => Some(terms.join(" OR ")),
         }
-    }
-}
-
-#[derive(utoipa::ToSchema, serde::Deserialize, serde::Serialize, Debug, PartialEq, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct PackageInfoSummary {
-    pub name: String,
-    pub version: String,
-    pub package_type: String,
-    pub purl: Option<String>,
-    pub description: String,
-    pub supplier: String,
-    pub href: String,
-    pub sbom: String,
-    pub vulnerabilities: Vec<V11yRef>,
-}
-
-impl PackageInfoSummary {
-    pub fn get_count_v11y(&self) -> usize {
-        self.vulnerabilities.len()
     }
 }

--- a/spog/ui/crates/backend/src/package_info.rs
+++ b/spog/ui/crates/backend/src/package_info.rs
@@ -22,7 +22,7 @@ impl PackageInfoService {
         }
     }
 
-    pub async fn get(&self, id: impl AsRef<str>) -> Result<PackageInfoSummary, ApiError> {
+    pub async fn get(&self, id: impl AsRef<str>) -> Result<PackageInfo, ApiError> {
         let url = self.backend.join(
             Endpoint::Api,
             &format!("/api/v1/package/{id}", id = urlencoding::encode(id.as_ref())),
@@ -61,7 +61,7 @@ impl PackageInfoService {
         &self,
         q: &str,
         options: &SearchParameters,
-    ) -> Result<SearchResult<Vec<PackageInfoSummary>>, ApiError> {
+    ) -> Result<SearchResult<Vec<PackageInfo>>, ApiError> {
         let response = self
             .client
             .get(self.backend.join(Endpoint::Api, "/api/v1/package/search")?)

--- a/spog/ui/crates/components/src/packages/search.rs
+++ b/spog/ui/crates/components/src/packages/search.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use bombastic_model::packages::PackageInfo;
 use patternfly_yew::prelude::*;
-use spog_model::search::PackageInfoSummary;
 use spog_ui_backend::PackageInfoService;
 use spog_ui_common::utils::pagination_to_offset;
 use spog_ui_utils::config::use_config;
@@ -41,7 +40,7 @@ pub fn packages_search_controls(props: &PackageSearchControlsProperties) -> Html
 pub fn use_package_search(
     search_params: UseReducerHandle<SearchState<DynamicSearchParameters>>,
     pagination: UsePagination,
-    callback: Callback<UseAsyncHandleDeps<SearchResult<Rc<Vec<PackageInfoSummary>>>, String>>,
+    callback: Callback<UseAsyncHandleDeps<SearchResult<Rc<Vec<spog_model::prelude::PackageInfo>>>, String>>,
 ) -> UseStandardSearch {
     let config = use_config();
     use_generic_search::<PackageInfo, _, _, _, _>(

--- a/spog/ui/src/pages/package/result/vulnerabilities.rs
+++ b/spog/ui/src/pages/package/result/vulnerabilities.rs
@@ -1,9 +1,6 @@
 use futures::future::try_join_all;
 use patternfly_yew::prelude::*;
-use spog_model::{
-    prelude::{CveSearchDocument, V11yRef},
-    search::PackageInfoSummary,
-};
+use spog_model::prelude::{CveSearchDocument, PackageInfo, V11yRef};
 use spog_ui_backend::{use_backend, CveService};
 use spog_ui_common::{utils::cvss::Cvss, utils::time::date, utils::OrNone};
 use spog_ui_components::{async_state_renderer::async_content, cvss::CvssScore, pagination::PaginationWrapped};
@@ -64,7 +61,7 @@ impl TableEntryRenderer<Column> for TableData {
 
 #[derive(PartialEq, Properties)]
 pub struct VulnerabilitiesProperties {
-    pub package: Rc<PackageInfoSummary>,
+    pub package: Rc<PackageInfo>,
 }
 
 #[function_component(Vulnerabilities)]


### PR DESCRIPTION
* Allow searching explicitly for "namespace" and "name" of the PURL
* Drop the `PackageInfoSummary` structure, it seemed like a copy
* Drop the "description" field, I don't think we will ever have this
