### PR TITLE
fix: parameters must be passed as string

### DIFF
--- a/deploy/openshift/parameters.yaml
+++ b/deploy/openshift/parameters.yaml
@@ -90,7 +90,7 @@ parameters:
 - name: GUAC_GQL_RESOURCES
   required: true
 - name: GUAC_GQL_AFFINITY
-  value: {}
+  value: "{}"
 - name: BOMBASTIC_COLLECTOR_RESOURCES
   required: true
 - name: VEXINATION_COLLECTOR_RESOURCES

--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -2323,7 +2323,7 @@ parameters:
 - name: GUAC_GQL_RESOURCES
   required: true
 - name: GUAC_GQL_AFFINITY
-  value: {}
+  value: "{}"
 - name: BOMBASTIC_COLLECTOR_RESOURCES
   required: true
 - name: VEXINATION_COLLECTOR_RESOURCES


### PR DESCRIPTION
Unquoting is handled by double curly for non-string types.