### PR TITLE
fix: get host and port from admin db

### DIFF
--- a/deploy/k8s/chart/templates/guac/graphql/030-Deployment.yaml
+++ b/deploy/k8s/chart/templates/guac/graphql/030-Deployment.yaml
@@ -70,12 +70,12 @@ spec:
             - name: PGHOST
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: guac-admin-db
                   key: "db.host"
             - name: PGPORT
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: guac-admin-db
                   key: "db.port"
             - name: DB_NAME
               valueFrom:


### PR DESCRIPTION
This makes it easier to maintain the guac-user-db secret not having to know the hostname of an RDS instance.