### PR TITLE
fix: always reindex bombastic at startup

### DIFF
--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -523,6 +523,8 @@ objects:
                 - file
                 - --index-dir
                 - /data/index
+                - --reindex
+                - always
               env:
                 - name: RUST_LOG
                   value: ${LOG_LEVEL}

--- a/deploy/openshift/values.yaml
+++ b/deploy/openshift/values.yaml
@@ -41,7 +41,7 @@ bombastic:
     schedule: ${BOMBASTIC_COLLECTOR_SCHEDULE}
     resources: ${{BOMBASTIC_COLLECTOR_RESOURCES}}
   indexer:
-    reindex: false
+    reindex: true
     index_sync_interval: ${BOMBASTIC_INDEXER_INDEX_SYNC_INTERVAL}
     index_writer_memory_bytes: ${BOMBASTIC_INDEXER_INDEX_WRITER_MEMORY_BYTES}
     topics:


### PR DESCRIPTION
Deleting documents from bombastic will not delete entries from the packages index, because packages are unique and index does not keep relationship to the SBOM (since multiple SBOMs may contain the same package).

As a workaround, reindexing the bombastic index on startup will allow the package index to be rebuilt upon a restart from the SBOMs that exist in the archive.

@ctron @bxf12315 Any thoughts or concerns on this? Maybe it's possible to add some kind of 'ref-counting' of the package in a separate index field eventually?