### PR TITLE
refactor: replace custom truncation with ExpandableSection

### DIFF
--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -1497,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]
@@ -1873,13 +1873,14 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "patternfly-yew"
-version = "0.5.0-rc.1"
-source = "git+https://github.com/ctron/patternfly-yew?rev=30b31e36120d3efc609f84e21a2baa208905a4e9#30b31e36120d3efc609f84e21a2baa208905a4e9"
+version = "0.5.2"
+source = "git+https://github.com/ctron/patternfly-yew?rev=17abb02bbcd6dc698f39ea1b859d2f17fae32587#17abb02bbcd6dc698f39ea1b859d2f17fae32587"
 dependencies = [
  "chrono",
  "gloo-events 0.2.0",
  "gloo-timers 0.3.0",
  "gloo-utils 0.2.0",
+ "implicit-clone",
  "js-sys",
  "log",
  "num-traits",
@@ -2265,6 +2266,12 @@ checksum = "862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302"
 dependencies = [
  "xmlparser",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
 name = "rsa"
@@ -2731,7 +2738,7 @@ dependencies = [
  "gloo-storage 0.3.0",
  "gloo-utils 0.2.0",
  "humansize",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "js-sys",
  "log",
  "markdown",
@@ -2740,7 +2747,7 @@ dependencies = [
  "packageurl",
  "patternfly-yew",
  "reqwest",
- "roxmltree",
+ "roxmltree 0.19.0",
  "serde",
  "serde_json",
  "sikula",
@@ -2831,7 +2838,7 @@ dependencies = [
  "gloo-storage 0.3.0",
  "gloo-utils 0.2.0",
  "humansize",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "js-sys",
  "log",
  "markdown",
@@ -2839,7 +2846,7 @@ dependencies = [
  "packageurl",
  "patternfly-yew",
  "reqwest",
- "roxmltree",
+ "roxmltree 0.18.1",
  "serde",
  "serde_json",
  "spdx-rs",
@@ -2881,7 +2888,7 @@ dependencies = [
  "gloo-storage 0.3.0",
  "gloo-utils 0.2.0",
  "humansize",
- "itertools 0.11.0",
+ "itertools 0.12.0",
  "js-sys",
  "log",
  "monaco",
@@ -2889,7 +2896,7 @@ dependencies = [
  "packageurl",
  "patternfly-yew",
  "reqwest",
- "roxmltree",
+ "roxmltree 0.19.0",
  "serde",
  "serde_json",
  "sikula",
@@ -3801,9 +3808,9 @@ dependencies = [
 
 [[package]]
 name = "yew-oauth2"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcc3c7f8f63c2dac170317d08d5481611ecd070c6a16b38c6b8a001babaee2e"
+checksum = "0a027a8eb1818da6962bdfcb110b25390c9cb0d5d8a0696b24fd89f54e43e533"
 dependencies = [
  "async-trait",
  "gloo-storage 0.3.0",

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -22,7 +22,7 @@ gloo-net = "0.4.0"
 gloo-storage = "0.3.0"
 gloo-utils = { version = "0.2.0", features = ["serde"] }
 humansize = "2"
-itertools = "0.11"
+itertools = "0.12.0"
 js-sys = "0.3"
 log = "0.4"
 markdown = "1.0.0-alpha.11"
@@ -31,7 +31,7 @@ openidconnect = "3"
 packageurl = "0.3"
 patternfly-yew = { version = "0.5.0-alpha.3", features = ["icons-fab", "tree"] }
 reqwest = { version = "0.11", features = ["json"] }
-roxmltree = "0.18"
+roxmltree = "0.19"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 sikula = { version = "0.4.1", default-features = false, features = ["time"] }
@@ -49,7 +49,7 @@ yew-consent = "0.2"
 yew-hooks = "0.3"
 yew-more-hooks = "0.3.1"
 yew-nested-router = "0.4.0"
-yew-oauth2 = { version = "0.7.0", features = ["router", "openid"] }
+yew-oauth2 = { version = "0.8.0", features = ["router", "openid"] }
 
 bombastic-model = { path = "../../bombastic/model" }
 exhort-model = { path = "../../exhort/model" }
@@ -94,7 +94,7 @@ members = [
 #yew-more-hooks = { git = "https://github.com/ctron/yew-more-hooks", rev = "fc0af774aa925edcd5a544e562619ecb539942f8" }
 #yew-more-hooks = { path = "../../../yew-more-hooks" }
 
-patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "30b31e36120d3efc609f84e21a2baa208905a4e9" } # FIXME: awaiting release
+patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "17abb02bbcd6dc698f39ea1b859d2f17fae32587" } # FIXME: awaiting release
 #patternfly-yew = { path = "../../../patternfly-yew" }
 
 #analytics-next = { git = "https://github.com/ctron/analytics-next-rs", rev = "9c95122f4e6dc308c90b945bd0f1925faf7cb828" } # FIXME: awaiting release

--- a/spog/ui/crates/backend/Cargo.toml
+++ b/spog/ui/crates/backend/Cargo.toml
@@ -30,7 +30,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 yew = { version = "0.21", features = ["csr"] }
 yew-more-hooks = "0.3.0"
-yew-oauth2 = { version = "0.7.0", features = ["router", "openid"] }
+yew-oauth2 = { version = "0.8.0", features = ["router", "openid"] }
 
 bombastic-model = { path = "../../../../bombastic/model" }
 exhort-model = { path = "../../../../exhort/model" }

--- a/spog/ui/crates/common/Cargo.toml
+++ b/spog/ui/crates/common/Cargo.toml
@@ -15,13 +15,13 @@ gloo-net = "0.4.0"
 gloo-storage = "0.3.0"
 gloo-utils = { version = "0.2.0", features = ["serde"] }
 humansize = "2"
-itertools = "0.11"
+itertools = "0.12"
 js-sys = "0.3"
 log = "0.4"
 markdown = "1.0.0-alpha.11"
 openidconnect = "3"
 packageurl = "0.3"
-patternfly-yew = { version = "0.5.0-alpha.3", features = ["icons-fab", "tree"] }
+patternfly-yew = { version = "0.5.0", features = ["icons-fab", "tree"] }
 reqwest = { version = "0.11", features = ["json"] }
 roxmltree = "0.18"
 serde = { version = "1", features = ["derive", "rc"] }
@@ -39,7 +39,7 @@ yew-consent = "0.2"
 yew-hooks = "0.3"
 yew-more-hooks = "0.3.0"
 yew-nested-router = "0.4.0"
-yew-oauth2 = { version = "0.7.0", features = ["router", "openid"] }
+yew-oauth2 = { version = "0.8.0", features = ["router", "openid"] }
 
 spog-model = { path = "../../../model" }
 

--- a/spog/ui/crates/components/Cargo.toml
+++ b/spog/ui/crates/components/Cargo.toml
@@ -17,15 +17,15 @@ gloo-net = "0.4.0"
 gloo-storage = "0.3.0"
 gloo-utils = { version = "0.2.0", features = ["serde"] }
 humansize = "2"
-itertools = "0.11"
+itertools = "0.12"
 js-sys = "0.3"
 log = "0.4"
 monaco = { version = "0.5", features = ["yew-components"] }
 openidconnect = "3"
 packageurl = "0.3"
-patternfly-yew = { version = "0.5.0-alpha.3", features = ["icons-fab", "tree"] }
+patternfly-yew = { version = "0.5.0", features = ["icons-fab", "tree"] }
 reqwest = { version = "0.11", features = ["json"] }
-roxmltree = "0.18"
+roxmltree = "0.19"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 sikula = { version = "0.4.1", default-features = false, features = ["time"] }
@@ -43,7 +43,7 @@ yew-consent = "0.2"
 yew-hooks = "0.3"
 yew-more-hooks = "0.3.0"
 yew-nested-router = "0.4.0"
-yew-oauth2 = { version = "0.7.0", features = ["router", "openid"] }
+yew-oauth2 = { version = "0.8.0", features = ["router", "openid"] }
 
 spog-model = { path = "../../../model" }
 v11y-model = { path = "../../../../v11y/model" }

--- a/spog/ui/crates/utils/Cargo.toml
+++ b/spog/ui/crates/utils/Cargo.toml
@@ -9,7 +9,7 @@ analytics-next = "0.1"
 gloo-storage = "0.3"
 log ="0.4.20"
 openidconnect = "3"
-patternfly-yew = "0.5.0-alpha.3"
+patternfly-yew = "0.5.0"
 serde_json = "1"
 strum = { version = "0.25", features = ["derive"] }
 yew = "0.21"
@@ -17,7 +17,7 @@ yew-consent = "0.2"
 yew-hooks = "0.3.0"
 yew-more-hooks = "0.3"
 yew-nested-router = "0.4.0"
-yew-oauth2 = { version = "0.7.0", features = ["openid"] }
+yew-oauth2 = { version = "0.8.0", features = ["openid"] }
 
 spog-model = { path = "../../../model" }
 

--- a/spog/ui/src/pages/cve/result/mod.rs
+++ b/spog/ui/src/pages/cve/result/mod.rs
@@ -4,6 +4,7 @@ mod products;
 
 use crate::hooks::use_related_advisories;
 use advisories::RelatedAdvisories;
+use cve::common::Description;
 use cve::published::Metric;
 use patternfly_yew::prelude::*;
 use products::RelatedProducts;
@@ -17,15 +18,6 @@ use yew::prelude::*;
 use yew_more_hooks::hooks::use_page_state;
 use yew_more_hooks::{hooks::use_async_with_cloned_deps, prelude::UseAsyncState};
 use yew_oauth2::hook::use_latest_access_token;
-
-const CVE_DESCRIPTION_MAX_LENGTH: usize = 180;
-
-fn truncate(s: &str, max_chars: usize) -> &str {
-    match s.char_indices().nth(max_chars) {
-        None => s,
-        Some((idx, _)) => &s[..idx],
-    }
-}
 
 #[derive(PartialEq, Properties)]
 pub struct ResultViewProperties {
@@ -184,19 +176,34 @@ fn cvss3(metrics: &[Metric]) -> Html {
 }
 
 #[derive(PartialEq, Properties)]
+struct DescriptionsProperties {
+    pub descriptions: Vec<Description>,
+}
+
+#[function_component(Descriptions)]
+fn descriptions(props: &DescriptionsProperties) -> Html {
+    html!(
+        <ExpandableSection variant={ExpandableSectionVariant::Truncate}>
+            <Content>
+                { for props.descriptions.iter().map(|desc| {
+                    html!(
+                        <div lang={desc.language.clone()}>
+                            <Markdown content={Rc::new(desc.value.clone())} />
+                        </div>
+                    )
+                })}
+            </Content>
+        </ExpandableSection>
+    )
+}
+
+#[derive(PartialEq, Properties)]
 pub struct CveDetailsViewProperties {
     pub details: Rc<cve::Cve>,
 }
 
 #[function_component(CveDetailsView)]
 pub fn cve_details(props: &CveDetailsViewProperties) -> Html {
-    let show_more = use_state_eq(|| false);
-
-    let show_more_toggle = use_callback(show_more.clone(), |_, show_more| {
-        let current = **show_more;
-        show_more.set(!current);
-    });
-
     html!(
         <Grid gutter=true> {
             match &*props.details {
@@ -204,33 +211,7 @@ pub fn cve_details(props: &CveDetailsViewProperties) -> Html {
                     html!(
                         <>
                             <GridItem cols={[6.lg(), 8.md(), 12.all()]}>
-                                <Content>
-                                    {
-                                        if !*show_more && details.containers.cna.descriptions.iter()
-                                            .map(|e| e.value.len())
-                                            .sum::<usize>() > CVE_DESCRIPTION_MAX_LENGTH
-                                        {
-                                            html!(
-                                                <>
-                                                    {truncate(&details.containers.cna.descriptions[0].value, CVE_DESCRIPTION_MAX_LENGTH)}{"..."}
-                                                    <Button variant={ButtonVariant::Link} onclick={show_more_toggle}>{ "More" }</Button>
-                                                </>
-                                            )
-                                        } else {
-                                            html!(
-                                                <>
-                                                    { for details.containers.cna.descriptions.iter().map(|desc|{
-                                                        html!(
-                                                            <div lang={desc.language.clone()}>
-                                                                <Markdown content={Rc::new(desc.value.clone())} />
-                                                            </div>
-                                                        )
-                                                    })}
-                                                </>
-                                            )
-                                        }
-                                    }
-                                </Content>
+                                <Descriptions descriptions={details.containers.cna.descriptions.clone()} />
                             </GridItem>
 
                             <GridItem cols={[12]}>
@@ -250,33 +231,7 @@ pub fn cve_details(props: &CveDetailsViewProperties) -> Html {
                     html!(
                         <>
                             <GridItem cols={[6.lg(), 8.md(), 12.all()]}>
-                                <Content>
-                                    {
-                                        if !*show_more && details.containers.cna.rejected_reasons.iter()
-                                            .map(|e| e.value.len())
-                                            .sum::<usize>() > CVE_DESCRIPTION_MAX_LENGTH
-                                        {
-                                            html!(
-                                                <>
-                                                    {truncate(&details.containers.cna.rejected_reasons[0].value, CVE_DESCRIPTION_MAX_LENGTH)}{"..."}
-                                                    <Button variant={ButtonVariant::Link} onclick={show_more_toggle}>{ "More" }</Button>
-                                                </>
-                                            )
-                                        } else {
-                                            html!(
-                                                <>
-                                                    { for details.containers.cna.rejected_reasons.iter().map(|desc|{
-                                                        html!(
-                                                            <div lang={desc.language.clone()}>
-                                                                <Markdown content={Rc::new(desc.value.clone())} />
-                                                            </div>
-                                                        )
-                                                    })}
-                                                </>
-                                            )
-                                        }
-                                    }
-                                </Content>
+                                <Descriptions descriptions={details.containers.cna.rejected_reasons.clone()} />
                             </GridItem>
 
                             <GridItem cols={[12]}>


### PR DESCRIPTION
Came out of a discussion on patternfly-yew … while the implementation is correct (at least when ignoring grapheme clusters), the outcome is not optimal: 

* Markdown cannot be rendered
* Not all characters have the same width

That's we the "expandable section" using the "truncate" variants seems like the better approach. It will truncate after 3 lines. Which gives a more stable visual result.