### PR TITLE
refactor: perform lowercase search

### DIFF
--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -978,8 +978,14 @@ pub fn create_string_query(field: Field, primary: &Primary<'_>) -> Box<dyn Query
 /// Convert a sikula primary to a tantivy query for text fields
 pub fn create_text_query(field: Field, primary: &Primary<'_>) -> Box<dyn Query> {
     match primary {
-        Primary::Equal(value) => Box::new(TermQuery::new(Term::from_field_text(field, value), Default::default())),
-        Primary::Partial(value) => Box::new(TermQuery::new(Term::from_field_text(field, value), Default::default())),
+        Primary::Equal(value) => Box::new(TermQuery::new(
+            Term::from_field_text(field, &value.to_lowercase()),
+            Default::default(),
+        )),
+        Primary::Partial(value) => Box::new(TermQuery::new(
+            Term::from_field_text(field, &value.to_lowercase()),
+            Default::default(),
+        )),
     }
 }
 

--- a/spog/api/src/endpoints/cve.rs
+++ b/spog/api/src/endpoints/cve.rs
@@ -18,7 +18,7 @@ use spog_model::{
 };
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
-use tracing::instrument;
+use tracing::{info_span, instrument, Instrument};
 use trustification_api::search::{SearchOptions, SearchResult};
 use trustification_auth::{
     authenticator::Authenticator,
@@ -181,7 +181,7 @@ where
 
     for id in advisory_ids {
         let stream = app.get_vex(&id, &provider).await?;
-        let x: BytesMut = stream.try_collect().await?;
+        let x: BytesMut = stream.try_collect().instrument(info_span!("receive vex", id)).await?;
 
         let csaf: Csaf = serde_json::from_slice(&x)?;
         let relationships = RelationshipsCache::new(&csaf);

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -1051,6 +1051,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_ngrams_scope() {
+        assert_search(|index| {
+            let result = search(&index, "openssl in:title");
+            assert_eq!(result.0.len(), 2);
+
+            let result = search(&index, "open in:title");
+            assert_eq!(result.0.len(), 2);
+
+            let result = search(&index, "ssl in:title");
+            assert_eq!(result.0.len(), 2);
+        });
+    }
+
+    #[tokio::test]
+    async fn test_ngrams_nocase() {
+        assert_search(|index| {
+            let result = search(&index, "Openssl in:title");
+            assert_eq!(result.0.len(), 2);
+
+            let result = search(&index, "Open in:title");
+            assert_eq!(result.0.len(), 2);
+
+            let result = search(&index, "SSL in:title");
+            assert_eq!(result.0.len(), 2);
+        });
+    }
+
+    #[tokio::test]
     async fn test_metadata() {
         let now = OffsetDateTime::now_utc();
         assert_search(|index| {


### PR DESCRIPTION
ngrams already get converted to lowercase. That's why I think it doesn't
make sense allowing uppercase characters. But instead lowercase the
search terms too, so that we can get a match.

This also means a different to other (string) fields, where we search
for string data, not "text". Those string fields don't use the ngram
mode.