### PR TITLE
task: set the Github repository code configurable

### DIFF
--- a/spog/api/src/config/default.yaml
+++ b/spog/api/src/config/default.yaml
@@ -7,6 +7,7 @@ global:
   supportUrl: https://github.com/trustification/trustification/issues
   supportCaseUrl: https://github.com/trustification/trustification/issues
   supportCaseLabel: "Open a support case"
+  showGithubLink: true
 
 bombastic:
 

--- a/spog/model/schema/config.json
+++ b/spog/model/schema/config.json
@@ -55,7 +55,8 @@
         "productName": null,
         "supportCaseLabel": null,
         "supportCaseUrl": null,
-        "supportUrl": null
+        "supportUrl": null,
+        "downstream": false
       },
       "allOf": [
         {
@@ -410,6 +411,12 @@
             "null"
           ],
           "format": "uri"
+        },
+        "downstream": {
+          "default": false,
+          "type": [
+            "boolean"
+          ]
         }
       }
     },

--- a/spog/model/schema/config.json
+++ b/spog/model/schema/config.json
@@ -56,7 +56,7 @@
         "supportCaseLabel": null,
         "supportCaseUrl": null,
         "supportUrl": null,
-        "downstream": false
+        "showGithubLink": true
       },
       "allOf": [
         {
@@ -412,8 +412,8 @@
           ],
           "format": "uri"
         },
-        "downstream": {
-          "default": false,
+        "showGithubLink": {
+          "default": true,
           "type": [
             "boolean"
           ]

--- a/spog/model/schema/config.json
+++ b/spog/model/schema/config.json
@@ -413,7 +413,7 @@
           "format": "uri"
         },
         "showGithubLink": {
-          "default": true,
+          "default": false,
           "type": [
             "boolean"
           ]

--- a/spog/model/src/config.rs
+++ b/spog/model/src/config.rs
@@ -106,6 +106,9 @@ pub struct Global {
 
     #[serde(default)]
     pub error_image_src: Option<String>,
+
+    #[serde(default)]
+    pub downstream: bool,
 }
 
 pub const DEFAULT_BRAND_SRC: &str = "assets/brand/trustification_logo_hori_reverse.svg";

--- a/spog/model/src/config.rs
+++ b/spog/model/src/config.rs
@@ -108,7 +108,7 @@ pub struct Global {
     pub error_image_src: Option<String>,
 
     #[serde(default)]
-    pub downstream: bool,
+    pub show_github_link: bool,
 }
 
 pub const DEFAULT_BRAND_SRC: &str = "assets/brand/trustification_logo_hori_reverse.svg";

--- a/spog/ui/src/console/mod.rs
+++ b/spog/ui/src/console/mod.rs
@@ -121,7 +121,7 @@ fn authenticated_page(props: &ChildrenProperties) -> Html {
         <Toolbar>
             <ToolbarContent>
                 <ToolbarItem modifiers={[ToolbarElementModifier::Right]}>
-                    if !config.global.downstream {
+                    if config.global.show_github_link {
                         <Button icon={Icon::Github} onclick={callback_github} variant={ButtonVariant::Plain} />
                     }
                     <Dropdown

--- a/spog/ui/src/console/mod.rs
+++ b/spog/ui/src/console/mod.rs
@@ -121,7 +121,9 @@ fn authenticated_page(props: &ChildrenProperties) -> Html {
         <Toolbar>
             <ToolbarContent>
                 <ToolbarItem modifiers={[ToolbarElementModifier::Right]}>
-                    <Button icon={Icon::Github} onclick={callback_github} variant={ButtonVariant::Plain} />
+                    if !config.global.downstream {
+                        <Button icon={Icon::Github} onclick={callback_github} variant={ButtonVariant::Plain} />
+                    }
                     <Dropdown
                         position={Position::Right}
                         variant={MenuToggleVariant::Plain}


### PR DESCRIPTION
*Suggestion: remove the Github (source code link) from the downstream distribution.*

The mockups don't have the Github link and although useful in upstream, I value not to show everything on downstream (just a personal opinion). Feel free to reject this PR.

- This PR adds a new config value `downstream` to be re-used at any part of the UI