### PR TITLE
fix: allow navigating to the scanner without reloading the page

### DIFF
--- a/container_files/Containerfile.services
+++ b/container_files/Containerfile.services
@@ -22,11 +22,11 @@ RUN TAG=$tag cargo build -p trust --release
 
 FROM registry.access.redhat.com/ubi9/ubi:latest as frontendbuilder
 
-ARG RUST_VERSION="1.72.1"
+ARG RUST_VERSION="1.74.0"
 ARG SASS_VERSION="1.69.5"
 ARG WASM_PACK_VERSION="0.12.1"
 ARG WASM_BINDGEN_VERSION="0.2.88"
-ARG TRUNK_VERSION="0.17.15"
+ARG TRUNK_VERSION="0.17.16"
 
 RUN dnf -y install nodejs git gcc
 

--- a/spog/api/src/config/default.yaml
+++ b/spog/api/src/config/default.yaml
@@ -496,7 +496,7 @@ landingPage:
               <a
                 class="pf-v5-c-button pf-m-primary pf-m-display-lg"
                 type="button"
-                href="/scanner"
+                onclick="window.wasmBindings.spogNavigateTo('/scanner'); return false;"
               >Scan SBOM</a>
             </div>
           </div>

--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -2734,6 +2734,7 @@ dependencies = [
  "exhort-model",
  "futures",
  "gloo-events 0.2.0",
+ "gloo-history 0.2.0",
  "gloo-net 0.4.0",
  "gloo-storage 0.3.0",
  "gloo-utils 0.2.0",

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -18,6 +18,7 @@ cve = "0.2"
 cvss = { version = "2", features = ["serde"] }
 cyclonedx-bom = "0.4"
 gloo-events = "0.2"
+gloo-history = "0.2"
 gloo-net = "0.4.0"
 gloo-storage = "0.3.0"
 gloo-utils = { version = "0.2.0", features = ["serde"] }

--- a/spog/ui/README.md
+++ b/spog/ui/README.md
@@ -8,13 +8,13 @@
 
 ```shell
 rustup target add wasm32-unknown-unknown
-cargo install trunk-ng
 cargo binstall trunk-ng # if you have `cargo-binstall` installed
+cargo install trunk-ng # or, otherwise
 ```
 
 > [!NOTE]
-> `trunk-ng` is a fork of `trunk`. Both should work at the moment, but `trunk-ng` has a bunch of fixes that `trunk` has
-> not.
+> `trunk-ng` is a fork of `trunk`. However, trunk-ng has additional features that we require. Trunk-ng version 0.17.16
+> or newer is required.
 
 ### Project
 

--- a/spog/ui/src/export.rs
+++ b/spog/ui/src/export.rs
@@ -1,0 +1,8 @@
+use gloo_history::History;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+/// trigger the router to navigate to some targets
+#[wasm_bindgen(js_name = spogNavigateTo)]
+pub fn navigate_to(path: &str) {
+    gloo_history::BrowserHistory::new().push(path)
+}

--- a/spog/ui/src/main.rs
+++ b/spog/ui/src/main.rs
@@ -3,6 +3,7 @@
 mod about;
 mod app;
 mod console;
+mod export;
 mod hooks;
 mod model;
 mod pages;


### PR DESCRIPTION
**NOTE:** This change requires that one updates `trunk` or `trunk-ng` to a version of `trunk-ng 0.17.16` or newer.