### PR TITLE
feat: allow case-insensitive searching for v11y as well

### DIFF
--- a/v11y/index/src/lib.rs
+++ b/v11y/index/src/lib.rs
@@ -401,7 +401,8 @@ mod test {
     fn load_valid_file(store: &mut IndexStore<Index>, writer: &mut IndexWriter, path: impl AsRef<Path>) {
         let data = std::fs::read(&path).unwrap();
         // ensure it parses
-        serde_json::from_slice::<Cve>(&data).expect(&format!("failed to parse test data: {}", path.as_ref().display()));
+        serde_json::from_slice::<Cve>(&data)
+            .unwrap_or_else(|_| panic!("failed to parse test data: {}", path.as_ref().display()));
         let name = path.as_ref().file_name().unwrap().to_str().unwrap();
         let name = name.rsplit_once('.').unwrap().0;
         // add to index

--- a/v11y/index/src/lib.rs
+++ b/v11y/index/src/lib.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 use time::OffsetDateTime;
 use trustification_api::search::SearchOptions;
 use trustification_index::{
-    create_boolean_query, create_date_query, create_float_query, create_string_query, field2bool, field2date_opt,
-    field2str, field2strvec,
+    create_boolean_query, create_date_query, create_float_query, create_string_query_case, create_text_query,
+    field2bool, field2date_opt, field2str, field2strvec,
     metadata::doc2metadata,
     sort_by,
     tantivy::{
@@ -22,7 +22,7 @@ use trustification_index::{
         store::ZstdCompressor,
         DateTime, DocAddress, DocId, IndexSettings, Score, Searcher, SegmentReader,
     },
-    term2query, Document, Error as SearchError, SearchQuery,
+    term2query, Case, Document, Error as SearchError, SearchQuery,
 };
 use v11y_model::search::{Cves, CvesSortable, SearchDocument, SearchHit};
 
@@ -60,6 +60,7 @@ impl Default for Index {
 impl Index {
     pub fn new() -> Self {
         let mut schema = Schema::builder();
+
         let fields = Fields {
             indexed_timestamp: schema.add_date_field("indexed_timestamp", STORED),
             id: schema.add_text_field("id", STRING | FAST | STORED),
@@ -71,8 +72,8 @@ impl Index {
             date_updated: schema.add_date_field("date_updated", INDEXED | FAST | STORED),
             date_rejected: schema.add_date_field("date_rejected", INDEXED | FAST | STORED),
 
-            title: schema.add_text_field("title", TEXT | FAST | STORED),
-            description: schema.add_text_field("description", TEXT | FAST | STORED),
+            title: schema.add_text_field("title", TEXT | STORED),
+            description: schema.add_text_field("description", TEXT | STORED),
 
             cvss3x_score: schema.add_f64_field("cvss3x_score", FAST | INDEXED | STORED),
             severity: schema.add_text_field("severity", STRING | FAST),
@@ -167,9 +168,11 @@ impl Index {
 
     fn resource2query(&self, resource: &Cves) -> Box<dyn Query> {
         match resource {
-            Cves::Id(value) => create_string_query(self.fields.id, value),
-            Cves::Title(value) => create_string_query(self.fields.title, value),
-            Cves::Description(value) => create_string_query(self.fields.description, value),
+            Cves::Id(value) => create_string_query_case(self.fields.id, value, Case::Uppercase),
+
+            // TODO: consider boosting the title
+            Cves::Title(value) => create_text_query(self.fields.title, value),
+            Cves::Description(value) => create_text_query(self.fields.description, value),
 
             Cves::Score(value) => create_float_query(&self.schema, [self.fields.cvss3x_score], value),
 
@@ -327,7 +330,7 @@ impl trustification_index::Index for Index {
             date_updated,
         };
 
-        let explanation: Option<serde_json::Value> = if options.explain {
+        let explanation: Option<Value> = if options.explain {
             match query.explain(searcher, doc_address) {
                 Ok(explanation) => serde_json::to_value(explanation).ok(),
                 Err(e) => {
@@ -384,5 +387,140 @@ impl trustification_index::WriteIndex for Index {
             .get_field("id")
             .map(|f| Term::from_field_text(f, id))
             .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::path::Path;
+    use trustification_index::{IndexStore, IndexWriter};
+
+    const TESTDATA: &[&str] = &["../testdata/CVE-2023-44487.json"];
+
+    fn load_valid_file(store: &mut IndexStore<Index>, writer: &mut IndexWriter, path: impl AsRef<Path>) {
+        let data = std::fs::read(&path).unwrap();
+        // ensure it parses
+        serde_json::from_slice::<Cve>(&data).expect(&format!("failed to parse test data: {}", path.as_ref().display()));
+        let name = path.as_ref().file_name().unwrap().to_str().unwrap();
+        let name = name.rsplit_once('.').unwrap().0;
+        // add to index
+        writer.add_document(store.index_as_mut(), name, &data).unwrap();
+    }
+
+    fn assert_search<F>(f: F)
+    where
+        F: FnOnce(IndexStore<Index>),
+    {
+        let _ = env_logger::try_init();
+
+        let index = Index::new();
+        let mut store = IndexStore::new_in_memory(index).unwrap();
+        let mut writer = store.writer().unwrap();
+
+        for file in TESTDATA {
+            load_valid_file(&mut store, &mut writer, file);
+        }
+
+        writer.commit().unwrap();
+
+        f(store);
+    }
+
+    fn search(index: &IndexStore<Index>, query: &str) -> (Vec<SearchHit<SearchDocument>>, usize) {
+        index
+            .search(
+                query,
+                0,
+                10000,
+                SearchOptions {
+                    metadata: false,
+                    explain: false,
+                    summaries: true,
+                },
+            )
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_by_id() {
+        assert_search(|index| {
+            let result = search(&index, r#"id:"CVE-2023-44487""#);
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
+    #[tokio::test]
+    async fn test_by_id_lowercase() {
+        assert_search(|index| {
+            let result = search(&index, r#"id:"cve-2023-44487""#);
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
+    #[tokio::test]
+    async fn test_in_id() {
+        assert_search(|index| {
+            let result = search(&index, r#"in:id "CVE-2023-44487""#);
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
+    #[tokio::test]
+    async fn test_in_id_lowercase() {
+        assert_search(|index| {
+            let result = search(&index, r#"in:id "cve-2023-44487""#);
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
+    #[tokio::test]
+    async fn test() {
+        assert_search(|index| {
+            let result = search(&index, r#"allow in:description"#);
+            assert_eq!(result.0.len(), 1);
+        });
+
+        assert_search(|index| {
+            let result = search(&index, r#"in:description 2023"#);
+            assert_eq!(result.0.len(), 1);
+        });
+
+        assert_search(|index| {
+            let result = search(&index, r#"in:description Octob"#);
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
+    #[tokio::test]
+    async fn test_in_description() {
+        assert_search(|index| {
+            let result = search(&index, r#"in:description October 2023"#);
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
+    #[tokio::test]
+    async fn test_in_description_lowercase() {
+        assert_search(|index| {
+            let result = search(&index, r#"in:description october 2023"#);
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
+    #[tokio::test]
+    async fn test_in_description_special() {
+        assert_search(|index| {
+            let result = search(&index, r#"in:description "HTTP/2""#);
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
+    #[tokio::test]
+    async fn test_in_description_special_lowercase() {
+        assert_search(|index| {
+            let result = search(&index, r#"in:description "http/2""#);
+            assert_eq!(result.0.len(), 1);
+        });
     }
 }

--- a/v11y/testdata/CVE-2023-44487.json
+++ b/v11y/testdata/CVE-2023-44487.json
@@ -1,0 +1,628 @@
+{
+  "dataType": "CVE_RECORD",
+  "dataVersion": "5.0",
+  "cveMetadata": {
+    "state": "PUBLISHED",
+    "cveId": "CVE-2023-44487",
+    "assignerOrgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+    "assignerShortName": "mitre",
+    "dateUpdated": "2023-12-02T01:06:19.527380",
+    "dateReserved": "2023-09-29T00:00:00",
+    "datePublished": "2023-10-10T00:00:00"
+  },
+  "containers": {
+    "cna": {
+      "providerMetadata": {
+        "orgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+        "shortName": "mitre",
+        "dateUpdated": "2023-12-02T01:06:19.527380"
+      },
+      "descriptions": [
+        {
+          "lang": "en",
+          "value": "The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023."
+        }
+      ],
+      "affected": [
+        {
+          "vendor": "n/a",
+          "product": "n/a",
+          "versions": [
+            {
+              "version": "n/a",
+              "status": "affected"
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "url": "https://github.com/dotnet/core/blob/e4613450ea0da7fd2fc6b61dfb2c1c1dec1ce9ec/release-notes/6.0/6.0.23/6.0.23.md?plain=1#L73"
+        },
+        {
+          "url": "https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/"
+        },
+        {
+          "url": "https://aws.amazon.com/security/security-bulletins/AWS-2023-011/"
+        },
+        {
+          "url": "https://cloud.google.com/blog/products/identity-security/how-it-works-the-novel-http2-rapid-reset-ddos-attack"
+        },
+        {
+          "url": "https://www.nginx.com/blog/http-2-rapid-reset-attack-impacting-f5-nginx-products/"
+        },
+        {
+          "url": "https://cloud.google.com/blog/products/identity-security/google-cloud-mitigated-largest-ddos-attack-peaking-above-398-million-rps/"
+        },
+        {
+          "url": "https://news.ycombinator.com/item?id=37831062"
+        },
+        {
+          "url": "https://blog.cloudflare.com/zero-day-rapid-reset-http2-record-breaking-ddos-attack/"
+        },
+        {
+          "url": "https://www.phoronix.com/news/HTTP2-Rapid-Reset-Attack"
+        },
+        {
+          "url": "https://github.com/envoyproxy/envoy/pull/30055"
+        },
+        {
+          "url": "https://github.com/haproxy/haproxy/issues/2312"
+        },
+        {
+          "url": "https://github.com/eclipse/jetty.project/issues/10679"
+        },
+        {
+          "url": "https://forums.swift.org/t/swift-nio-http2-security-update-cve-2023-44487-http-2-dos/67764"
+        },
+        {
+          "url": "https://github.com/nghttp2/nghttp2/pull/1961"
+        },
+        {
+          "url": "https://github.com/netty/netty/commit/58f75f665aa81a8cbcf6ffa74820042a285c5e61"
+        },
+        {
+          "url": "https://github.com/alibaba/tengine/issues/1872"
+        },
+        {
+          "url": "https://github.com/apache/tomcat/tree/main/java/org/apache/coyote/http2"
+        },
+        {
+          "url": "https://news.ycombinator.com/item?id=37830987"
+        },
+        {
+          "url": "https://news.ycombinator.com/item?id=37830998"
+        },
+        {
+          "url": "https://github.com/caddyserver/caddy/issues/5877"
+        },
+        {
+          "url": "https://www.bleepingcomputer.com/news/security/new-http-2-rapid-reset-zero-day-attack-breaks-ddos-records/"
+        },
+        {
+          "url": "https://github.com/bcdannyboy/CVE-2023-44487"
+        },
+        {
+          "url": "https://github.com/grpc/grpc-go/pull/6703"
+        },
+        {
+          "url": "https://github.com/icing/mod_h2/blob/0a864782af0a942aa2ad4ed960a6b32cd35bcf0a/mod_http2/README.md?plain=1#L239-L244"
+        },
+        {
+          "url": "https://github.com/nghttp2/nghttp2/releases/tag/v1.57.0"
+        },
+        {
+          "url": "https://mailman.nginx.org/pipermail/nginx-devel/2023-October/S36Q5HBXR7CAIMPLLPRSSSYR4PCMWILK.html"
+        },
+        {
+          "url": "https://my.f5.com/manage/s/article/K000137106"
+        },
+        {
+          "url": "https://msrc.microsoft.com/blog/2023/10/microsoft-response-to-distributed-denial-of-service-ddos-attacks-against-http/2/"
+        },
+        {
+          "url": "https://bugzilla.proxmox.com/show_bug.cgi?id=4988"
+        },
+        {
+          "url": "https://cgit.freebsd.org/ports/commit/?id=c64c329c2c1752f46b73e3e6ce9f4329be6629f9"
+        },
+        {
+          "url": "https://seanmonstar.com/post/730794151136935936/hyper-http2-rapid-reset-unaffected"
+        },
+        {
+          "url": "https://github.com/microsoft/CBL-Mariner/pull/6381"
+        },
+        {
+          "url": "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo"
+        },
+        {
+          "url": "https://github.com/facebook/proxygen/pull/466"
+        },
+        {
+          "url": "https://gist.github.com/adulau/7c2bfb8e9cdbe4b35a5e131c66a0c088"
+        },
+        {
+          "url": "https://github.com/micrictor/http2-rst-stream"
+        },
+        {
+          "url": "https://edg.io/lp/blog/resets-leaks-ddos-and-the-tale-of-a-hidden-cve"
+        },
+        {
+          "url": "https://openssf.org/blog/2023/10/10/http-2-rapid-reset-vulnerability-highlights-need-for-rapid-response/"
+        },
+        {
+          "url": "https://github.com/h2o/h2o/security/advisories/GHSA-2m7v-gc89-fjqf"
+        },
+        {
+          "url": "https://github.com/h2o/h2o/pull/3291"
+        },
+        {
+          "url": "https://github.com/nodejs/node/pull/50121"
+        },
+        {
+          "url": "https://github.com/dotnet/announcements/issues/277"
+        },
+        {
+          "url": "https://github.com/golang/go/issues/63417"
+        },
+        {
+          "url": "https://github.com/advisories/GHSA-vx74-f528-fxqg"
+        },
+        {
+          "url": "https://github.com/apache/trafficserver/pull/10564"
+        },
+        {
+          "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-44487"
+        },
+        {
+          "url": "https://tomcat.apache.org/security-10.html#Fixed_in_Apache_Tomcat_10.1.14"
+        },
+        {
+          "url": "https://lists.apache.org/thread/5py8h42mxfsn8l1wy6o41xwhsjlsd87q"
+        },
+        {
+          "url": "https://www.openwall.com/lists/oss-security/2023/10/10/6"
+        },
+        {
+          "url": "https://www.haproxy.com/blog/haproxy-is-not-affected-by-the-http-2-rapid-reset-attack-cve-2023-44487"
+        },
+        {
+          "url": "https://github.com/opensearch-project/data-prepper/issues/3474"
+        },
+        {
+          "url": "https://github.com/kubernetes/kubernetes/pull/121120"
+        },
+        {
+          "url": "https://github.com/oqtane/oqtane.framework/discussions/3367"
+        },
+        {
+          "url": "https://github.com/advisories/GHSA-xpw8-rcwv-8f8p"
+        },
+        {
+          "url": "https://netty.io/news/2023/10/10/4-1-100-Final.html"
+        },
+        {
+          "url": "https://www.cisa.gov/news-events/alerts/2023/10/10/http2-rapid-reset-vulnerability-cve-2023-44487"
+        },
+        {
+          "url": "https://www.theregister.com/2023/10/10/http2_rapid_reset_zeroday/"
+        },
+        {
+          "url": "https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack"
+        },
+        {
+          "url": "https://news.ycombinator.com/item?id=37837043"
+        },
+        {
+          "url": "https://github.com/kazu-yamamoto/http2/issues/93"
+        },
+        {
+          "url": "https://martinthomson.github.io/h2-stream-limits/draft-thomson-httpbis-h2-stream-limits.html"
+        },
+        {
+          "url": "https://github.com/kazu-yamamoto/http2/commit/f61d41a502bd0f60eb24e1ce14edc7b6df6722a1"
+        },
+        {
+          "url": "https://github.com/apache/httpd/blob/afcdbeebbff4b0c50ea26cdd16e178c0d1f24152/modules/http2/h2_mplx.c#L1101-L1113"
+        },
+        {
+          "name": "DSA-5522",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://www.debian.org/security/2023/dsa-5522"
+        },
+        {
+          "name": "DSA-5521",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://www.debian.org/security/2023/dsa-5521"
+        },
+        {
+          "url": "https://access.redhat.com/security/cve/cve-2023-44487"
+        },
+        {
+          "url": "https://github.com/ninenines/cowboy/issues/1615"
+        },
+        {
+          "url": "https://github.com/varnishcache/varnish-cache/issues/3996"
+        },
+        {
+          "url": "https://github.com/tempesta-tech/tempesta/issues/1986"
+        },
+        {
+          "url": "https://blog.vespa.ai/cve-2023-44487/"
+        },
+        {
+          "url": "https://github.com/etcd-io/etcd/issues/16740"
+        },
+        {
+          "url": "https://www.darkreading.com/cloud/internet-wide-zero-day-bug-fuels-largest-ever-ddos-event"
+        },
+        {
+          "url": "https://istio.io/latest/news/security/istio-security-2023-004/"
+        },
+        {
+          "url": "https://github.com/junkurihara/rust-rpxy/issues/97"
+        },
+        {
+          "url": "https://bugzilla.suse.com/show_bug.cgi?id=1216123"
+        },
+        {
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2242803"
+        },
+        {
+          "url": "https://ubuntu.com/security/CVE-2023-44487"
+        },
+        {
+          "url": "https://community.traefik.io/t/is-traefik-vulnerable-to-cve-2023-44487/20125"
+        },
+        {
+          "url": "https://github.com/advisories/GHSA-qppj-fm5r-hxr3"
+        },
+        {
+          "url": "https://github.com/apache/httpd-site/pull/10"
+        },
+        {
+          "url": "https://github.com/projectcontour/contour/pull/5826"
+        },
+        {
+          "url": "https://github.com/linkerd/website/pull/1695/commits/4b9c6836471bc8270ab48aae6fd2181bc73fd632"
+        },
+        {
+          "url": "https://github.com/line/armeria/pull/5232"
+        },
+        {
+          "url": "https://blog.litespeedtech.com/2023/10/11/rapid-reset-http-2-vulnerablilty/"
+        },
+        {
+          "url": "https://security.paloaltonetworks.com/CVE-2023-44487"
+        },
+        {
+          "url": "https://github.com/akka/akka-http/issues/4323"
+        },
+        {
+          "url": "https://github.com/openresty/openresty/issues/930"
+        },
+        {
+          "url": "https://github.com/apache/apisix/issues/10320"
+        },
+        {
+          "url": "https://github.com/Azure/AKS/issues/3947"
+        },
+        {
+          "url": "https://github.com/Kong/kong/discussions/11741"
+        },
+        {
+          "url": "https://github.com/arkrwn/PoC/tree/main/CVE-2023-44487"
+        },
+        {
+          "url": "https://www.netlify.com/blog/netlify-successfully-mitigates-cve-2023-44487/"
+        },
+        {
+          "url": "https://github.com/caddyserver/caddy/releases/tag/v2.7.5"
+        },
+        {
+          "name": "[debian-lts-announce] 20231013 [SECURITY] [DLA 3617-1] tomcat9 security update",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00020.html"
+        },
+        {
+          "name": "[oss-security] 20231013 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "http://www.openwall.com/lists/oss-security/2023/10/13/4"
+        },
+        {
+          "name": "[oss-security] 20231013 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "http://www.openwall.com/lists/oss-security/2023/10/13/9"
+        },
+        {
+          "url": "https://arstechnica.com/security/2023/10/how-ddosers-used-the-http-2-protocol-to-deliver-attacks-of-unprecedented-size/"
+        },
+        {
+          "url": "https://lists.w3.org/Archives/Public/ietf-http-wg/2023OctDec/0025.html"
+        },
+        {
+          "name": "FEDORA-2023-ed2642fd58",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/JMEXY22BFG5Q64HQCM5CK2Q7KDKVV4TY/"
+        },
+        {
+          "url": "https://linkerd.io/2023/10/12/linkerd-cve-2023-44487/"
+        },
+        {
+          "name": "[debian-lts-announce] 20231016 [SECURITY] [DLA 3621-1] nghttp2 security update",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00023.html"
+        },
+        {
+          "url": "https://security.netapp.com/advisory/ntap-20231016-0001/"
+        },
+        {
+          "name": "[debian-lts-announce] 20231016 [SECURITY] [DLA 3617-2] tomcat9 regression update",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00024.html"
+        },
+        {
+          "name": "[oss-security] 20231018 Vulnerability in Jenkins",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "http://www.openwall.com/lists/oss-security/2023/10/18/4"
+        },
+        {
+          "name": "[oss-security] 20231018 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "http://www.openwall.com/lists/oss-security/2023/10/18/8"
+        },
+        {
+          "name": "[oss-security] 20231019 CVE-2023-45802: Apache HTTP Server: HTTP/2 stream memory not reclaimed right away on RST",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "http://www.openwall.com/lists/oss-security/2023/10/19/6"
+        },
+        {
+          "name": "FEDORA-2023-54fadada12",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZKQSIKIAT5TJ3WSLU3RDBQ35YX4GY4V3/"
+        },
+        {
+          "name": "FEDORA-2023-5ff7bf1dd8",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/JIZSEFC3YKCGABA2BZW6ZJRMDZJMB7PJ/"
+        },
+        {
+          "name": "[oss-security] 20231020 Re: CVE-2023-44487: HTTP/2 Rapid Reset attack against many implementations",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "http://www.openwall.com/lists/oss-security/2023/10/20/8"
+        },
+        {
+          "name": "FEDORA-2023-17efd3f2cd",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/WLPRQ5TWUQQXYWBJM7ECYDAIL2YVKIUH/"
+        },
+        {
+          "name": "FEDORA-2023-d5030c983c",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/E72T67UPDRXHIDLO3OROR25YAMN4GGW5/"
+        },
+        {
+          "name": "FEDORA-2023-0259c3f26f",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/BFQD3KUEMFBHPAPBGLWQC34L4OWL5HAZ/"
+        },
+        {
+          "name": "FEDORA-2023-2a9214af5f",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZLU6U2R2IC2K64NDPNMV55AUAO65MAF4/"
+        },
+        {
+          "name": "FEDORA-2023-e9c04d81c1",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/X6QXN4ORIVF6XBW4WWFE7VNPVC74S45Y/"
+        },
+        {
+          "name": "FEDORA-2023-f66fc0f62a",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LKYHSZQFDNR7RSA7LHVLLIAQMVYCUGBG/"
+        },
+        {
+          "name": "FEDORA-2023-4d2fd884ea",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/FNA62Q767CFAFHBCDKYNPBMZWB7TWYVU/"
+        },
+        {
+          "name": "FEDORA-2023-b2c50535cb",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LNMZJCDHGLJJLXO4OXWJMTVQRNWOC7UL/"
+        },
+        {
+          "name": "FEDORA-2023-fe53e13b5b",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/KSEGD2IWKNUO3DWY4KQGUQM5BISRWHQE/"
+        },
+        {
+          "name": "FEDORA-2023-4bf641255e",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/CLB4TW7KALB3EEQWNWCN7OUIWWVWWCG2/"
+        },
+        {
+          "name": "[debian-lts-announce] 20231030 [SECURITY] [DLA 3641-1] jetty9 security update",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00045.html"
+        },
+        {
+          "name": "DSA-5540",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://www.debian.org/security/2023/dsa-5540"
+        },
+        {
+          "name": "[debian-lts-announce] 20231031 [SECURITY] [DLA 3638-1] h2o security update",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00047.html"
+        },
+        {
+          "url": "https://discuss.hashicorp.com/t/hcsec-2023-32-vault-consul-and-boundary-affected-by-http-2-rapid-reset-denial-of-service-vulnerability-cve-2023-44487/59715"
+        },
+        {
+          "name": "FEDORA-2023-1caffb88af",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/VHUHTSXLXGXS7JYKBXTA3VINUPHTNGVU/"
+        },
+        {
+          "name": "FEDORA-2023-3f70b8d406",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/VSRDIV77HNKUSM7SJC5BKE5JSHLHU2NK/"
+        },
+        {
+          "name": "FEDORA-2023-7b52921cae",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/3N4NJ7FR4X4FPZUGNTQAPSTVB2HB2Y4A/"
+        },
+        {
+          "name": "FEDORA-2023-7934802344",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/ZB43REMKRQR62NJEI7I5NQ4FSXNLBKRT/"
+        },
+        {
+          "name": "FEDORA-2023-dbe64661af",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/HT7T2R4MQKLIF4ODV4BDLPARWFPCJ5CZ/"
+        },
+        {
+          "name": "FEDORA-2023-822aab0a5a",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/XFOIBB4YFICHDM7IBOP7PWXW3FX4HLL2/"
+        },
+        {
+          "name": "[debian-lts-announce] 20231105 [SECURITY] [DLA 3645-1] trafficserver security update",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00001.html"
+        },
+        {
+          "name": "DSA-5549",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://www.debian.org/security/2023/dsa-5549"
+        },
+        {
+          "name": "FEDORA-2023-c0c6a91330",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/2MBEPPC36UBVOZZNAXFHKLFGSLCMN5LI/"
+        },
+        {
+          "name": "FEDORA-2023-492b7be466",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/WE2I52RHNNU42PX6NZ2RBUHSFFJ2LVZX/"
+        },
+        {
+          "name": "DSA-5558",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://www.debian.org/security/2023/dsa-5558"
+        },
+        {
+          "name": "[debian-lts-announce] 20231119 [SECURITY] [DLA 3656-1] netty security update",
+          "tags": [
+            "mailing-list"
+          ],
+          "url": "https://lists.debian.org/debian-lts-announce/2023/11/msg00012.html"
+        },
+        {
+          "name": "GLSA-202311-09",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://security.gentoo.org/glsa/202311-09"
+        },
+        {
+          "name": "DSA-5570",
+          "tags": [
+            "vendor-advisory"
+          ],
+          "url": "https://www.debian.org/security/2023/dsa-5570"
+        }
+      ],
+      "problemTypes": [
+        {
+          "descriptions": [
+            {
+              "type": "text",
+              "lang": "en",
+              "description": "n/a"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -897,6 +897,24 @@ mod tests {
         });
     }
 
+    /// Test if we can find a word containing special characters in title or description
+    #[tokio::test]
+    #[ignore]
+    async fn test_title_special() {
+        assert_search(|index| {
+            let result = search(&index, r#"microcode_ctl in:title"#);
+            assert_eq!(result.0.len(), 1);
+        });
+        assert_search(|index| {
+            let result = search(&index, r#"Microcode_Ctl in:title"#);
+            assert_eq!(result.0.len(), 1);
+        });
+        assert_search(|index| {
+            let result = search(&index, r#"MICROCODE_CTL in:title"#);
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
     #[tokio::test]
     async fn test_severity() {
         assert_search(|index| {
@@ -941,7 +959,7 @@ mod tests {
     async fn test_query_and_products() {
         assert_search(|index| {
             let result = search(&index, "kernel");
-            assert_eq!(result.0.len(), 1, "should find one kernel");
+            assert_eq!(result.0.len(), 1);
 
             let result = search(&index, "\"cpe:/a:redhat:enterprise_linux:9\" in:package");
             assert_eq!(result.0.len(), 1);

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -1,5 +1,5 @@
 use csaf::{
-    definitions::{NoteCategory, ProductIdT},
+    definitions::{BranchesT, NoteCategory, ProductIdT, ProductIdentificationHelper},
     product_tree::ProductTree,
     Csaf,
 };
@@ -14,17 +14,16 @@ use time::OffsetDateTime;
 use trustification_api::search::SearchOptions;
 use trustification_index::{
     boost, create_date_query, create_float_query, create_string_query, create_text_query, field2date, field2float,
-    field2str, field2strvec, sort_by,
+    field2str, field2strvec,
+    metadata::doc2metadata,
+    sort_by,
     tantivy::{
         self,
         collector::TopDocs,
         doc,
-        query::{AllQuery, TermSetQuery},
-        query::{BooleanQuery, Query},
+        query::{AllQuery, BooleanQuery, Query, TermSetQuery},
         schema::{Field, Schema, Term, FAST, INDEXED, STORED, STRING, TEXT},
-        schema::{IndexRecordOption, TextFieldIndexing},
         store::ZstdCompressor,
-        tokenizer::{Language, LowerCaser, NgramTokenizer, RemoveLongFilter, Stemmer, TextAnalyzer, TokenizerManager},
         DateTime, DocAddress, DocId, IndexSettings, Score, Searcher, SegmentReader, SnippetGenerator,
     },
     term2query, Document, Error as SearchError, SearchQuery,
@@ -201,7 +200,7 @@ impl trustification_index::Index for Index {
             cve_severity_count,
         };
 
-        let explanation: Option<serde_json::Value> = if options.explain {
+        let explanation = if options.explain {
             match query.explain(searcher, doc_address) {
                 Ok(explanation) => serde_json::to_value(explanation).ok(),
                 Err(e) => {
@@ -231,20 +230,6 @@ impl trustification_index::WriteIndex for Index {
         "vex"
     }
 
-    fn tokenizers(&self) -> Result<TokenizerManager, SearchError> {
-        let manager = TokenizerManager::default();
-        let ngram = NgramTokenizer::all_ngrams(3, 8)?;
-        manager.register(
-            "ngram",
-            TextAnalyzer::builder(ngram)
-                .filter(RemoveLongFilter::limit(40))
-                .filter(LowerCaser)
-                .filter(Stemmer::new(Language::English))
-                .build(),
-        );
-        Ok(manager)
-    }
-
     fn settings(&self) -> IndexSettings {
         IndexSettings {
             docstore_compression: tantivy::store::Compressor::Zstd(ZstdCompressor::default()),
@@ -253,7 +238,7 @@ impl trustification_index::WriteIndex for Index {
     }
 
     fn parse_doc(&self, data: &[u8]) -> Result<Csaf, SearchError> {
-        serde_json::from_slice::<csaf::Csaf>(data).map_err(|e| SearchError::DocParser(e.to_string()))
+        serde_json::from_slice::<Csaf>(data).map_err(|e| SearchError::DocParser(e.to_string()))
     }
 
     fn index_doc(&self, id: &str, csaf: &Csaf) -> Result<Vec<(String, Document)>, SearchError> {
@@ -266,7 +251,7 @@ impl trustification_index::WriteIndex for Index {
         let mut documents: Vec<(String, Document)> = Vec::new();
 
         let mut document = doc!(
-            self.fields.advisory_id => id,
+            self.fields.advisory_id => id.to_uppercase(),
             self.fields.advisory_status => document_status,
             self.fields.advisory_title => csaf.document.title.clone(),
         );
@@ -327,7 +312,7 @@ impl trustification_index::WriteIndex for Index {
                 }
 
                 if let Some(cve) = &vuln.cve {
-                    document.add_text(self.fields.cve_id, cve);
+                    document.add_text(self.fields.cve_id, cve.to_uppercase());
                 }
 
                 if let Some(scores) = &vuln.scores {
@@ -507,20 +492,11 @@ impl Index {
     pub fn new() -> Self {
         let mut schema = Schema::builder();
         let indexed_timestamp = schema.add_date_field("indexed_timestamp", STORED);
-        let text_options = TextFieldIndexing::default()
-            .set_tokenizer("ngram")
-            .set_index_option(IndexRecordOption::WithFreqsAndPositions);
 
         let advisory_id = schema.add_text_field("advisory_id", STRING | FAST | STORED);
         let advisory_status = schema.add_text_field("advisory_status", STRING);
-        let advisory_title = schema.add_text_field(
-            "advisory_title",
-            (TEXT | STORED).set_indexing_options(text_options.clone()),
-        );
-        let advisory_description = schema.add_text_field(
-            "advisory_description",
-            (TEXT | STORED).set_indexing_options(text_options.clone()),
-        );
+        let advisory_title = schema.add_text_field("advisory_title", TEXT | STORED);
+        let advisory_description = schema.add_text_field("advisory_description", TEXT | STORED);
         let advisory_revision = schema.add_text_field("advisory_revision", STRING | STORED);
         let advisory_severity = schema.add_text_field("advisory_severity", STRING | STORED);
         let advisory_initial = schema.add_date_field("advisory_initial_date", INDEXED);
@@ -528,9 +504,8 @@ impl Index {
         let advisory_severity_score = schema.add_f64_field("advisory_severity_score", FAST);
 
         let cve_id = schema.add_text_field("cve_id", STRING | FAST | STORED);
-        let cve_title = schema.add_text_field("cve_title", (TEXT | STORED).set_indexing_options(text_options.clone()));
-        let cve_description =
-            schema.add_text_field("cve_description", (TEXT | STORED).set_indexing_options(text_options));
+        let cve_title = schema.add_text_field("cve_title", TEXT | STORED);
+        let cve_description = schema.add_text_field("cve_description", TEXT | STORED);
         let cve_discovery = schema.add_date_field("cve_discovery_date", INDEXED);
         let cve_release = schema.add_date_field("cve_release_date", INDEXED | STORED);
         let cve_severity = schema.add_text_field("cve_severity", STRING | FAST);
@@ -584,7 +559,7 @@ impl Index {
             Vulnerabilities::Id(value) => boost(
                 Box::new(TermSetQuery::new(vec![Term::from_field_text(
                     self.fields.advisory_id,
-                    value,
+                    &value.to_uppercase(),
                 )])),
                 ID_WEIGHT,
             ),
@@ -592,7 +567,7 @@ impl Index {
             Vulnerabilities::Cve(value) => boost(
                 Box::new(TermSetQuery::new(vec![Term::from_field_text(
                     self.fields.cve_id,
-                    value,
+                    &value.to_uppercase(),
                 )])),
                 CVE_ID_WEIGHT,
             ),
@@ -660,9 +635,6 @@ impl Index {
         }
     }
 }
-
-use csaf::definitions::{BranchesT, ProductIdentificationHelper};
-use trustification_index::metadata::doc2metadata;
 
 fn find_product_identifier<'m, F: Fn(&'m ProductIdentificationHelper) -> Option<R>, R>(
     branches: &'m BranchesT,
@@ -789,7 +761,17 @@ mod tests {
     }
 
     fn search(index: &IndexStore<Index>, query: &str) -> (Vec<SearchHit>, usize) {
-        index.search(query, 0, 10000, SearchOptions::default()).unwrap()
+        index
+            .search(
+                query,
+                0,
+                10000,
+                SearchOptions {
+                    explain: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap()
     }
 
     #[tokio::test]
@@ -804,6 +786,14 @@ mod tests {
     async fn test_free_form_simple_primary_2() {
         assert_search(|index| {
             let result = search(&index, "CVE-2023-0286");
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
+    #[tokio::test]
+    async fn test_free_form_simple_primary_lowercase_2() {
+        assert_search(|index| {
+            let result = search(&index, "cve-2023-0286");
             assert_eq!(result.0.len(), 1);
         });
     }
@@ -892,6 +882,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_title_case_insensitive() {
+        assert_search(|index| {
+            let result = search(&index, r#""microcode" in:title"#);
+            assert_eq!(result.0.len(), 1);
+        });
+        assert_search(|index| {
+            let result = search(&index, r#""Microcode" in:title"#);
+            assert_eq!(result.0.len(), 1);
+        });
+        assert_search(|index| {
+            let result = search(&index, r#""MICROCODE" in:title"#);
+            assert_eq!(result.0.len(), 1);
+        });
+    }
+
+    #[tokio::test]
     async fn test_severity() {
         assert_search(|index| {
             let result = search(&index, "severity:Important");
@@ -935,7 +941,7 @@ mod tests {
     async fn test_query_and_products() {
         assert_search(|index| {
             let result = search(&index, "kernel");
-            assert_eq!(result.0.len(), 1);
+            assert_eq!(result.0.len(), 1, "should find one kernel");
 
             let result = search(&index, "\"cpe:/a:redhat:enterprise_linux:9\" in:package");
             assert_eq!(result.0.len(), 1);
@@ -1033,48 +1039,6 @@ mod tests {
             assert_eq!(result.0[2].document.advisory_id, "RHSA-2023:1441");
             assert_eq!(result.0[3].document.advisory_id, "RHSA-2021:3029");
             assert!(result.0[0].document.advisory_date > result.0[1].document.advisory_date);
-        });
-    }
-
-    #[tokio::test]
-    async fn test_ngrams() {
-        assert_search(|index| {
-            let result = search(&index, "title:openssl");
-            assert_eq!(result.0.len(), 2);
-
-            let result = search(&index, "title:open");
-            assert_eq!(result.0.len(), 2);
-
-            let result = search(&index, "title:ssl");
-            assert_eq!(result.0.len(), 2);
-        });
-    }
-
-    #[tokio::test]
-    async fn test_ngrams_scope() {
-        assert_search(|index| {
-            let result = search(&index, "openssl in:title");
-            assert_eq!(result.0.len(), 2);
-
-            let result = search(&index, "open in:title");
-            assert_eq!(result.0.len(), 2);
-
-            let result = search(&index, "ssl in:title");
-            assert_eq!(result.0.len(), 2);
-        });
-    }
-
-    #[tokio::test]
-    async fn test_ngrams_nocase() {
-        assert_search(|index| {
-            let result = search(&index, "Openssl in:title");
-            assert_eq!(result.0.len(), 2);
-
-            let result = search(&index, "Open in:title");
-            assert_eq!(result.0.len(), 2);
-
-            let result = search(&index, "SSL in:title");
-            assert_eq!(result.0.len(), 2);
         });
     }
 


### PR DESCRIPTION
I checked the other indexes for case-insensitive search. We might want to discuss SBOMs and packages separately.

For CVEs (v11y), we can enable this. But as the data didn't get indexed in the require format before, that change would require re-indexing the full CVE data. We can do that, but I would prefer to do this after the release. I don't think the added value makes up for the risk we're adding at this point.

So I'll leave this open as a draft PR.

Also see: https://issues.redhat.com/browse/TC-894