### PR TITLE
task: Set browser tab title set by config

### DIFF
--- a/spog/ui/src/console/mod.rs
+++ b/spog/ui/src/console/mod.rs
@@ -18,7 +18,17 @@ use yew_oauth2::{openid::*, prelude::*};
 #[function_component(Console)]
 pub fn console() -> Html {
     let config = use_config();
+    let product_name = config.global.product_name();
     let render = move |route| render(route, &config);
+
+    // Set the title to the page
+    match gloo_utils::document().query_selector("title") {
+        Ok(title) => match title {
+            Some(element) => element.set_text_content(Some(&product_name)),
+            None => log::warn!("Invalid query_selector title"),
+        },
+        Err(_) => log::warn!("Could not update title"),
+    };
 
     html!(<RouterSwitch<AppRoute> {render} default={html!(<pages::NotFound />)}/>)
 }


### PR DESCRIPTION
The title of the webapp that appears in the browser tab should be dynamic and set to the name of product being deployed.

By default the title will be set to https://github.com/trustification/trustification/blob/main/spog/model/src/config.rs#L119
and should be configured on Downstream with the appropriate branding name

![Screenshot from 2023-11-30 13-22-23](https://github.com/trustification/trustification/assets/2582866/840b60a3-eba5-48e0-b92d-15c19bb991de)
