### PR TITLE
task: Load favicon without trunk

### DIFF
--- a/spog/ui/index.html
+++ b/spog/ui/index.html
@@ -35,7 +35,7 @@
 
     <link data-trunk rel="copy-dir" href="assets">
     <link data-trunk rel="copy-file" href="assets/codicon.ttf">
-    <link data-trunk rel="copy-file" href="branding/favicon.ico">
+    <link href="branding/favicon.ico">
 
     <link data-trunk rel="copy-file" href="branding/site.webmanifest">
     <link rel="manifest" href="site.webmanifest">


### PR DESCRIPTION
@ctron I could not test this in Prod, so I rely on your review :)

After removing the `data-trunk rel="copy-file"` attributes from the favicon link I would expect this to be loaded from the configmap set in the OCP instance.