### PR TITLE
feat: provide a template to recreate postgres database

### DIFF
--- a/deploy/openshift/database-recreate-template.yaml
+++ b/deploy/openshift/database-recreate-template.yaml
@@ -1,0 +1,188 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: trustification-database-recreate
+objects:
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: database-recreate-${GUAC_IMAGE_TAG}-${JOBID}
+  spec:
+    backoffLimit: 10
+    completions: 1
+    parallelism: 1
+    ttlSecondsAfterFinished: 600
+    template:
+      spec:
+        restartPolicy: OnFailure
+  template:
+    spec:
+      restartPolicy: OnFailure
+
+      volumes:
+        - name: init-data
+          configMap:
+            name: pre-install-guac-config
+      initContainers:
+        - name: drop-database
+          image: ${PG_IMAGE}:${PG_IMAGE_TAG}
+          imagePullPolicy: Always
+          env:
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.host"
+            - name: PGPORT
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.port"
+            - name: PGDATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.name"
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.user"
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.password"
+
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: guac-user-db
+                  key: "db.name"
+
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: guac-user-db
+                  key: "db.user"
+
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: guac-user-db
+                  key: "db.password"
+
+          volumeMounts:
+            - mountPath: /etc/init-data
+              name: init-data
+
+          command:
+            - dropdb
+            - -e
+            - -f
+            - --username=$(DB_USER)
+            - --password=$(DB_PASSWORD)
+            - $(DB_NAME)
+        - name: init-database
+          image: ${PG_IMAGE}:${PG_IMAGE_TAG}
+          imagePullPolicy: Always
+          env:
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.host"
+            - name: PGPORT
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.port"
+            - name: PGDATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.name"
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.user"
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.password"
+
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: guac-user-db
+                  key: "db.name"
+
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: guac-user-db
+                  key: "db.user"
+
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: guac-user-db
+                  key: "db.password"
+
+          volumeMounts:
+            - mountPath: /etc/init-data
+              name: init-data
+
+          command:
+            - psql
+            - -v
+            - ON_ERROR_STOP=1
+            - -v
+            - db_name=$(DB_NAME)
+            - -v
+            - db_user=$(DB_USER)
+            - -v
+            - db_password=$(DB_PASSWORD)
+            - -f
+            - /etc/init-data/init.sql
+      containers:
+        - image: ${GUAC_IMAGE}:${GUAC_IMAGE_TAG}
+          imagePullPolicy: Always
+          name: migrate
+          command: ["/opt/guac/guacmigrate"]
+          args:
+            - "--db-address"
+            - "postgres://$(DB_USER):$(DB_PASSWORD)@$(PGHOST):$(PGPORT)/$(DB_NAME)"
+            - "--db-driver"
+            - "postgres"
+            - "--db-debug"
+            - "true"
+          env:
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.host"
+            - name: PGPORT
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.port"
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  # we indeed require the user database, as we set up guac's schema
+                  name: guac-user-db
+                  key: "db.name"
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.user"
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: guac-admin-db
+                  key: "db.password"


### PR DESCRIPTION
This is the example of the template that could be used downstream to recreate postgres database.
I contains a job with 3 containers:
1. Drop database
2. Init database
3. Run Guac migration

It needs the following parameters:
* PG_IMAGE
* PG_IMAGE_TAG
* GUAC_IMAE
* GUAC_IMAGE_TAG

Hopefully after running this job, we don't even need to restart Guac

> [!WARNING]
> This has not been tested!

I'm not sure how to best test/iterate over this without disrupting environments.