### PR TITLE
fix: try a better way to handle branding assets

### DIFF
--- a/container_files/Containerfile.services
+++ b/container_files/Containerfile.services
@@ -22,7 +22,7 @@ RUN TAG=$tag cargo build -p trust --release
 
 FROM registry.access.redhat.com/ubi9/ubi:latest as frontendbuilder
 
-ARG RUST_VERSION="1.74.0"
+ARG RUST_VERSION="1.71.0"
 ARG SASS_VERSION="1.69.5"
 ARG WASM_PACK_VERSION="0.12.1"
 ARG WASM_BINDGEN_VERSION="0.2.88"
@@ -99,7 +99,6 @@ WORKDIR /trustification/spog/ui
 
 RUN true \
     && npm ci \
-    && rustup target add wasm32-unknown-unknown \
     && trunk build --release --dist /public
 
 # safeguard to ensure the project was built

--- a/spog/ui/config/nginx.conf
+++ b/spog/ui/config/nginx.conf
@@ -42,7 +42,17 @@ http {
         }
 
         location / {
-            index  index.html;
+            index index.html;
+        }
+
+        location /branding/ {
+            alias /public/branding;
+            try_files $uri $uri/ @default;
+        }
+
+        location @default {
+            rewrite ^/branding(.*)$ $1 break;
+            root /public/branding-default;
         }
 
         location ~* \.html$ {

--- a/spog/ui/dev/trunk-hook.sh
+++ b/spog/ui/dev/trunk-hook.sh
@@ -13,4 +13,7 @@ if [[ "$TRUNK_PROFILE" == "debug" ]]; then
         echo "Override with local settings..."
         cp "$TRUNK_STAGING_DIR/endpoints/backend.local.json" "$TRUNK_STAGING_DIR/endpoints/backend.json"
     fi
+
+    echo "Copy branding-default folder to branding"
+    cp -a "$TRUNK_STAGING_DIR/branding-default" "$TRUNK_STAGING_DIR/branding"
 fi

--- a/spog/ui/index.html
+++ b/spog/ui/index.html
@@ -29,19 +29,17 @@
         }
     </style>
 
-    <link data-trunk rel="icon" href="branding/trustification_icon.svg">
-
     <link data-trunk rel="scss" href="styles/main.scss">
+
+    <link data-trunk rel="copy-dir" href="branding" data-target-path="branding-default">
 
     <link data-trunk rel="copy-dir" href="assets">
     <link data-trunk rel="copy-file" href="assets/codicon.ttf">
-    <link data-trunk rel="copy-file" href="branding/favicon.ico">
 
-    <link data-trunk rel="copy-file" href="branding/site.webmanifest">
-    <link rel="manifest" href="site.webmanifest">
-
-    <link data-trunk rel="copy-file" href="branding/apple-touch-icon.png">
-    <link rel="apple-touch-icon" href="apple-touch-icon.png">
+    <!-- don't use data-trunk so that we are able to replace that icon later -->
+    <link rel="icon" href="branding/trustification_icon.svg">
+    <link rel="manifest" href="branding/site.webmanifest">
+    <link rel="apple-touch-icon" href="branding/apple-touch-icon.png">
 
     <link data-trunk rel="copy-dir" href="node_modules/@patternfly/patternfly/assets">
     <link data-trunk rel="copy-dir" href="node_modules/@fortawesome/fontawesome-free/webfonts">
@@ -50,7 +48,7 @@
 </head>
 
 <body>
-<div id="loading"><div id="loading-background"></div></div>
+    <div id="loading"><div id="loading-background"></div></div>
 </body>
 
 </html>


### PR DESCRIPTION
* Branding is expected to be found under /branding
* The local /branding folder will be copied to /branding-default by trunk
* A trunk hook will duplicate that directory to /branding in local development mode
* Nginx will be configured to resolve /branding resources first from /branding, then falling back to /branding-default

This way it is possible to perform easy local testing, and have the deployment override the branding resources (which are mounted into /branding), but still leverage the defaults from /branding-default.