### PR TITLE
feat: allow setting a service account for the guac init job

### DIFF
--- a/deploy/k8s/chart/templates/init-guac/020-Job.yaml
+++ b/deploy/k8s/chart/templates/init-guac/020-Job.yaml
@@ -25,6 +25,10 @@ spec:
 
       restartPolicy: OnFailure
 
+{{ with .Values.guac.initJob.serviceAccountName }}
+      serviceAccountName: {{ . }}
+{{ end }}
+
       volumes:
         - name: init-data
           configMap:

--- a/deploy/openshift/parameters.yaml
+++ b/deploy/openshift/parameters.yaml
@@ -149,3 +149,5 @@ parameters:
   value: spogUi
 - name: POSTGRESQL_IMAGE
   value: "docker.io/library/postgres:15"
+- name: GUAC_INIT_JOB_SERVICE_ACCOUNT
+  value: trustification-service

--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -1936,6 +1936,7 @@ objects:
       template:
         spec:
           restartPolicy: OnFailure
+          serviceAccountName: ${GUAC_INIT_JOB_SERVICE_ACCOUNT}
           volumes:
             - name: init-data
               configMap:
@@ -2151,3 +2152,5 @@ parameters:
   value: spogUi
 - name: POSTGRESQL_IMAGE
   value: "docker.io/library/postgres:15"
+- name: GUAC_INIT_JOB_SERVICE_ACCOUNT
+  value: trustification-service

--- a/deploy/openshift/values.yaml
+++ b/deploy/openshift/values.yaml
@@ -146,6 +146,8 @@ guac:
   database:
     enabled: true
     image: ${POSTGRESQL_IMAGE}
+  initJob:
+    serviceAccountName: ${GUAC_INIT_JOB_SERVICE_ACCOUNT}
   graphql:
     debug: false
     affinity: ${{GUAC_GQL_AFFINITY}}

--- a/deploy/trustification.dev/dev.yaml
+++ b/deploy/trustification.dev/dev.yaml
@@ -230,6 +230,7 @@ guac:
   database:
     enabled: false
     image: docker.io/library/postgres:15
+  initJob: {}
   graphql:
     debug: true
     affinity:

--- a/deploy/trustification.dev/prod.yaml
+++ b/deploy/trustification.dev/prod.yaml
@@ -230,6 +230,7 @@ guac:
   database:
     enabled: true
     image: docker.io/library/postgres:15
+  initJob: {}
   graphql:
     debug: true
     affinity:

--- a/deploy/trustification.dev/staging.yaml
+++ b/deploy/trustification.dev/staging.yaml
@@ -229,6 +229,7 @@ guac:
   database:
     enabled: true
     image: docker.io/library/postgres:15
+  initJob: {}
   graphql:
     debug: true
     affinity:


### PR DESCRIPTION
same as PR  #926, but allow using this without the value