### PR TITLE
fix: group cve related product results both by status and sbom

### DIFF
--- a/spog/model/src/cve.rs
+++ b/spog/model/src/cve.rs
@@ -5,7 +5,7 @@ use v11y_model::search::SearchDocument;
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct CveDetails {
     pub id: String,
-    pub products: BTreeMap<ProductCveStatus, Vec<ProductRelatedToCve>>,
+    pub products: BTreeMap<ProductCveStatus, BTreeMap<String, Vec<PackageRelatedToProductCve>>>,
     pub advisories: Vec<AdvisoryOverview>,
 
     #[serde(default)]


### PR DESCRIPTION
This fix adds additional grouping of the results, so that all packages affected for the sbom will be one entry (on top of status).

We still need to support transitive dependencies, which we have in the result, but let's do that in the followup. 