### PR TITLE
[TC-767] - ReEnable icons for "Agreegated severity": advisory

### DIFF
--- a/spog/ui/crates/components/src/severity.rs
+++ b/spog/ui/crates/components/src/severity.rs
@@ -8,6 +8,12 @@ pub struct SeverityProperties {
 
 #[function_component(Severity)]
 pub fn severity(props: &SeverityProperties) -> Html {
+    let severity_text = match RedHatSeverity::from_str(&props.severity) {
+        Ok(severity) => {
+            format!("{}", severity)
+        },
+        Err(_) => props.severity.clone().to_string()
+    };
     html!(
         <>
             <span class={classes!("tc-c-severity")}>
@@ -16,7 +22,7 @@ pub fn severity(props: &SeverityProperties) -> Html {
                 </span>
                 <span class={classes!("tc-c-severity__text")}>
                     { " " }
-                    { &props.severity }
+                    { &severity_text }
                 </span>
             </span>
         </>
@@ -75,10 +81,10 @@ impl FromStr for RedHatSeverity {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "Low" => Self::Low,
-            "Moderate" => Self::Moderate,
-            "Important" => Self::Important,
-            "Critical" => Self::Critical,
+            "Low" | "low" => Self::Low,
+            "Moderate" | "moderate" => Self::Moderate,
+            "Important" | "important" => Self::Important,
+            "Critical" | "critical" => Self::Critical,
             _ => return Err(()),
         })
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-767

Current problem: The column "Aggregated severity" of the "advisories" table does not have the appropriate "Shield icon + color" and generates confusion

The icon and colors for the "Aggregated severity" was already in place but all current data gives *lowercase* aggregated severity, while the code was expecting the first letter to be uppercase.