### PR TITLE
[TC-770] - Consolidate Analytics

### DIFF
--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "analytics-next"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edad46819ce879d493432966b87e1d0188267c5eb97d45aa16999ffd7c6343bd"
+checksum = "b0270085e02060975ff077d6eb131df1ed577630d460353700f8e8e7bb55d073"
 dependencies = [
  "analytics-next-sys",
  "gloo-utils 0.2.0",
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "analytics-next-sys"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bad223cd0efd3e385fb967d5aabe334245483272e67f1bfe4182b2535343be"
+checksum = "f3b463f31b58147b512cfb23369a48a9617726cdfa56c95af7358f4882605796"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2"
 description = "Single Pane of Glass"
 
 [dependencies]
-analytics-next = "0.1.1"
+analytics-next = "0.1.2"
 anyhow = "1"
 async-trait = "0.1"
 browser-panic-hook = "0.2.0"
@@ -99,7 +99,7 @@ members = [
 #patternfly-yew = { path = "../../../patternfly-yew" }
 
 #analytics-next = { git = "https://github.com/ctron/analytics-next-rs", rev = "9c95122f4e6dc308c90b945bd0f1925faf7cb828" } # FIXME: awaiting release
-#analytics-next = { path = "../../../analytics-next" }
+#analytics-next = { path = "../../../analytics-next-rs" }
 
 csaf = { git = "https://github.com/voteblake/csaf-rs", rev = "76cb9ede10adb1fbb495b17e5fd8d95c5cf6c900" } # FIXME: waiting for release
 monaco = { git = "https://github.com/siku2/rust-monaco", rev = "8b8eb78004709058399c2d0dfa7c460d30fe62fd" } # FIXME: waiting for release 0.5.0

--- a/spog/ui/crates/components/src/download.rs
+++ b/spog/ui/crates/components/src/download.rs
@@ -26,7 +26,7 @@ pub fn download(props: &DownloadProperties) -> Html {
     });
 
     let onclick = use_wrap_tracking(onclick, props.href.clone(), |_, href| {
-        ("Download File", json!({"href": href}))
+        ("File Downloaded", json!({"href": href}))
     });
 
     html!(

--- a/spog/ui/src/analytics/mod.rs
+++ b/spog/ui/src/analytics/mod.rs
@@ -1,0 +1,46 @@
+use analytics_next::TrackingEvent;
+use serde_json::json;
+
+pub struct AnalyticEvents {
+    pub page: ObjectNameAnalytics,
+    pub action: ActionAnalytics,
+}
+
+pub enum ObjectNameAnalytics {
+    HomePage,
+    UniversalSearchPage,
+}
+
+pub enum ActionAnalytics {
+    Search(String),
+    SelectTab(String),
+}
+
+impl std::fmt::Display for ObjectNameAnalytics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HomePage => f.write_str("HomePage"),
+            Self::UniversalSearchPage => f.write_str("UniversalSearchPage"),
+        }
+    }
+}
+
+impl std::fmt::Display for ActionAnalytics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Search(_) => f.write_str("Search"),
+            Self::SelectTab(_) => f.write_str("SelectTab"),
+        }
+    }
+}
+
+impl From<AnalyticEvents> for TrackingEvent<'static> {
+    fn from(value: AnalyticEvents) -> Self {
+        let event_key = format!("{} {}", value.page, value.action);
+        let json = match value.action {
+            ActionAnalytics::Search(filter_text) => json!({ "filter_text": filter_text }),
+            ActionAnalytics::SelectTab(tab_name) => json!({ "tab_name": tab_name }),
+        };
+        (event_key, json).into()
+    }
+}

--- a/spog/ui/src/analytics/mod.rs
+++ b/spog/ui/src/analytics/mod.rs
@@ -2,7 +2,7 @@ use analytics_next::TrackingEvent;
 use serde_json::json;
 
 pub struct AnalyticEvents {
-    pub page: ObjectNameAnalytics,
+    pub obj_name: ObjectNameAnalytics,
     pub action: ActionAnalytics,
 }
 
@@ -36,7 +36,7 @@ impl std::fmt::Display for ActionAnalytics {
 
 impl From<AnalyticEvents> for TrackingEvent<'static> {
     fn from(value: AnalyticEvents) -> Self {
-        let event_key = format!("{} {}", value.page, value.action);
+        let event_key = format!("{} {}", value.obj_name, value.action);
         let json = match value.action {
             ActionAnalytics::Search(filter_text) => json!({ "filter_text": filter_text }),
             ActionAnalytics::SelectTab(tab_name) => json!({ "tab_name": tab_name }),

--- a/spog/ui/src/analytics/mod.rs
+++ b/spog/ui/src/analytics/mod.rs
@@ -8,7 +8,7 @@ pub struct AnalyticEvents {
 
 pub enum ObjectNameAnalytics {
     HomePage,
-    UniversalSearchPage,
+    SearchPage,
 }
 
 pub enum ActionAnalytics {
@@ -20,7 +20,7 @@ impl std::fmt::Display for ObjectNameAnalytics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::HomePage => f.write_str("HomePage"),
-            Self::UniversalSearchPage => f.write_str("UniversalSearchPage"),
+            Self::SearchPage => f.write_str("SearchPage"),
         }
     }
 }

--- a/spog/ui/src/main.rs
+++ b/spog/ui/src/main.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "1024"]
 
 mod about;
+mod analytics;
 mod app;
 mod common;
 mod console;
@@ -8,7 +9,6 @@ mod export;
 mod hooks;
 mod model;
 mod pages;
-mod analytics;
 
 use browser_panic_hook::{CustomBody, IntoPanicHook};
 use wasm_bindgen::prelude::*;

--- a/spog/ui/src/main.rs
+++ b/spog/ui/src/main.rs
@@ -8,6 +8,7 @@ mod export;
 mod hooks;
 mod model;
 mod pages;
+mod analytics;
 
 use browser_panic_hook::{CustomBody, IntoPanicHook};
 use wasm_bindgen::prelude::*;

--- a/spog/ui/src/pages/index.rs
+++ b/spog/ui/src/pages/index.rs
@@ -26,7 +26,7 @@ pub fn index() -> Html {
         (analytics.clone(), router.clone(), text.clone()),
         |_, (analytics, router, terms)| {
             analytics.track(AnalyticEvents {
-                page: ObjectNameAnalytics::HomePage,
+                obj_name: ObjectNameAnalytics::HomePage,
                 action: ActionAnalytics::Search((**terms).clone()),
             });
 

--- a/spog/ui/src/pages/index.rs
+++ b/spog/ui/src/pages/index.rs
@@ -1,13 +1,15 @@
+use crate::analytics::{ActionAnalytics, AnalyticEvents, ObjectNameAnalytics};
 use patternfly_yew::prelude::*;
 use spog_ui_common::components::SafeHtml;
 use spog_ui_navigation::AppRoute;
-use spog_ui_utils::config::use_config;
+use spog_ui_utils::{analytics::use_analytics, config::use_config};
 use yew::prelude::*;
 use yew_nested_router::prelude::*;
 
 #[function_component(Index)]
 pub fn index() -> Html {
     let config = use_config();
+    let analytics = use_analytics();
 
     let text = use_state_eq(String::new);
     let onchange = use_callback(text.clone(), |new_text, text| text.set(new_text));
@@ -20,13 +22,21 @@ pub fn index() -> Html {
             });
         }
     });
-    let onsubmit = use_callback((router.clone(), text.clone()), |_, (router, terms)| {
-        if let Some(router) = router {
-            router.push(AppRoute::Search {
-                terms: (**terms).clone(),
+    let onsubmit = use_callback(
+        (analytics.clone(), router.clone(), text.clone()),
+        |_, (analytics, router, terms)| {
+            analytics.track(AnalyticEvents {
+                page: ObjectNameAnalytics::HomePage,
+                action: ActionAnalytics::Search((**terms).clone()),
             });
-        }
-    });
+
+            if let Some(router) = router {
+                router.push(AppRoute::Search {
+                    terms: (**terms).clone(),
+                });
+            }
+        },
+    );
 
     html!(
         <>

--- a/spog/ui/src/pages/scanner/inspect.rs
+++ b/spog/ui/src/pages/scanner/inspect.rs
@@ -18,7 +18,7 @@ struct AnalyzeResult<'a>(&'a Result<Rc<String>, spog_ui_common::error::ApiError>
 impl<'a> From<AnalyzeResult<'a>> for TrackingEvent<'static> {
     fn from(value: AnalyzeResult<'a>) -> Self {
         (
-            "Analyze Result",
+            "ScanSBOMPage Scan Result",
             match &value.0 {
                 Ok(value) => {
                     json!({"ok": {

--- a/spog/ui/src/pages/scanner/mod.rs
+++ b/spog/ui/src/pages/scanner/mod.rs
@@ -29,7 +29,7 @@ pub struct ParseOutcome<'a>(&'a Result<SBOM, anyhow::Error>);
 impl<'a> From<ParseOutcome<'a>> for TrackingEvent<'static> {
     fn from(value: ParseOutcome<'a>) -> Self {
         (
-            "SBOM preflight check",
+            "ScanSBOMPage Preflight Check",
             match &value.0 {
                 Ok(value) => json!({
                     "ok": {

--- a/spog/ui/src/pages/scanner/upload.rs
+++ b/spog/ui/src/pages/scanner/upload.rs
@@ -23,7 +23,7 @@ struct LoadFiles(u32);
 
 impl From<LoadFiles> for TrackingEvent<'static> {
     fn from(value: LoadFiles) -> Self {
-        ("Loading files", json!({"numberOfFiles": value.0})).into()
+        ("ScanSBOMPage File Loaded", json!({"numberOfFiles": value.0})).into()
     }
 }
 
@@ -33,7 +33,7 @@ struct SubmitSbom {
 
 impl From<SubmitSbom> for TrackingEvent<'static> {
     fn from(value: SubmitSbom) -> Self {
-        ("Submit SBOM", json!({"size": value.size})).into()
+        ("ScanSBOMPage ScanButton Clicked", json!({"size": value.size})).into()
     }
 }
 
@@ -42,7 +42,7 @@ struct Dropped(&'static str, usize, usize);
 impl From<Dropped> for TrackingEvent<'static> {
     fn from(value: Dropped) -> Self {
         (
-            "Dropped SBOM",
+            "ScanSBOMPage File Dropped",
             json!({
                 "type": value.0,
                 "items": value.1,
@@ -76,7 +76,7 @@ impl DropContent {
     }
 }
 
-tracking_event!(Cleared: "Cleared SBOM content" => json!({}));
+tracking_event!(Cleared: "ScanSBOMPage ClearButton Clicked" => json!({}));
 
 impl std::fmt::Display for DropContent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -225,7 +225,7 @@ pub fn upload(props: &UploadProperties) -> Html {
     let onopen = use_callback(
         (file_input_ref.clone(), analytics.clone()),
         |_: (), (file_input_ref, analytics)| {
-            analytics.track(("Click load button", None));
+            analytics.track(("ScanSBOMPage LoadButton Clicked", None));
             if let Some(ele) = file_input_ref.cast::<web_sys::HtmlElement>() {
                 ele.click();
             }

--- a/spog/ui/src/pages/search.rs
+++ b/spog/ui/src/pages/search.rs
@@ -19,24 +19,14 @@ use yew_more_hooks::prelude::*;
 
 use crate::analytics::{ActionAnalytics, AnalyticEvents, ObjectNameAnalytics};
 
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize, strum::EnumString, strum::Display)]
+#[strum(serialize_all = "camelCase")]
 pub enum TabIndex {
     Advisories,
     Sboms,
     #[default]
     Cves,
     Packages,
-}
-
-impl std::fmt::Display for TabIndex {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Advisories => f.write_str("Advisories"),
-            Self::Sboms => f.write_str("Sboms"),
-            Self::Cves => f.write_str("Cves"),
-            Self::Packages => f.write_str("Packages"),
-        }
-    }
 }
 
 #[derive(PartialEq, Properties)]

--- a/spog/ui/src/pages/search.rs
+++ b/spog/ui/src/pages/search.rs
@@ -19,7 +19,9 @@ use yew_more_hooks::prelude::*;
 
 use crate::analytics::{ActionAnalytics, AnalyticEvents, ObjectNameAnalytics};
 
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize, strum::EnumString, strum::Display)]
+#[derive(
+    Copy, Clone, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize, strum::EnumString, strum::Display,
+)]
 #[strum(serialize_all = "camelCase")]
 pub enum TabIndex {
     Advisories,

--- a/spog/ui/src/pages/search.rs
+++ b/spog/ui/src/pages/search.rs
@@ -89,7 +89,7 @@ pub fn search(props: &SearchProperties) -> Html {
         (analytics.clone(), text.clone(), search_terms.clone()),
         |_, (analytics, terms, search_terms)| {
             analytics.track(AnalyticEvents {
-                obj_name: ObjectNameAnalytics::UniversalSearchPage,
+                obj_name: ObjectNameAnalytics::SearchPage,
                 action: ActionAnalytics::Search((**terms).clone()),
             });
 
@@ -100,7 +100,7 @@ pub fn search(props: &SearchProperties) -> Html {
         (analytics.clone(), text.clone(), search_terms.clone()),
         |_, (analytics, terms, search_terms)| {
             analytics.track(AnalyticEvents {
-                obj_name: ObjectNameAnalytics::UniversalSearchPage,
+                obj_name: ObjectNameAnalytics::SearchPage,
                 action: ActionAnalytics::Search((**terms).clone()),
             });
 
@@ -113,7 +113,7 @@ pub fn search(props: &SearchProperties) -> Html {
     let tab = use_state_eq(|| page_state.tab);
     let onselect = use_callback((analytics.clone(), tab.clone()), |index, (analytics, tab)| {
         analytics.track(AnalyticEvents {
-            obj_name: ObjectNameAnalytics::UniversalSearchPage,
+            obj_name: ObjectNameAnalytics::SearchPage,
             action: ActionAnalytics::SelectTab(format!("{}", *tab.clone())),
         });
 

--- a/spog/ui/src/pages/search.rs
+++ b/spog/ui/src/pages/search.rs
@@ -89,7 +89,7 @@ pub fn search(props: &SearchProperties) -> Html {
         (analytics.clone(), text.clone(), search_terms.clone()),
         |_, (analytics, terms, search_terms)| {
             analytics.track(AnalyticEvents {
-                page: ObjectNameAnalytics::UniversalSearchPage,
+                obj_name: ObjectNameAnalytics::UniversalSearchPage,
                 action: ActionAnalytics::Search((**terms).clone()),
             });
 
@@ -100,7 +100,7 @@ pub fn search(props: &SearchProperties) -> Html {
         (analytics.clone(), text.clone(), search_terms.clone()),
         |_, (analytics, terms, search_terms)| {
             analytics.track(AnalyticEvents {
-                page: ObjectNameAnalytics::UniversalSearchPage,
+                obj_name: ObjectNameAnalytics::UniversalSearchPage,
                 action: ActionAnalytics::Search((**terms).clone()),
             });
 
@@ -113,7 +113,7 @@ pub fn search(props: &SearchProperties) -> Html {
     let tab = use_state_eq(|| page_state.tab);
     let onselect = use_callback((analytics.clone(), tab.clone()), |index, (analytics, tab)| {
         analytics.track(AnalyticEvents {
-            page: ObjectNameAnalytics::UniversalSearchPage,
+            obj_name: ObjectNameAnalytics::UniversalSearchPage,
             action: ActionAnalytics::SelectTab(format!("{}", *tab.clone())),
         });
 


### PR DESCRIPTION
We need to put the analytics code at one single point and avoid spreading of "event names" as much as we can.

- [x] Log the search entries on the Home Page + Log the search at the "Search results" page
- [x] Track the selected tabs on the "Search results" page
- [x] What SBOMs are being downloaded + number of times the download link is clicked (this has been implemented before this PR  by Jens)
- [x] Count number of successful and unsuccessful sboms being scanned (This was done before this PR by Jens)
- [ ] Log what filters are used while searching in the "Search results" page

The idea is to put all "event keys" in one single place so it is easier for us to keep good naming convention. I suggest also following good practices described at https://segment.com/docs/getting-started/implementation-guide/#event-anatomy-and-naming-standards 

```
Segment recommends the best practice of using an “Object Action” (Noun Verb)
naming convention for all Track events (for example, Menu Clicked)
```