### PR TITLE
fix: change regex to catch more red hat related patterns

### DIFF
--- a/exhort/api/src/server.rs
+++ b/exhort/api/src/server.rs
@@ -168,7 +168,7 @@ async fn recommend(
 ) -> actix_web::Result<impl Responder> {
     let mut recommendations = HashMap::new();
 
-    let pattern = Regex::new("\\.redhat-[0-9]+$").unwrap();
+    let pattern = Regex::new("redhat-[0-9]+$").unwrap();
 
     for purl_str in &request.purls {
         if let Ok(purl) = PackageUrl::from_str(purl_str) {


### PR DESCRIPTION
This is just a small fix to the regex so it can catch versions like `2.13.8.Final-redhat-00004`. Note that it is not `.redhat-xxxxx`.

With this change I get the found packages.

```
{
  "recommendations": {
    ...
    "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00004": [
      {
        "package": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00004?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
        "vulnerabilities": []
      },
      {
        "package": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.8.Final-redhat-00005?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
        "vulnerabilities": []
      }
    ]
  }
}
```