### PR TITLE
feat: allow setting the initial backend JSON

### DIFF
--- a/deploy/k8s/chart/templates/spog/ui/030-Deployment.yaml
+++ b/deploy/k8s/chart/templates/spog/ui/030-Deployment.yaml
@@ -52,6 +52,10 @@ spec:
             - name: WRITE_KEY
               {{ . | toYaml | nindent 14 }}
 {{- end }}
+{{- with .Values.spog.ui.initialBackendJson }}
+            - name: BACKEND_JSON
+              value: {{ . | quote }}
+{{- end }}
           volumeMounts:
             - name: endpoints
               mountPath: /endpoints

--- a/deploy/openshift/parameters.yaml
+++ b/deploy/openshift/parameters.yaml
@@ -151,3 +151,5 @@ parameters:
   value: "docker.io/library/postgres:15"
 - name: GUAC_INIT_JOB_SERVICE_ACCOUNT
   value: trustification-service
+- name: INITIAL_BACKEND_JSON
+  value: "{}"

--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -1035,6 +1035,8 @@ objects:
                     secretKeyRef:
                       key: ${SEGMENT_SECRET_API_KEY}
                       name: ${SEGMENT_SECRET_NAME}
+                - name: BACKEND_JSON
+                  value: ${INITIAL_BACKEND_JSON}
               volumeMounts:
                 - name: endpoints
                   mountPath: /endpoints
@@ -2154,3 +2156,5 @@ parameters:
   value: "docker.io/library/postgres:15"
 - name: GUAC_INIT_JOB_SERVICE_ACCOUNT
   value: trustification-service
+- name: INITIAL_BACKEND_JSON
+  value: "{}"

--- a/deploy/openshift/values.yaml
+++ b/deploy/openshift/values.yaml
@@ -21,6 +21,7 @@ spog:
   ui:
     customize: true
     resources: ${{SPOG_UI_RESOURCES}}
+    initialBackendJson: ${INITIAL_BACKEND_JSON}
     segmentWriteKey:
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
Add an option to inject the initial backend json value before processing it.

We do require this to enable the external consent setting.