### PR TITLE
fix: upgrade guac_rs to fix find_vulnerability_statuses function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3076,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "guac"
 version = "0.1.0"
-source = "git+https://github.com/trustification/guac-rs.git?rev=dce42db4222b482f95ab3868dcf6aea20f26e379#dce42db4222b482f95ab3868dcf6aea20f26e379"
+source = "git+https://github.com/trustification/guac-rs.git?rev=a36282f462c80b79b22547340f0d5416d1a46a44#a36282f462c80b79b22547340f0d5416d1a46a44"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ default-members = [
 ]
 
 [workspace.dependencies]
-guac = { git = "https://github.com/trustification/guac-rs.git", rev="dce42db4222b482f95ab3868dcf6aea20f26e379" }
+guac = { git = "https://github.com/trustification/guac-rs.git", rev="a36282f462c80b79b22547340f0d5416d1a46a44" }
 #guac = { path = "../guac-rs/lib" }
 
 [patch.crates-io]


### PR DESCRIPTION
upgrade guac_rs to fix `find_vulnerability_statuses function` to work with certify vex/vuln directly