### PR TITLE
chore: lower query logging to trace, limit regexp state output

### DIFF
--- a/bombastic/index/src/packages/mod.rs
+++ b/bombastic/index/src/packages/mod.rs
@@ -317,7 +317,7 @@ impl trustification_index::Index for Index {
             term2query(&query.term, &|resource| self.resource2query(resource))
         };
 
-        debug!("Processed query: {:?}", query);
+        log::trace!("Processed query: {:?}", query);
         Ok(SearchQuery { query, sort_by })
     }
 

--- a/bombastic/index/src/sbom/mod.rs
+++ b/bombastic/index/src/sbom/mod.rs
@@ -460,7 +460,7 @@ impl trustification_index::Index for Index {
             term2query(&query.term, &|resource| self.resource2query(resource))
         };
 
-        debug!("Processed query: {:?}", query);
+        log::trace!("Processed query: {:?}", query);
         Ok(SearchQuery { query, sort_by })
     }
 

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -755,7 +755,7 @@ impl<INDEX: Index> IndexStore<INDEX> {
 
         let query = self.index.prepare_query(q)?;
 
-        debug!("Processed query: {:?}", query);
+        log::trace!("Processed query: {:?}", query);
 
         let (top_docs, count) = if let Some(sort_by) = query.sort_by {
             let field = sort_by.0;

--- a/v11y/index/src/lib.rs
+++ b/v11y/index/src/lib.rs
@@ -228,7 +228,7 @@ impl trustification_index::Index for Index {
             term2query(&query.term, &|resource| self.resource2query(resource))
         };
 
-        log::debug!("Processed query: {:?}", query);
+        log::trace!("Processed query: {:?}", query);
         Ok(SearchQuery { query, sort_by })
     }
 

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -93,7 +93,7 @@ impl trustification_index::Index for Index {
             term2query(&query.term, &|resource| self.resource2query(resource))
         };
 
-        debug!("Processed query: {:?}", query);
+        log::trace!("Processed query: {:?}", query);
         Ok(SearchQuery { query, sort_by })
     }
 


### PR DESCRIPTION
The Debug implementation of the Regexp query dumps the regexp instruction set, which can be rather long and is not really useful.