### PR TITLE
feat: allow searching packages by qualifier

### DIFF
--- a/bombastic/index/src/packages/mod.rs
+++ b/bombastic/index/src/packages/mod.rs
@@ -16,8 +16,7 @@ use trustification_index::{
         self,
         collector::TopDocs,
         doc,
-        query::Query,
-        query::{AllQuery, BooleanQuery, TermSetQuery},
+        query::{AllQuery, BooleanQuery, Query, TermQuery, TermSetQuery},
         schema::{Field, Schema, Term, FAST, STORED, STRING, TEXT},
         store::ZstdCompressor,
         DateTime, DocAddress, DocId, IndexSettings, Order, Score, Searcher, SegmentReader,
@@ -279,6 +278,14 @@ impl Index {
 
             PackageInfo::Name(value) => self.create_string_query(&[self.fields.purl_name], value),
             PackageInfo::Namespace(value) => self.create_string_query(&[self.fields.purl_namespace], value),
+
+            PackageInfo::Qualifier(value) => {
+                let value = format!("{}={}", value.qualifier, value.expression);
+                Box::new(TermQuery::new(
+                    Term::from_field_text(self.fields.purl_qualifiers, &value),
+                    Default::default(),
+                ))
+            }
         }
     }
 

--- a/bombastic/model/src/packages/mod.rs
+++ b/bombastic/model/src/packages/mod.rs
@@ -27,6 +27,7 @@ pub enum PackageInfo<'a> {
     License(&'a str),
     #[search(default)]
     Description(&'a str),
+    Qualifier(Qualified<'a, &'a str>),
 }
 
 /// A document returned from the search index for every match.


### PR DESCRIPTION
We need to search by architecture, like this: `qualifier:arch:aarch64`