### PR TITLE
Enhance download tracking data

### DIFF
--- a/spog/ui/crates/components/src/advisory/mod.rs
+++ b/spog/ui/crates/components/src/advisory/mod.rs
@@ -66,7 +66,7 @@ impl TableEntryRenderer<Column> for AdvisoryEntry {
             ),
             Column::Revision => date(self.summary.date),
             Column::Download => html!(if let Some(url) = &self.url {
-                <Download href={url.clone()} />
+                <Download href={url.clone()} r#type="csaf"/>
             }),
             Column::Vulnerabilities => {
                 let l = self.summary.cves.len();

--- a/spog/ui/crates/components/src/download.rs
+++ b/spog/ui/crates/components/src/download.rs
@@ -14,6 +14,7 @@ pub struct DownloadProperties {
     pub children: Children,
 
     pub href: Url,
+    pub r#type: String,
 }
 
 #[function_component(Download)]
@@ -25,9 +26,11 @@ pub fn download(props: &DownloadProperties) -> Html {
         let _ = gloo_utils::window().location().set_href(href.as_str());
     });
 
-    let onclick = use_wrap_tracking(onclick, props.href.clone(), |_, href| {
-        ("File Downloaded", json!({"href": href}))
-    });
+    let onclick = use_wrap_tracking(
+        onclick,
+        (props.r#type.clone(), props.href.clone()),
+        |_, (r#type, href)| ("SearchPage File Downloaded", json!({"type": r#type, "href": href})),
+    );
 
     html!(
         <Button
@@ -54,7 +57,7 @@ pub fn inline_download(props: &LocalDownloadButtonProperties) -> Html {
     let onclick = use_wrap_tracking(
         onclick,
         (props.r#type.clone(), props.filename.clone()),
-        |_, (r#type, filename)| ("Download File", json!({"type": r#type, "filename": filename})),
+        |_, (r#type, filename)| ("DetailsPage File Downloaded", json!({"type": r#type, "filename": filename})),
     );
 
     let href = use_state_eq::<Option<String>, _>(|| None);

--- a/spog/ui/crates/components/src/sbom/mod.rs
+++ b/spog/ui/crates/components/src/sbom/mod.rs
@@ -63,7 +63,7 @@ impl TableEntryRenderer<Column> for PackageEntry {
             Column::Created => date(self.package.created).into(),
             Column::Download => html!(
                 if let Some(url) = &self.url {
-                    <Download href={url.clone()} />
+                    <Download href={url.clone()} r#type="sbom"/>
                 }
             )
             .into(),


### PR DESCRIPTION
Currently there are 2 components that serve the "downloads"
- <Download/> used in the main tabs tables. I added the "type" field of this event and enhance the event key
- <LocalDownloadButton/> used in the page details of each entity "Advisory", "Sbom", "CVE"

Both need to be consistent in naming and in properties