### PR TITLE
Dataset configurable cronjob

### DIFF
--- a/deploy/k8s/chart/templates/init-dataset/030-CronJob.yaml
+++ b/deploy/k8s/chart/templates/init-dataset/030-CronJob.yaml
@@ -1,0 +1,40 @@
+{{ if .Values.dataset.enabledJob }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: apply-dataset-job
+  labels:
+    app.kubernetes.io/name: apply-dataset-job
+    app.kubernetes.io/component: init
+    app.kubernetes.io/part-of: trustification
+spec:
+  schedule: {{ .Values.dataset.scheduleJob | default "0 1 * * *" }}
+  suspend: {{ .Values.dataset.suspendJob | default true }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: apply-dataset-manual-job
+            app.kubernetes.io/component: init
+            app.kubernetes.io/part-of: trustification
+        spec:
+          restartPolicy: OnFailure
+
+          containers:
+            - name: run
+              image: {{ .Values.trustImage }}:{{ .Values.release }}
+              imagePullPolicy: {{ .Values.imagePullPolicy }}
+
+              command: [ "/usr/bin/bash" ]
+              args:
+                - "-ce"
+                - |
+                  set -e
+                  /trust bombastic walker --sink https://sbom.{{ .Values.domain }} --source /data/sbom
+                  /trust vexination walker --sink https://vex.{{ .Values.domain }}/api/v1/vex --source /data/csaf
+
+              env:
+                {{- include "trustification.authentication-client" ( dict "root" . "clientId" "walker" ) | nindent 16 }}
+{{ end }}

--- a/deploy/openshift/parameters.yaml
+++ b/deploy/openshift/parameters.yaml
@@ -153,3 +153,9 @@ parameters:
   value: trustification-service
 - name: INITIAL_BACKEND_JSON
   value: "{}"
+- name: DATASET_ENABLED_JOB
+  value: "true"
+- name: DATASET_SUSPEND_JOB
+  value: "true"
+- name: DATASET_SCHEDULE_JOB
+  value: "0 * * * *"

--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -1662,6 +1662,55 @@ objects:
   - apiVersion: batch/v1
     kind: CronJob
     metadata:
+      name: apply-dataset-job
+      labels:
+        app.kubernetes.io/name: apply-dataset-job
+        app.kubernetes.io/component: init
+        app.kubernetes.io/part-of: trustification
+    spec:
+      schedule: ${DATASET_SCHEDULE_JOB}
+      suspend: ${{DATASET_SUSPEND_JOB}}
+      concurrencyPolicy: Forbid
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: apply-dataset-manual-job
+                app.kubernetes.io/component: init
+                app.kubernetes.io/part-of: trustification
+            spec:
+              restartPolicy: OnFailure
+              containers:
+                - name: run
+                  image: ${BACKEND_IMAGE}:${IMAGE_TAG}
+                  imagePullPolicy: Always
+                  command:
+                    - /usr/bin/bash
+                  args:
+                    - -ce
+                    - 'set -e
+
+                      /trust bombastic walker --sink https://sbom.${DOMAIN} --source
+                      /data/sbom
+
+                      /trust vexination walker --sink https://vex.${DOMAIN}/api/v1/vex
+                      --source /data/csaf
+
+                      '
+                  env:
+                    - name: OIDC_PROVIDER_CLIENT_ID
+                      value: trusted-content-api
+                    - name: OIDC_PROVIDER_CLIENT_SECRET
+                      valueFrom:
+                        secretKeyRef:
+                          key: ${OIDC_PROVIDER_CLIENT_SECRET_KEY}
+                          name: ${OIDC_PROVIDER_CLIENT_SECRET_NAME}
+                    - name: OIDC_PROVIDER_ISSUER_URL
+                      value: ${ISSUER_URL}
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
       name: v11y-walker
       labels:
         app.kubernetes.io/name: v11y-walker
@@ -2156,3 +2205,9 @@ parameters:
   value: trustification-service
 - name: INITIAL_BACKEND_JSON
   value: "{}"
+- name: DATASET_ENABLED_JOB
+  value: "true"
+- name: DATASET_SUSPEND_JOB
+  value: "true"
+- name: DATASET_SCHEDULE_JOB
+  value: "0 * * * *"

--- a/deploy/openshift/values.yaml
+++ b/deploy/openshift/values.yaml
@@ -181,3 +181,6 @@ oidcClients:
       value: trusted-content-api
 dataset:
   enabled: false
+  enabledJob: ${{DATASET_ENABLED_JOB}}
+  suspendJob: ${{DATASET_SUSPEND_JOB}}
+  scheduleJob: ${DATASET_SCHEDULE_JOB}


### PR DESCRIPTION
Configurable job to run manually the dataset in case of needed. Currently exists a job executed only after a deploy.