### PR TITLE
feat: Upload SBOM

### DIFF
--- a/spog/api/src/endpoints/sbom/mod.rs
+++ b/spog/api/src/endpoints/sbom/mod.rs
@@ -1,8 +1,10 @@
 mod get;
+mod post;
 mod search;
 mod vuln;
 
 pub use get::*;
+pub use post::*;
 pub use search::*;
 pub use vuln::*;
 
@@ -25,5 +27,6 @@ pub(crate) fn configure(auth: Option<Arc<Authenticator>>) -> impl FnOnce(&mut Se
         );
         // the get operation doesn't get the authenticator added, as we check this using the access_token query parameter
         config.service(web::resource("/api/v1/sbom").to(get));
+        config.service(web::resource("/api/v1/sbom/upload").to(post));
     }
 }

--- a/spog/api/src/endpoints/sbom/post.rs
+++ b/spog/api/src/endpoints/sbom/post.rs
@@ -1,0 +1,35 @@
+use actix_web::{web, HttpResponse};
+use actix_web_httpauth::extractors::bearer::BearerAuth;
+use bytes::Bytes;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::app_state::AppState;
+
+#[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
+pub struct PostParams {
+    /// Access token to use for authentication
+    pub token: Option<String>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/sbom/upload",
+    responses(
+        (status = OK, description = "SBOM was uploaded"),
+    ),
+    params(PostParams)
+)]
+#[instrument(skip(state, access_token))]
+pub async fn post(
+    data: Bytes,
+    state: web::Data<AppState>,
+    web::Query(PostParams { token }): web::Query<PostParams>,
+    access_token: Option<BearerAuth>,
+) -> actix_web::Result<HttpResponse> {
+    let id = Uuid::new_v4().to_string();
+
+    let token = token.or_else(|| access_token.map(|s| s.token().to_string()));
+    state.post_sbom(&id, &token, data).await?;
+    Ok(HttpResponse::Ok().body(id))
+}

--- a/spog/ui/crates/backend/src/sbom.rs
+++ b/spog/ui/crates/backend/src/sbom.rs
@@ -1,5 +1,5 @@
 use crate::{ApplyAccessToken, Backend, Endpoint};
-use reqwest::StatusCode;
+use reqwest::{Body, StatusCode};
 use spog_model::prelude::{SbomReport, SbomSummary};
 use spog_ui_common::error::*;
 use std::rc::Rc;
@@ -21,6 +21,20 @@ impl SBOMService {
             access_token,
             client: reqwest::Client::new(),
         }
+    }
+
+    pub async fn upload(&self, data: impl Into<Body>) -> Result<String, ApiError> {
+        let url = self.backend.join(Endpoint::Api, "/api/v1/sbom/upload")?;
+
+        let response = self
+            .client
+            .post(url)
+            .latest_access_token(&self.access_token)
+            .body(data)
+            .send()
+            .await?;
+
+        Ok(response.api_error_for_status().await?.text().await?)
     }
 
     pub async fn get(&self, id: impl AsRef<str>) -> Result<Option<String>, ApiError> {

--- a/spog/ui/crates/components/src/download.rs
+++ b/spog/ui/crates/components/src/download.rs
@@ -57,7 +57,12 @@ pub fn inline_download(props: &LocalDownloadButtonProperties) -> Html {
     let onclick = use_wrap_tracking(
         onclick,
         (props.r#type.clone(), props.filename.clone()),
-        |_, (r#type, filename)| ("DetailsPage File Downloaded", json!({"type": r#type, "filename": filename})),
+        |_, (r#type, filename)| {
+            (
+                "DetailsPage File Downloaded",
+                json!({"type": r#type, "filename": filename}),
+            )
+        },
     );
 
     let href = use_state_eq::<Option<String>, _>(|| None);

--- a/spog/ui/crates/navigation/src/lib.rs
+++ b/spog/ui/crates/navigation/src/lib.rs
@@ -12,6 +12,7 @@ pub enum AppRoute {
     },
     Advisory(View),
     Scanner,
+    Uploader,
     Search {
         terms: String,
     },

--- a/spog/ui/src/console/mod.rs
+++ b/spog/ui/src/console/mod.rs
@@ -79,6 +79,7 @@ fn authenticated_page(props: &ChildrenProperties) -> Html {
                     if config.features.scanner {
                         <NavRouterItem<AppRoute> to={AppRoute::Scanner}>{ "Scan SBOM" }</NavRouterItem<AppRoute>>
                     }
+                    <NavRouterItem<AppRoute> to={AppRoute::Uploader}>{ "Upload SBOM" }</NavRouterItem<AppRoute>>
                     if config.features.extend_section {
                         <NavExpandable title="Extend">
                             if let Ok(url) = backend.join(Endpoint::Bombastic, "/swagger-ui/") {
@@ -224,6 +225,7 @@ fn render(route: AppRoute, config: &spog_model::config::Configuration) -> Html {
 
         AppRoute::Chicken => html!(<pages::Chicken/>),
         AppRoute::Scanner if config.features.scanner => html!(<pages::Scanner/>),
+        AppRoute::Uploader => html!(<pages::Uploader/>),
 
         AppRoute::Sbom(View::Search { query }) if config.features.dedicated_search => {
             html!(<pages::Sbom {query} />)

--- a/spog/ui/src/pages/mod.rs
+++ b/spog/ui/src/pages/mod.rs
@@ -15,6 +15,7 @@ mod sbom_report;
 mod sbom_search;
 mod scanner;
 mod search;
+mod uploader;
 
 pub use self::cve::*;
 pub use advisory::*;
@@ -31,3 +32,4 @@ pub use sbom_report::SbomReport;
 pub use sbom_search::Sbom;
 pub use scanner::*;
 pub use search::Search;
+pub use uploader::*;

--- a/spog/ui/src/pages/scanner/mod.rs
+++ b/spog/ui/src/pages/scanner/mod.rs
@@ -1,7 +1,7 @@
 mod inspect;
 // mod unknown;
-mod report;
-mod upload;
+pub mod report;
+pub mod upload;
 
 use analytics_next::TrackingEvent;
 use anyhow::bail;
@@ -56,7 +56,7 @@ fn is_supported_package(purl: &str) -> bool {
     }
 }
 
-fn parse(data: &[u8]) -> Result<SBOM, anyhow::Error> {
+pub fn parse(data: &[u8]) -> Result<SBOM, anyhow::Error> {
     let sbom = SBOM::parse(data)?;
 
     #[allow(clippy::single_match)]

--- a/spog/ui/src/pages/scanner/upload.rs
+++ b/spog/ui/src/pages/scanner/upload.rs
@@ -98,6 +98,9 @@ impl std::fmt::Display for DropContent {
 
 #[derive(Clone, PartialEq, Properties)]
 pub struct UploadProperties {
+    #[prop_or("Scan".into())]
+    pub primary_btn_text: AttrValue,
+
     pub onsubmit: Callback<Rc<String>>,
     #[prop_or(default_validate())]
     pub onvalidate: Callback<Rc<String>, Result<Rc<String>, String>>,
@@ -295,7 +298,7 @@ pub fn upload(props: &UploadProperties) -> Html {
                     disabled={state == InputState::Error}
                     onclick={onsubmit}
                 >
-                    {"Scan"}
+                    {&props.primary_btn_text}
                 </Button>
             </FlexItem>
             <FlexItem>

--- a/spog/ui/src/pages/uploader/inspect.rs
+++ b/spog/ui/src/pages/uploader/inspect.rs
@@ -1,0 +1,73 @@
+use super::CommonHeader;
+use patternfly_yew::prelude::*;
+use reqwest::Body;
+use spog_ui_backend::{use_backend, SBOMService};
+use spog_ui_common::error::components::Error;
+use spog_ui_navigation::AppRoute;
+use std::rc::Rc;
+use yew::prelude::*;
+use yew_more_hooks::hooks::r#async::*;
+use yew_nested_router::prelude::*;
+use yew_oauth2::hook::use_latest_access_token;
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct InspectProperties {
+    pub raw: Rc<String>,
+    pub onreset: Callback<()>,
+}
+
+#[function_component(Inspect)]
+pub fn inspect(props: &InspectProperties) -> Html {
+    let backend = use_backend();
+    let access_token = use_latest_access_token();
+
+    let upload = {
+        use_async_with_cloned_deps(
+            move |raw| async move {
+                let service = SBOMService::new(backend, access_token);
+                service.upload(Body::from((*raw).clone())).await.map(Rc::new)
+            },
+            props.raw.clone(),
+        )
+    };
+
+    html!(
+        <>
+            <CommonHeader onreset={props.onreset.clone()}/>
+            {
+                match &*upload {
+                    UseAsyncState::Pending | UseAsyncState::Processing => html!(
+                        <PageSection fill={PageSectionFill::Fill}>
+                            <Spinner />
+                        </PageSection>
+                    ),
+                    UseAsyncState::Ready(Ok(data)) => html!(
+                        <Redirect sbom_id={data.clone()}/>
+                    ),
+                    UseAsyncState::Ready(Err(_)) => html!(
+                        <Error title="Error" message="Error while uploading the file" />
+                    ),
+                }
+            }
+        </>
+    )
+}
+
+#[derive(Properties, Clone, PartialEq, Eq)]
+pub struct RedirectProps {
+    sbom_id: Rc<String>,
+}
+
+#[function_component(Redirect)]
+pub fn redirect(props: &RedirectProps) -> Html {
+    let router = use_router::<AppRoute>();
+
+    use_effect_with(props.clone(), move |_props| {
+        if let Some(router) = &router {
+            router.push(AppRoute::Search { terms: "".to_string() });
+        }
+        || {}
+    });
+
+    Html::default()
+}

--- a/spog/ui/src/pages/uploader/mod.rs
+++ b/spog/ui/src/pages/uploader/mod.rs
@@ -1,0 +1,100 @@
+mod inspect;
+
+use crate::pages::scanner::parse;
+use crate::pages::scanner::upload::Upload;
+use inspect::Inspect;
+use patternfly_yew::prelude::*;
+use spog_ui_utils::config::*;
+use std::rc::Rc;
+use yew::prelude::*;
+use yew_more_hooks::prelude::*;
+
+#[function_component(Uploader)]
+pub fn uploader() -> Html {
+    let content = use_state_eq(|| None::<Rc<String>>);
+    let onsubmit = use_callback(content.clone(), |data, content| content.set(Some(data)));
+
+    let sbom = use_memo(content.clone(), |content| {
+        content
+            .as_ref()
+            .and_then(|data| parse(data.as_bytes()).ok().map(|sbom| (data.clone(), Rc::new(sbom))))
+    });
+
+    let onvalidate = use_callback((), |data: Rc<String>, ()| {
+        let result = parse(data.as_bytes());
+        match result {
+            Ok(_sbom) => Ok(data),
+            Err(err) => Err(format!("Failed to parse SBOM as CycloneDX 1.3: {err}")),
+        }
+    });
+
+    // allow resetting the form
+    let onreset = use_callback(content.clone(), move |_, content| {
+        content.set(None);
+    });
+
+    match &*sbom {
+        Some((raw, _bom)) => {
+            html!(<Inspect {onreset} raw={(*raw).clone()} />)
+        }
+        None => {
+            html!(
+                <>
+                    <CommonHeader />
+
+                    <PageSection variant={PageSectionVariant::Light} fill=true>
+                        <Upload primary_btn_text="Upload" {onsubmit} {onvalidate} />
+                    </PageSection>
+                </>
+            )
+        }
+    }
+}
+
+#[derive(PartialEq, Properties)]
+pub struct CommonHeaderProperties {
+    #[prop_or_default]
+    pub onreset: Option<Callback<()>>,
+}
+
+#[function_component(CommonHeader)]
+fn common_header(props: &CommonHeaderProperties) -> Html {
+    let config = use_config();
+
+    let onreset = use_map(props.onreset.clone(), move |callback| callback.reform(|_| ()));
+
+    html!(
+        <PageSection sticky={[PageSectionSticky::Top]} variant={PageSectionVariant::Light}>
+            <Flex>
+                <FlexItem>
+                    <Content>
+                        <Title>{"Upload an SBOM"}</Title>
+                        <p>
+                            {"Load an existing CycloneDX 1.3 or SPDX 2.2 file"}
+                            if let Some(url) = &config.scanner.documentation_url {
+                                {" or "}
+                                <a
+                                    href={url.to_string()} target="_blank"
+                                    class="pf-v5-c-button pf-m-link pf-m-inline"
+                                >
+                                    {"learn about creating an SBOM"}
+                                </a>
+                            }
+                            { "." }
+                        </p>
+                    </Content>
+                </FlexItem>
+                <FlexItem modifiers={[FlexModifier::Align(Alignment::Right), FlexModifier::Align(Alignment::End)]}>
+                    if let Some(onreset) = onreset {
+                        <Button
+                            label={"Scan another"}
+                            icon={Icon::Redo}
+                            variant={ButtonVariant::Secondary}
+                            onclick={onreset}
+                        />
+                    }
+                </FlexItem>
+            </Flex>
+        </PageSection>
+    )
+}


### PR DESCRIPTION
- Uploads an sbom using the same patterns as "scan sbom"
- Each sbom details have now the "reports" tab wich invokes crds to generate the reports
- Each SBOM will have the ID generated by uuid (we can discuss this)
- **Yet to do**:  Fetch the list of sboms every 5 seconds to update the table ui so the user sees his sbom when it is ready after being indexed.