### PR TITLE
fix: fall back to 3.0 score when we can't parse 3.1

### DIFF
--- a/v11y/walker/src/lib.rs
+++ b/v11y/walker/src/lib.rs
@@ -78,7 +78,8 @@ impl Run {
                         }
                     }
 
-                    log::info!("Filters: {:?}", filter.len());
+                    log::info!("Filters: {}", filter.len());
+                    log::info!("Prefixes: {:?}", self.require_prefix);
 
                     let walker = WalkDir::new(&self.source).follow_links(true).contents_first(true);
                     'entry: for entry in walker {


### PR DESCRIPTION
This is **not** a fix for #1025, but might fall back to 3.0 and shows the vector it failed to parse