### PR TITLE
[stable] analytics tracking for changes to the filter

### DIFF
--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -45,10 +45,11 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "analytics-next"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209e4d7f284a933b786b78e8a53d805aa441aa6a8ba12401a3bc42cedd1f191"
+checksum = "c51c4630e678aa2416d523a7b09a9600ddc0d272cd00fcc3d79b57ce54942472"
 dependencies = [
+ "analytics-next-macro",
  "analytics-next-sys",
  "gloo-utils 0.2.0",
  "js-sys",
@@ -59,10 +60,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "analytics-next-sys"
-version = "0.1.3"
+name = "analytics-next-macro"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d221eef98497b3cdab6460cf6174d5c9e90bbc60b3f6b5e999bb47f9cd01cbf9"
+checksum = "c810419774e81e2508bafbf2a609f485783941d76917630ecf8a05594c8dcf02"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "analytics-next-sys"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36aae578fc4d023a5cdab9ffacd9761dbcd5dbe591728d0fb6ed5f7b6e1a443b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -153,7 +165,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -354,7 +366,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -557,7 +569,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -579,7 +591,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -825,7 +837,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1231,7 +1243,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1801,7 +1813,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1930,7 +1942,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2024,7 +2036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2072,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -2098,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -2476,7 +2488,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2558,7 +2570,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2604,7 +2616,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3020,7 +3032,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3042,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3102,7 +3114,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3255,7 +3267,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3393,7 +3405,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.38",
+ "syn 2.0.48",
  "url",
 ]
 
@@ -3493,7 +3505,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -3527,7 +3539,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3759,7 +3771,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3805,7 +3817,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2"
 description = "Single Pane of Glass"
 
 [dependencies]
-analytics-next = "0.1.3"
+analytics-next = "0.1.6"
 anyhow = "1"
 async-trait = "0.1"
 browser-panic-hook = "0.2.0"

--- a/spog/ui/crates/components/src/advisory/search.rs
+++ b/spog/ui/crates/components/src/advisory/search.rs
@@ -1,5 +1,6 @@
 use crate::{
     advisory::AdvisoryResult,
+    analytics::SearchContext,
     hooks::{use_generic_search, UseStandardSearch},
     search::*,
 };
@@ -7,7 +8,7 @@ use patternfly_yew::prelude::*;
 use spog_model::prelude::*;
 use spog_ui_backend::VexService;
 use spog_ui_common::utils::pagination_to_offset;
-use spog_ui_utils::config::use_config;
+use spog_ui_utils::{analytics::use_analytics, config::use_config};
 use std::rc::Rc;
 use trustification_api::search::SearchResult;
 use vexination_model::prelude::Vulnerabilities;
@@ -22,11 +23,13 @@ pub struct AdvisorySearchControlsProperties {
 #[function_component(AdvisorySearchControls)]
 pub fn advisory_search_controls(props: &AdvisorySearchControlsProperties) -> Html {
     let config = use_config();
+    let analytics = use_analytics();
+
     let filters = use_memo((), |()| config.vexination.filters.clone());
 
     let search_config = {
         use_memo((), move |()| {
-            let (search, defaults) = convert_search(&filters);
+            let (search, defaults) = convert_search(&filters, &analytics, SearchContext::Advisory);
             props.search_params.dispatch(SearchModeAction::ApplyDefault(defaults));
             search
         })

--- a/spog/ui/crates/components/src/analytics.rs
+++ b/spog/ui/crates/components/src/analytics.rs
@@ -1,0 +1,8 @@
+#[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SearchContext {
+    Advisory,
+    Cve,
+    Sbom,
+    Package,
+}

--- a/spog/ui/crates/components/src/cve/search.rs
+++ b/spog/ui/crates/components/src/cve/search.rs
@@ -1,4 +1,5 @@
 use crate::{
+    analytics::SearchContext,
     cve::CveResult,
     hooks::{use_generic_search, UseStandardSearch},
     search::*,
@@ -7,7 +8,7 @@ use patternfly_yew::prelude::*;
 use spog_model::cve::CveSearchDocument;
 use spog_ui_backend::CveService;
 use spog_ui_common::utils::pagination_to_offset;
-use spog_ui_utils::config::use_config;
+use spog_ui_utils::{analytics::use_analytics, config::use_config};
 use std::rc::Rc;
 use trustification_api::search::SearchResult;
 use v11y_model::search::Cves;
@@ -22,11 +23,13 @@ pub struct CveSearchControlsProperties {
 #[function_component(CveSearchControls)]
 pub fn cve_search_controls(props: &CveSearchControlsProperties) -> Html {
     let config = use_config();
+    let analytics = use_analytics();
+
     let filters = use_memo((), |()| config.cve.filters.clone());
 
     let search_config = {
         use_memo((), move |()| {
-            let (search, defaults) = convert_search(&filters);
+            let (search, defaults) = convert_search(&filters, &analytics, SearchContext::Cve);
             props.search_params.dispatch(SearchModeAction::ApplyDefault(defaults));
             search
         })

--- a/spog/ui/crates/components/src/lib.rs
+++ b/spog/ui/crates/components/src/lib.rs
@@ -1,6 +1,7 @@
 //! Re-usable component
 
 pub mod advisory;
+pub mod analytics;
 pub mod async_state_renderer;
 pub mod backend;
 pub mod common;

--- a/spog/ui/crates/components/src/packages/search.rs
+++ b/spog/ui/crates/components/src/packages/search.rs
@@ -1,4 +1,5 @@
 use crate::{
+    analytics::SearchContext,
     hooks::{use_generic_search, UseStandardSearch},
     packages::PackagesResult,
     search::*,
@@ -7,7 +8,7 @@ use bombastic_model::packages::PackageInfo;
 use patternfly_yew::prelude::*;
 use spog_ui_backend::PackageInfoService;
 use spog_ui_common::utils::pagination_to_offset;
-use spog_ui_utils::config::use_config;
+use spog_ui_utils::{analytics::use_analytics, config::use_config};
 use std::rc::Rc;
 use trustification_api::search::SearchResult;
 use yew::prelude::*;
@@ -21,11 +22,13 @@ pub struct PackageSearchControlsProperties {
 #[function_component(PackageSearchControls)]
 pub fn packages_search_controls(props: &PackageSearchControlsProperties) -> Html {
     let config = use_config();
+    let analytics = use_analytics();
+
     let filters = use_memo((), |()| config.packages.filters.clone());
 
     let search_config = {
         use_memo((), move |()| {
-            let (search, defaults) = convert_search(&filters);
+            let (search, defaults) = convert_search(&filters, &analytics, SearchContext::Package);
             props.search_params.dispatch(SearchModeAction::ApplyDefault(defaults));
             search
         })

--- a/spog/ui/crates/components/src/sbom/search.rs
+++ b/spog/ui/crates/components/src/sbom/search.rs
@@ -1,4 +1,5 @@
 use crate::{
+    analytics::SearchContext,
     hooks::{use_generic_search, SearchOperationContext, UseStandardSearch},
     sbom::SbomResult,
     search::*,
@@ -8,7 +9,7 @@ use patternfly_yew::prelude::*;
 use spog_model::prelude::*;
 use spog_ui_backend::{self, PackageService};
 use spog_ui_common::utils::pagination_to_offset;
-use spog_ui_utils::config::use_config;
+use spog_ui_utils::{analytics::use_analytics, config::use_config};
 use std::rc::Rc;
 use trustification_api::search::SearchResult;
 use yew::prelude::*;
@@ -22,9 +23,12 @@ pub struct SbomSearchControlsProperties {
 #[function_component(SbomSearchControls)]
 pub fn sbom_search_controls(props: &SbomSearchControlsProperties) -> Html {
     let config = use_config();
+    let analytics = use_analytics();
+
     let filters = use_memo((), |()| config.bombastic.filters.clone());
+
     let search_config = use_memo((), |()| {
-        let (search, defaults) = convert_search(&filters);
+        let (search, defaults) = convert_search(&filters, &analytics, SearchContext::Sbom);
         props.search_params.dispatch(SearchModeAction::ApplyDefault(defaults));
         search
     });

--- a/spog/ui/crates/utils/src/analytics/mod.rs
+++ b/spog/ui/crates/utils/src/analytics/mod.rs
@@ -48,6 +48,15 @@ impl AnalyticsContext {
 
     /// trigger a "tracking" event, if enabled
     pub fn track<'a>(&self, event: impl Into<TrackingEvent<'a>>) {
+        #[cfg(debug_assertions)]
+        {
+            let event = event.into();
+            log::debug!("Tracking event: {event:?}");
+            if let Some(analytics) = &self.analytics {
+                analytics.track(event);
+            }
+        }
+        #[cfg(not(debug_assertions))]
         if let Some(analytics) = &self.analytics {
             analytics.track(event);
         }

--- a/v11y/walker/src/lib.rs
+++ b/v11y/walker/src/lib.rs
@@ -78,7 +78,8 @@ impl Run {
                         }
                     }
 
-                    log::info!("Filters: {:?}", filter.len());
+                    log::info!("Filters: {}", filter.len());
+                    log::info!("Prefixes: {:?}", self.require_prefix);
 
                     let walker = WalkDir::new(&self.source).follow_links(true).contents_first(true);
                     'entry: for entry in walker {


### PR DESCRIPTION
This is mainly adding the analytics tracking for changes to the filter.

- [fix: fall back to 3.0 score when we can't parse 3.1](https://github.com/trustification/trustification/pull/1029/commits/4cfd9ade78fa29bf4b56e841e99a2f868218912f)

- [chore: show prefixes when running](https://github.com/trustification/trustification/pull/1029/commits/2543d1fb6f9d1aa348d3c4e80eaf803e7ce5eddc)

- [feat: add tracking events for filter controls](https://github.com/trustification/trustification/pull/1029/commits/8e5a47c638ddcdef46410f3c65b5bde3baaf5368)

