### PR TITLE
[stable] Cherry-pick relevant commits of PR #1038

### DIFF
--- a/bombastic/indexer/src/lib.rs
+++ b/bombastic/indexer/src/lib.rs
@@ -55,7 +55,7 @@ impl Run {
                 |_context| async { Ok(()) },
                 |context| async move {
                     let sbom_index: Box<dyn WriteIndex<Document = (SBOM, String)>> = Box::new(sbom::Index::new());
-                    let index = block_in_place(|| {
+                    let sbom_store = block_in_place(|| {
                         IndexStore::new(&self.storage, &self.index, sbom_index, context.metrics.registry())
                     })?;
 
@@ -72,7 +72,7 @@ impl Run {
                     }
 
                     let mut indexer = Indexer {
-                        indexes: vec![index, package_store],
+                        indexes: vec![sbom_store, package_store],
                         storage,
                         bus,
                         stored_topic: self.stored_topic.as_str(),

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -738,10 +738,11 @@ where
             ) {
                 Ok(Some(index)) => {
                     *self.inner.write().unwrap() = index;
-                    log::debug!("Index reloaded");
+                    log::debug!("Index replaced");
                 }
                 Ok(None) => {
                     // No index change
+                    log::debug!("No index change");
                 }
                 Err(e) => {
                     log::warn!("Error syncing index: {:?}, keeping old", e);

--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -103,46 +103,7 @@ where
             select! {
                 command = self.commands.recv() => {
                     if let Some(IndexerCommand::Reindex) = command {
-                        for index in &mut self.indexes {
-                            index.reset()?;
-                        }
-                        log::info!("Reindexing all documents");
-                        const MAX_RETRIES: usize = 3;
-                        let mut retries = MAX_RETRIES;
-                        let mut token = ContinuationToken::default();
-                        loop {
-                            retries -= 1;
-                            match self.reindex(&mut writers, token).await {
-                                Ok(_) => {
-                                    log::info!("Reindexing finished");
-                                    for (index, writer) in self.indexes.iter_mut().zip(writers.drain(..)) {
-                                        match index.snapshot(writer, &self.storage, true).await {
-                                            Ok(_) => {
-                                                log::info!("Reindexed index published");
-                                            }
-                                            Err(e) => {
-                                                log::warn!("(Ignored) Error publishing index: {:?}", e);
-                                            }
-                                        }
-                                    }
-                                    for index in self.indexes.iter_mut() {
-                                        writers.push(block_in_place(|| index.writer())?);
-                                    }
-                                    *self.status.lock().await = IndexerStatus::Running;
-                                    break;
-                                }
-                                Err((e, resume_token)) => {
-                                    token = resume_token;
-                                    log::warn!("Reindexing failed: {:?}. Retries: {}", e, retries);
-                                    if retries == 0 {
-                                        panic!("Reindexing failed after {} retries, giving up", MAX_RETRIES);
-                                    } else {
-                                        *self.status.lock().await = IndexerStatus::Failed { error: e.to_string() };
-                                        tokio::time::sleep(Duration::from_secs(10)).await;
-                                    }
-                                }
-                            }
-                        }
+                        self.handle_reindex(&mut writers).await?;
                     }
                 }
                 event = consumer.next() => match event {
@@ -250,6 +211,53 @@ where
                 }
             }
         }
+    }
+
+    async fn handle_reindex(&mut self, writers: &mut Vec<IndexWriter>) -> anyhow::Result<()> {
+        log::info!("Reindexing all documents");
+
+        for index in &mut self.indexes {
+            index.reset()?;
+        }
+
+        const MAX_RETRIES: usize = 3;
+        let mut retries = MAX_RETRIES;
+        let mut token = ContinuationToken::default();
+        loop {
+            retries -= 1;
+            match self.reindex(writers, token).await {
+                Ok(_) => {
+                    log::info!("Reindexing finished");
+                    for (index, writer) in self.indexes.iter_mut().zip(writers.drain(..)) {
+                        match index.snapshot(writer, &self.storage, true).await {
+                            Ok(_) => {
+                                log::info!("Reindexed index published");
+                            }
+                            Err(e) => {
+                                log::warn!("(Ignored) Error publishing index: {:?}", e);
+                            }
+                        }
+                    }
+                    for index in self.indexes.iter_mut() {
+                        writers.push(block_in_place(|| index.writer())?);
+                    }
+                    *self.status.lock().await = IndexerStatus::Running;
+                    break;
+                }
+                Err((e, resume_token)) => {
+                    token = resume_token;
+                    log::warn!("Reindexing failed: {:?}. Retries: {}", e, retries);
+                    if retries == 0 {
+                        panic!("Reindexing failed after {} retries, giving up", MAX_RETRIES);
+                    } else {
+                        *self.status.lock().await = IndexerStatus::Failed { error: e.to_string() };
+                        tokio::time::sleep(Duration::from_secs(10)).await;
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 
     async fn reindex(


### PR DESCRIPTION
CP of https://github.com/trustification/trustification/pull/1038

When reindexing, the indexes are "reset", which basically means that new indexes are being created. However, the loop still holds on to the old writers. So when resetting the indexes, we must also create new writers.

Otherwise the logic will write to the old indexes, and the new ones will stay empty.

Only the following commits must be merged backported:

* 239e44b6209c664d18e005310ce880d94cd4a7af
* 931b16c1d2b7037c9febb231c99d8654b3de839f
* 3eecb8659bd75f9ed726a59b6f68e66dd355fe8e
* 7e82ad9010556be122fb6d41e8abc24d11659879 (actual fix)

---

Also, this changes the DS1 `csaf` layout to the new file system layout