### PR TITLE
task: Request api.trusted_content scope to get orgId

### DIFF
--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -1043,7 +1043,7 @@ objects:
                 - name: CLIENT_ID
                   value: trusted-content-frontend
                 - name: SCOPES
-                  value: openid email id.username
+                  value: openid email id.username api.trusted_content
                 - name: WRITE_KEY
                   valueFrom:
                     secretKeyRef:

--- a/deploy/openshift/values.yaml
+++ b/deploy/openshift/values.yaml
@@ -166,7 +166,7 @@ guac:
 oidcClients:
   frontend:
     issuerUrl: ${ISSUER_URL}
-    scopes: "openid email id.username"
+    scopes: "openid email id.username api.trusted_content"
     clientId:
       value: trusted-content-frontend
   walker:


### PR DESCRIPTION
Within RHSSO we have a scope `api.trusted_content` assigned. After contacting the RHSSO team, they have set up the scope `api.trusted_content` so we will get the ORG_ID claim if the scope `api.trusted_content` is requested while doing the auth flow.

I'd like to deploy this to https://trustification.stage.devshift.net/ . Should I open this PR directly on the `stable` branch?