### PR TITLE
define git-auth workspace for release PipelineRun

### DIFF
--- a/.tekton/trustification-service-release.yaml
+++ b/.tekton/trustification-service-release.yaml
@@ -375,6 +375,8 @@ spec:
         - "false"
     workspaces:
     - name: workspace
+    - name: git-auth
+      optional: true
     - name: docker-credentials
       optional: true
   taskRunTemplate: {}
@@ -393,4 +395,7 @@ spec:
   - name: docker-credentials
     secret:
       secretName: trustification-service-release
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
 status: {}


### PR DESCRIPTION
## Why

Results watcher logs have been throwing a lot of "reconcile error" - 
```
{"level":"error","ts":"2024-02-05T11:52:51.162Z","logger":"watcher","caller":"controller/controller.go:566","msg":"Reconcile error","knative.dev/traceid":"92bf1cfc-18b6-46fa-abfe-97bc1318686e","knative.dev/key":"trusted-content-tenant/trustification-service-release-s6ddf","duration":"5.540319796s","error":"error patching object: admission webhook \"validation.webhook.pipeline.tekton.dev\" denied the request: validation failed: invalid value: pipeline task \"clone-repository\" expects workspace with name \"git-auth\" but none exists in pipeline spec: spec[1].workspaces[1]","stacktrace":"knative.dev/pkg/controller.(*Impl).handleErr\n\t/opt/app-root/src/vendor/knative.dev/pkg/controller/controller.go:566\nknative.dev/pkg/controller.(*Impl).processNextWorkItem\n\t/opt/app-root/src/vendor/knative.dev/pkg/controller/controller.go:543\nknative.dev/pkg/controller.(*Impl).RunContext.func3\n\t/opt/app-root/src/vendor/knative.dev/pkg/controller/controller.go:491"}
```
## Change 

Define the `git-auth` workspace. This is following the fact that the workspace `basic-auth` is provided for `git-clone` task but is not provided in the Pipeline Spec to be used by the taskrun. Please refer https://github.com/tektoncd/catalog/tree/main/task/git-clone/0.9/#using-basic-auth-credentials on using git-clone task in a PipelineRun.