### PR TITLE
feat: allow using groups as source for permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3718,6 +3718,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96acbc6188d3bd83519d053efec756aa4419de62ec47be7f28dec297f7dc9eb0"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "jsonpath_lib"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4809,6 +4822,51 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e1288dbd7786462961e69bfd4df7848c1e37e8b74303dbdab82c3a9cdd2809"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1381c29a877c6d34b8c176e734f35d7f7f5b3adaefe940cb4d1bb7af94678e2e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0934d6907f148c22a3acbda520c7eed243ad7487a30f51f6ce52b58b7077a8a"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "petgraph"
@@ -7818,6 +7876,7 @@ dependencies = [
  "clap",
  "futures-util",
  "humantime",
+ "jsonpath-rust",
  "log",
  "openid",
  "reqwest",
@@ -8000,6 +8059,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { version = "0.4.26", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
 futures-util = "0.3"
 humantime = "2"
+jsonpath-rust = "0.4"
 log = "0.4"
 openid = "0.12"
 reqwest = "0.11"

--- a/auth/schema/auth.json
+++ b/auth/schema/auth.json
@@ -30,7 +30,7 @@
         "issuerUrl"
       ],
       "properties": {
-        "additionalScopes": {
+        "additionalPermissions": {
           "description": "Additional scopes which get added for client\n\nThis can be useful if a client is considered to only provide identities which are supposed to have certain scopes, but don't provide them.",
           "type": "array",
           "items": {
@@ -40,6 +40,24 @@
         "clientId": {
           "description": "The ID of the client",
           "type": "string"
+        },
+        "groupMappings": {
+          "description": "Mapping table for groups returned found through the `groups_selector` to permissions.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "groupSelector": {
+          "description": "JSON path extracting a list of groups from the access token",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "issuerUrl": {
           "description": "The issuer URL",
@@ -54,7 +72,7 @@
           ]
         },
         "scopeMappings": {
-          "description": "Mapping table for scopes returned by the issuer to scopes which are expected by us.",
+          "description": "Mapping table for scopes returned by the issuer to permissions.",
           "type": "object",
           "additionalProperties": {
             "type": "array",

--- a/auth/src/authenticator/claims.rs
+++ b/auth/src/authenticator/claims.rs
@@ -35,14 +35,14 @@ impl CompactJson for AccessTokenClaims {}
 #[derive(Clone, Debug)]
 pub struct ValidatedAccessToken {
     pub access_token: AccessTokenClaims,
-    pub mapped_scopes: Vec<String>,
+    pub permissions: Vec<String>,
 }
 
 impl From<ValidatedAccessToken> for UserDetails {
     fn from(token: ValidatedAccessToken) -> Self {
         Self {
             id: token.access_token.sub,
-            scopes: token.mapped_scopes,
+            permissions: token.permissions,
         }
     }
 }

--- a/auth/src/authenticator/config.rs
+++ b/auth/src/authenticator/config.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 #[derive(Clone, Debug, Default, clap::Args)]
 #[command(rename_all_env = "SCREAMING_SNAKE_CASE", next_help_heading = "Authentication")]
 pub struct AuthenticatorConfigArguments {
-    /// Flag to to disable authentication, default is on.
+    /// Flag to disable authentication, default is on.
     #[arg(
         id = "authentication-disabled",
         default_value_t = false,
@@ -36,8 +36,10 @@ impl AuthenticatorConfig {
                     client_id: client_id.to_string(),
                     issuer_url: devmode::issuer_url(),
                     scope_mappings: default_scope_mappings(),
-                    additional_scopes: Default::default(),
+                    additional_permissions: Default::default(),
                     required_audience: None,
+                    group_selector: None,
+                    group_mappings: Default::default(),
                     tls_insecure: false,
                     tls_ca_certificates: Default::default(),
                 })
@@ -103,7 +105,7 @@ pub struct AuthenticatorClientConfig {
     /// The issuer URL
     pub issuer_url: String,
 
-    /// Mapping table for scopes returned by the issuer to scopes which are expected by us.
+    /// Mapping table for scopes returned by the issuer to permissions.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub scope_mappings: HashMap<String, Vec<String>>,
 
@@ -112,7 +114,8 @@ pub struct AuthenticatorClientConfig {
     /// This can be useful if a client is considered to only provide identities which are supposed
     /// to have certain scopes, but don't provide them.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub additional_scopes: Vec<String>,
+    #[serde(alias = "additional_scopes")]
+    pub additional_permissions: Vec<String>,
 
     /// Enforce an audience claim (`aud`) for tokens.
     ///
@@ -120,9 +123,18 @@ pub struct AuthenticatorClientConfig {
     #[serde(default)]
     pub required_audience: Option<String>,
 
+    /// JSON path extracting a list of groups from the access token
+    #[serde(default)]
+    pub group_selector: Option<String>,
+
+    /// Mapping table for groups returned found through the `groups_selector` to permissions.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub group_mappings: HashMap<String, Vec<String>>,
+
     /// Ignore TLS checks when contacting the issuer
     #[serde(default)]
     pub tls_insecure: bool,
+
     /// Add additional certificates as trust anchor for contacting the issuer
     #[serde(default)]
     pub tls_ca_certificates: Vec<PathBuf>,
@@ -139,7 +151,9 @@ impl SingleAuthenticatorClientConfig {
                 tls_insecure: self.tls_insecure,
                 required_audience: self.required_audience.clone(),
                 scope_mappings: default_scope_mappings(),
-                additional_scopes: Default::default(),
+                group_selector: None,
+                group_mappings: Default::default(),
+                additional_permissions: Default::default(),
             })
     }
 }

--- a/auth/src/authenticator/mod.rs
+++ b/auth/src/authenticator/mod.rs
@@ -13,12 +13,17 @@ pub mod error;
 pub mod user;
 
 use crate::{authenticator::claims::ValidatedAccessToken, authenticator::config::AuthenticatorConfig};
+use anyhow::anyhow;
 use biscuit::jws::Compact;
 use claims::AccessTokenClaims;
 use config::AuthenticatorClientConfig;
 use error::AuthenticationError;
 use futures_util::{stream, StreamExt, TryStreamExt};
+use jsonpath_rust::parser::model::JsonPath;
+use jsonpath_rust::path::json_path_instance;
+use jsonpath_rust::JsonPathValue;
 use openid::{Client, Configurable, Discovered, Empty, Jws};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::ops::Deref;
 use tracing::instrument;
@@ -145,11 +150,26 @@ async fn create_client(config: AuthenticatorClientConfig) -> anyhow::Result<Auth
 
     log::debug!("Discovered OpenID: {:#?}", client.config());
 
+    let group_selector = config
+        .group_selector
+        .map(|selector| {
+            jsonpath_rust::parser::parser::parse_json_path(&selector).map_err(|err| {
+                anyhow!(
+                    "Unable to parse JSON path group selector for client '{}' / '{}': {err}",
+                    config.issuer_url,
+                    client.client_id,
+                )
+            })
+        })
+        .transpose()?;
+
     Ok(AuthenticatorClient {
         client,
         audience: config.required_audience,
         scope_mappings: config.scope_mappings,
-        additional_scopes: config.additional_scopes,
+        additional_permissions: config.additional_permissions,
+        group_selector,
+        group_mappings: config.group_mappings,
     })
 }
 
@@ -158,20 +178,44 @@ pub struct AuthenticatorClient {
     client: Client<Discovered>,
     audience: Option<String>,
     scope_mappings: HashMap<String, Vec<String>>,
-    additional_scopes: Vec<String>,
+    additional_permissions: Vec<String>,
+    group_selector: Option<JsonPath>,
+    group_mappings: HashMap<String, Vec<String>>,
 }
 
 impl AuthenticatorClient {
     /// Convert from a set of (verified!) access token claims into a [`ValidatedAccessToken`] struct.
     pub fn convert_token(&self, access_token: AccessTokenClaims) -> ValidatedAccessToken {
-        let mut mapped_scopes = Self::map_scopes(&access_token.scope, &self.scope_mappings);
-        mapped_scopes.extend(self.additional_scopes.clone());
+        let mut permissions = Self::map_scopes(&access_token.scope, &self.scope_mappings);
+        permissions.extend(self.additional_permissions.clone());
+        let groups = self
+            .group_selector
+            .as_ref()
+            .map(|selector| Self::extract_groups(&access_token.extended_claims, selector))
+            .unwrap_or_default();
+
+        permissions.extend(Self::map_groups(groups, &self.group_mappings));
+
         ValidatedAccessToken {
             access_token,
-            mapped_scopes,
+            permissions,
         }
     }
 
+    /// Extract the groups from the value/access token
+    fn extract_groups(value: &Value, selector: &JsonPath) -> Vec<String> {
+        json_path_instance(selector, value)
+            .find(JsonPathValue::from_root(value))
+            .into_iter()
+            .filter_map(|group| match group {
+                JsonPathValue::Slice(data, _) => data.as_str().map(|s| s.to_string()),
+                JsonPathValue::NewValue(data) => data.as_str().map(|s| s.to_string()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Run the scopes through the scope mapping configuration
     fn map_scopes(scopes: &str, scope_mappings: &HashMap<String, Vec<String>>) -> Vec<String> {
         scopes
             .split(' ')
@@ -180,6 +224,17 @@ impl AuthenticatorClient {
                     .get(scope)
                     .cloned()
                     .unwrap_or_else(|| vec![scope.to_string()])
+            })
+            .collect()
+    }
+
+    /// Run the groups through the group mapping configuration
+    fn map_groups(groups: Vec<String>, group_mappings: &HashMap<String, Vec<String>>) -> Vec<String> {
+        groups
+            .into_iter()
+            .flat_map(|group| match group_mappings.get(&group) {
+                Some(permissions) => permissions.clone(),
+                None => vec![group],
             })
             .collect()
     }
@@ -196,6 +251,7 @@ impl Deref for AuthenticatorClient {
 #[cfg(test)]
 mod test {
     use super::*;
+    use jsonpath_rust::JsonPathFinder;
 
     fn assert_scope_mapping(scopes: &str, mappings: &[(&str, &[&str])], expected: &[&str]) {
         let mappings = mappings
@@ -219,5 +275,49 @@ mod test {
     #[test]
     fn test_no_scope_mapping() {
         assert_scope_mapping("foo bar baz", &[], &["foo", "bar", "baz"]);
+    }
+
+    #[test]
+    fn test_groups() {
+        let token = r#"{
+  "sub": "dfbf2b67-eb5e-44e5-8d70-581bf6fa4eff",
+  "foo:bar": [
+    "manager",
+    "reader"
+  ],
+  "iss": "https://foo/bar",
+  "version": 2,
+  "client_id": "1m4qeejd6v593cd4bimueircjk",
+  "origin_jti": "a49f30ee-a4d3-4f16-aff1-d334ab4e3b00",
+  "token_use": "access",
+  "scope": "openid",
+  "auth_time": 1707311332,
+  "exp": 1707314932,
+  "iat": 1707311332,
+  "jti": "524d55bf-da6b-41a6-91d2-8c16f9dfd198",
+  "username": "admin"
+}"#;
+
+        let value: Value = serde_json::from_str(token).unwrap();
+
+        const PATH: &str = r#"$.['foo:bar'][*]"#;
+        let alternative = JsonPathFinder::from_str(token, PATH)
+            .unwrap()
+            .find_slice()
+            .into_iter()
+            .flat_map(|v| {
+                // println!("Found: {v:?}");
+                match v {
+                    JsonPathValue::Slice(data, _) => data.as_str().map(ToString::to_string),
+                    JsonPathValue::NewValue(data) => data.as_str().map(ToString::to_string),
+                    _ => None,
+                }
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(&alternative, &["manager", "reader"]);
+
+        let selector = jsonpath_rust::parser::parser::parse_json_path(PATH).unwrap();
+        let groups = AuthenticatorClient::extract_groups(&value, &selector);
+        assert_eq!(&groups, &["manager", "reader"]);
     }
 }

--- a/auth/src/authenticator/user.rs
+++ b/auth/src/authenticator/user.rs
@@ -30,15 +30,15 @@ use crate::authenticator::error::AuthorizationError;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UserDetails {
     pub id: String,
-    pub scopes: Vec<String>,
+    pub permissions: Vec<String>,
 }
 
 impl UserDetails {
-    pub fn require_scope(&self, scope: impl AsRef<str>) -> Result<(), AuthorizationError> {
-        let scope = scope.as_ref();
-        log::debug!("Requiring scope: {scope}");
+    pub fn require_permission(&self, permission: impl AsRef<str>) -> Result<(), AuthorizationError> {
+        let permission = permission.as_ref();
+        log::debug!("Requiring scope: {permission}");
 
-        if self.scopes.iter().any(|r| r == scope) {
+        if self.permissions.iter().any(|r| r == permission) {
             Ok(())
         } else {
             Err(AuthorizationError::Failed)

--- a/auth/src/authorizer/mod.rs
+++ b/auth/src/authorizer/mod.rs
@@ -19,7 +19,7 @@ impl Authorizer {
 
     /// Require a permission from a user.
     ///
-    /// If the user passes the check, the function will return `Ok(())`. Otherwise an error will be
+    /// If the user passes the check, the function will return `Ok(())`. Otherwise, an error will be
     /// returned.
     pub fn require(&self, user: &UserInformation, permission: Permission) -> Result<(), AuthorizationError> {
         if self.config.is_none() {
@@ -34,7 +34,7 @@ impl Authorizer {
             UserInformation::Anonymous => return Err(AuthorizationError::Failed),
         };
 
-        user.require_scope(permission)?;
+        user.require_permission(permission)?;
 
         // we passed
         Ok(())


### PR DESCRIPTION
Aside from renaming to `additional_permissions` (which should still be a non-breaking change due to the alias) that shouldn't change the current behavior. But it allows to extract groups and map those into permissions too.