### PR TITLE
fix: Tab selection event data

### DIFF
--- a/spog/ui/src/pages/search/mod.rs
+++ b/spog/ui/src/pages/search/mod.rs
@@ -98,7 +98,7 @@ pub fn search(props: &SearchProperties) -> Html {
     let onselect = use_callback((analytics.clone(), tab.clone()), |index, (analytics, tab)| {
         analytics.track(AnalyticEvents {
             obj_name: ObjectNameAnalytics::SearchPage,
-            action: ActionAnalytics::SelectTab(format!("{}", *tab.clone())),
+            action: ActionAnalytics::SelectTab(format!("{}", &index)),
         });
 
         tab.set(index)


### PR DESCRIPTION
Currently we are sending the previous tab selected, while we should send the tab that has just been selected. This PR will fix it