### PR TITLE
Adding git and postgresql client on the default image

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -47,8 +47,6 @@ jobs:
             containerfile: container_files/Containerfile.docs
           - name: trust-tests
             containerfile: container_files/Containerfile.tests
-          - name: git
-            containerfile: container_files/Containerfile.git
 
     steps:
 

--- a/container_files/Containerfile.git
+++ b/container_files/Containerfile.git
@@ -1,5 +1,0 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-LABEL org.opencontainers.image.source="https://github.com/trustification/trustification"
-RUN microdnf install --nodocs git -y
-ENTRYPOINT ["git"]
-WORKDIR /git

--- a/container_files/Containerfile.services
+++ b/container_files/Containerfile.services
@@ -103,7 +103,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL org.opencontainers.image.source="https://github.com/trustification/trustification"
 
-RUN microdnf update -y && microdnf install -y nginx jq
+RUN microdnf update -y && microdnf install -y nginx jq git postgresql
 RUN true \
     && mkdir /public \
     && mkdir /endpoints


### PR DESCRIPTION
Adding git and postgresql client on the default image. In this way we can skip the maintenance of the git image and the use of postgresql server image used only from a cronjob.