### PR TITLE
ci: prepare for release branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,11 +6,13 @@ on:
     branches:
       - main
       - stable
+      - release/*
   # Also on PRs, just be careful not to publish anything
   pull_request:
     branches:
       - main
       - stable
+      - release/*
   # Allow to be called from other workflows (like "release")
   workflow_call:
   # But don't trigger on tags, as they are covered by the "release.yaml" workflow

--- a/.github/workflows/rita-new-pr.yaml
+++ b/.github/workflows/rita-new-pr.yaml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - stable
+      - release/*
     types:
       - opened
       - reopened

--- a/.github/workflows/rita-pr-merged.yaml
+++ b/.github/workflows/rita-pr-merged.yaml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - stable
+      - release/*
     types:
       - closed
 

--- a/.github/workflows/rita-request-review.yaml
+++ b/.github/workflows/rita-request-review.yaml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - stable
+      - release/*
     types:
       - review_requested
 


### PR DESCRIPTION
This adds CI testing for "release" branches:

* using the pattern `release/*` (e.g. `release/0.1.x`)
* releases are still built from tags, not branches
* the task of actually branching off of `main` can be done next (when we think it's ready)
* this is only for "upstream", nothing else
