### PR TITLE
Bump guac image to v0.3.27

### DIFF
--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -12,7 +12,7 @@ EXHORT_API_PORT=8088
 COLLECTORIST_API_PORT=8180
 COLLECTOR_OSV_API_PORT=8181
 COLLECTOR_SNYK_API_PORT=8182
-GUAC_IMAGE=ghcr.io/trustification/guac:v0.3.26
+GUAC_IMAGE=ghcr.io/trustification/guac:v0.3.27
 #GUAC_IMAGE=local-organic-guac
 
 CHROMEDRIVER_IMAGE=docker.io/selenium/standalone-chrome:117.0

--- a/deploy/k8s/legacy/values-crc.yaml
+++ b/deploy/k8s/legacy/values-crc.yaml
@@ -3,7 +3,7 @@ trustImage: ghcr.io/trustification/trust
 uiImage: ghcr.io/trustification/trust
 docsImage: ghcr.io/trustification/trust-docs
 testsImage: ghcr.io/trustification/trust-tests
-guacImage: ghcr.io/trustification/guac:v0.3.21
+guacImage: ghcr.io/trustification/guac:v0.3.27
 domain: trustification.apps-crc.testing
 
 deployPostgres: true

--- a/deploy/k8s/legacy/values-minikube.yaml
+++ b/deploy/k8s/legacy/values-minikube.yaml
@@ -3,7 +3,7 @@ trustImage: ghcr.io/trustification/trust
 uiImage: ghcr.io/trustification/trust
 docsImage: ghcr.io/trustification/trust-docs
 testsImage: ghcr.io/trustification/trust-tests
-guacImage: ghcr.io/trustification/guac:v0.3.21
+guacImage: ghcr.io/trustification/guac:v0.3.27
 
 deployPostgres: true
 deployMinio: true

--- a/deploy/k8s/legacy/values-openshift-blueprint.yaml
+++ b/deploy/k8s/legacy/values-openshift-blueprint.yaml
@@ -41,7 +41,7 @@ trustImage: ghcr.io/trustification/trust
 uiImage: ghcr.io/trustification/trust
 docsImage: ghcr.io/trustification/trust-docs
 testsImage: ghcr.io/trustification/trust-tests
-guacImage: ghcr.io/trustification/guac:v0.3.21
+guacImage: ghcr.io/trustification/guac:v0.3.27
 
 domain: apps.cluster-s2528.sandbox1481.opentlc.com
 

--- a/deploy/trustification.dev/dev.yaml
+++ b/deploy/trustification.dev/dev.yaml
@@ -3,7 +3,7 @@ trustImage: ghcr.io/trustification/trust
 uiImage: ghcr.io/trustification/trust
 docsImage: ghcr.io/trustification/trust-docs
 testsImage: ghcr.io/trustification/trust-tests
-guacImage: ghcr.io/trustification/guac:v0.3.21
+guacImage: ghcr.io/trustification/guac:v0.3.27
 domain: dev.trustification.dev
 replicas: 1
 graphqlReplicas: 1

--- a/deploy/trustification.dev/prod.yaml
+++ b/deploy/trustification.dev/prod.yaml
@@ -3,7 +3,7 @@ trustImage: ghcr.io/trustification/trust
 uiImage: ghcr.io/trustification/trust
 docsImage: ghcr.io/trustification/trust-docs
 testsImage: ghcr.io/trustification/trust-tests
-guacImage: ghcr.io/trustification/guac:v0.3.21
+guacImage: ghcr.io/trustification/guac:v0.3.27
 domain: trustification.dev
 replicas: 2
 graphqlReplicas: 1

--- a/deploy/trustification.dev/staging.yaml
+++ b/deploy/trustification.dev/staging.yaml
@@ -3,7 +3,7 @@ trustImage: ghcr.io/trustification/trust
 uiImage: ghcr.io/trustification/trust
 docsImage: ghcr.io/trustification/trust-docs
 testsImage: ghcr.io/trustification/trust-tests
-guacImage: ghcr.io/trustification/guac:v0.3.21
+guacImage: ghcr.io/trustification/guac:v0.3.27
 domain: staging.trustification.dev
 replicas: 1
 imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Bump guac container image to v0.3.27 
Supports https://github.com/trustification/trustification/pull/1082
Partially supersedes https://github.com/trustification/trustification/pull/1092 