### PR TITLE
chore: don't unwrap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,7 +160,7 @@ jobs:
         run: cargo check
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::unwrap_used
 
       - name: Test
         run: cargo test
@@ -197,7 +197,7 @@ jobs:
 
       - name: Clippy
         run: |
-          cargo clippy --target wasm32-unknown-unknown --all-targets --all-features --manifest-path spog/ui/Cargo.toml -- -D warnings
+          cargo clippy --target wasm32-unknown-unknown --all-targets --all-features --manifest-path spog/ui/Cargo.toml -- -D warnings -D clippy::unwrap_used
 
   ci-frontend-test:
     runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,6 +1755,7 @@ dependencies = [
  "reqwest",
  "serde",
  "trustification-auth",
+ "url",
 ]
 
 [[package]]
@@ -1810,6 +1811,7 @@ dependencies = [
  "trustification-auth",
  "trustification-common",
  "trustification-infrastructure",
+ "url",
  "url-escape",
  "utoipa",
  "utoipa-swagger-ui",
@@ -1862,11 +1864,12 @@ name = "collectorist-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "derive_more",
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "trustification-auth",
+ "url",
 ]
 
 [[package]]
@@ -7730,6 +7733,7 @@ dependencies = [
  "env_logger 0.11.2",
  "humantime",
  "log",
+ "parking_lot",
  "prometheus",
  "rand 0.8.5",
  "rust-s3",
@@ -8098,6 +8102,7 @@ dependencies = [
  "trustification-api",
  "trustification-auth",
  "trustification-infrastructure",
+ "url",
  "v11y-model",
 ]
 

--- a/admin/src/upload.rs
+++ b/admin/src/upload.rs
@@ -1,7 +1,8 @@
+use anyhow::{bail, Context};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::StatusCode;
 use trustification_auth::client::OpenIdTokenProviderConfigArguments;
 use trustification_auth::client::TokenInjector;
@@ -131,12 +132,19 @@ async fn upload(
     let headers: HeaderMap = headers
         .iter()
         .map(|s| {
-            let mut parts = s.splitn(2, ':');
-            let key = parts.next().unwrap().trim();
-            let value = parts.next().unwrap().trim();
-            (key.parse().unwrap(), value.parse().unwrap())
+            let Some((key, value)) = s.split_once(':') else {
+                bail!("Header value must be in the format of 'key:value'");
+            };
+
+            Ok((
+                key.parse::<HeaderName>()
+                    .with_context(|| format!("Unable to parse '{key}' as header name"))?,
+                value
+                    .parse::<HeaderValue>()
+                    .with_context(|| format!("Unable to parse '{value}' as header value"))?,
+            ))
         })
-        .collect();
+        .collect::<Result<_, _>>()?;
     builder = builder.headers(headers);
     builder = builder.body(data);
 

--- a/auth/src/authenticator/mod.rs
+++ b/auth/src/authenticator/mod.rs
@@ -113,7 +113,7 @@ impl Authenticator {
     }
 
     /// Validate a bearer token.
-    #[instrument(level = "debug", skip_all, fields(token=token.as_ref()), ret)]
+    #[instrument(level = "debug", skip_all, fields(token = token.as_ref()), ret)]
     pub async fn validate_token<S: AsRef<str>>(&self, token: S) -> Result<ValidatedAccessToken, AuthenticationError> {
         let mut token: Compact<AccessTokenClaims, Empty> = Jws::new_encoded(token.as_ref());
 

--- a/bombastic/api/src/lib.rs
+++ b/bombastic/api/src/lib.rs
@@ -1,8 +1,7 @@
-use std::{net::TcpListener, process::ExitCode, sync::Arc, time::Duration};
-
 use actix_web::web;
 use bytesize::ByteSize;
 use prometheus::Registry;
+use std::{net::TcpListener, process::ExitCode, sync::Arc, time::Duration};
 use tokio::task::block_in_place;
 use trustification_auth::{
     auth::AuthConfigArguments,
@@ -195,6 +194,7 @@ impl Run {
 
 pub(crate) type SbomIndex = IndexStore<bombastic_index::sbom::Index>;
 pub(crate) type PackageIndex = IndexStore<bombastic_index::packages::Index>;
+
 pub struct AppState {
     storage: Storage,
     sbom_index: SbomIndex,

--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -7,7 +7,7 @@ use actix_web::{
     error::{self, PayloadError},
     get, guard,
     http::{
-        header::{self, Accept, AcceptEncoding, ContentType, HeaderValue, CONTENT_ENCODING},
+        header::{self, Accept, AcceptEncoding, ContentType, Encoding, HeaderValue, CONTENT_ENCODING},
         Method, StatusCode,
     },
     web, HttpRequest, HttpResponse, Responder,
@@ -80,7 +80,10 @@ impl error::ResponseError for Error {
         match self {
             Self::InvalidContentType => res.insert_header(Accept::json()),
             Self::InvalidContentEncoding => res.insert_header(AcceptEncoding(
-                ACCEPT_ENCODINGS.iter().map(|s| s.parse().unwrap()).collect(),
+                ACCEPT_ENCODINGS
+                    .iter()
+                    .map(|s| s.parse().expect("known values must parse"))
+                    .collect(),
             )),
             _ => &mut res,
         }
@@ -142,18 +145,16 @@ async fn query_sbom(
     let storage = &state.storage;
     // determine the encoding of the stored object, if any
     let encoding = storage.get_head(path.clone()).await.ok().and_then(|head| {
-        head.content_encoding.and_then(|ref e| {
-            accept_encoding
-                .negotiate([e.parse().unwrap()].iter())
-                .map(|s| s.to_string())
-                .filter(|x| x == e)
-        })
+        head.content_encoding
+            .as_ref()
+            .and_then(|e| e.parse::<Encoding>().ok())
+            .and_then(|e| accept_encoding.negotiate([&e].into_iter()).filter(|x| x == &e))
     });
     match encoding {
         // if client's accept-encoding includes S3 encoding, return encoded stream
         Some(enc) => Ok(HttpResponse::Ok()
             .content_type(ContentType::json())
-            .insert_header((header::CONTENT_ENCODING, enc))
+            .insert_header((header::CONTENT_ENCODING, enc.to_string()))
             .streaming(storage.get_encoded_stream(path).await.map_err(Error::Storage)?)),
         // otherwise, decode the stream
         None => Ok(HttpResponse::Ok()

--- a/bombastic/index/src/packages/mod.rs
+++ b/bombastic/index/src/packages/mod.rs
@@ -519,7 +519,7 @@ impl trustification_index::WriteIndex for Index {
         self.schema
             .get_field("package_url")
             .map(|f| Term::from_field_text(f, id))
-            .unwrap()
+            .expect("the document schema defines this field")
     }
 }
 

--- a/bombastic/index/src/sbom/mod.rs
+++ b/bombastic/index/src/sbom/mod.rs
@@ -657,7 +657,7 @@ impl trustification_index::WriteIndex for Index {
         self.schema
             .get_field("sbom_id")
             .map(|f| Term::from_field_text(f, id))
-            .unwrap()
+            .expect("the document schema defines this field")
     }
 }
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/collector/client/Cargo.toml
+++ b/collector/client/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-#tokio = { version = "1.0", features = ["full"] }
-#clap = { version = "4", features = ["derive"] }
-reqwest = { version = "0.11.18", features = ["json"] }
 anyhow = "1"
+reqwest = { version = "0.11.18", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+url = "2"
+
 trustification-auth = { path = "../../auth" }
 
 

--- a/collector/client/src/lib.rs
+++ b/collector/client/src/lib.rs
@@ -3,6 +3,7 @@ use trustification_auth::client::{TokenInjector, TokenProvider};
 
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
+use url::ParseError;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CollectPackagesRequest {
@@ -38,12 +39,12 @@ impl CollectorUrl {
         Self { base_url }
     }
 
-    pub fn packages_url(&self) -> Url {
-        self.base_url.join("packages").unwrap()
+    pub fn packages_url(&self) -> Result<Url, ParseError> {
+        self.base_url.join("packages")
     }
 
-    pub fn vulnerabilities_url(&self) -> Url {
-        self.base_url.join("vulnerabilities").unwrap()
+    pub fn vulnerabilities_url(&self) -> Result<Url, ParseError> {
+        self.base_url.join("vulnerabilities")
     }
 }
 
@@ -71,7 +72,7 @@ impl CollectorClient {
     ) -> Result<CollectPackagesResponse, anyhow::Error> {
         let response = self
             .client
-            .post(self.url.packages_url())
+            .post(self.url.packages_url()?)
             .inject_token(self.provider.as_ref())
             .await?
             .json(&request)

--- a/collector/snyk/Cargo.toml
+++ b/collector/snyk/Cargo.toml
@@ -30,6 +30,7 @@ chrono = "0.4.26"
 url-escape = "0.1.1"
 regex = "1.9.3"
 hide = "0.1"
+url = "2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/collectorist/api/src/config.rs
+++ b/collectorist/api/src/config.rs
@@ -18,7 +18,9 @@ impl CollectorsConfig {
         collectors.insert(
             "osv".into(),
             CollectorConfig {
-                url: endpoint::CollectorOsv::url().join(DEFAULT_BASE).unwrap(),
+                url: endpoint::CollectorOsv::url()
+                    .join(DEFAULT_BASE)
+                    .expect("devmode url must parse"),
                 interests: vec![Interest::Package, Interest::Vulnerability],
                 cadence: default_cadence(),
             },
@@ -26,7 +28,9 @@ impl CollectorsConfig {
         collectors.insert(
             "snyk".into(),
             CollectorConfig {
-                url: endpoint::CollectorSnyk::url().join(DEFAULT_BASE).unwrap(),
+                url: endpoint::CollectorSnyk::url()
+                    .join(DEFAULT_BASE)
+                    .expect("devmode url must parse"),
                 interests: vec![Interest::Package],
                 cadence: default_cadence(),
             },

--- a/collectorist/client/Cargo.toml
+++ b/collectorist/client/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
-derive_more = "0.99"
+url = "2"
+thiserror = "1"
 
 trustification-auth = { path = "../../auth" }

--- a/exhort/api/src/server.rs
+++ b/exhort/api/src/server.rs
@@ -168,7 +168,7 @@ async fn recommend(
 ) -> actix_web::Result<impl Responder> {
     let mut recommendations = HashMap::new();
 
-    let pattern = Regex::new("redhat-[0-9]+$").unwrap();
+    let pattern = Regex::new("redhat-[0-9]+$").expect("known regexp which must parse");
 
     for purl_str in &request.purls {
         if let Ok(purl) = PackageUrl::from_str(purl_str) {

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = "1"
 trustification-api = { path = "../api"}
 tokio = { version = "1", features = ["sync"] }
 bytesize = "1.3"
+parking_lot = "0.12"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/index/src/s3dir.rs
+++ b/index/src/s3dir.rs
@@ -335,7 +335,7 @@ impl S3FileWatcher {
     }
 
     fn compute_checksum(bucket: &Bucket, path: &Path) -> Result<u32, io::Error> {
-        match bucket.get_object_blocking(path.to_str().unwrap()) {
+        match bucket.get_object_blocking(path.to_string_lossy()) {
             Ok(response) => {
                 let data = response.to_vec();
 

--- a/infrastructure/src/endpoint.rs
+++ b/infrastructure/src/endpoint.rs
@@ -10,7 +10,7 @@ pub trait Endpoint: Debug {
     }
 
     fn url() -> Url {
-        Url::parse(&format!("http://localhost:{}{}", Self::PORT, Self::PATH)).unwrap()
+        Url::parse(&format!("http://localhost:{}{}", Self::PORT, Self::PATH)).expect("default value must parse")
     }
 }
 

--- a/infrastructure/src/tracing.rs
+++ b/infrastructure/src/tracing.rs
@@ -78,7 +78,7 @@ impl Injector for HeaderInjector {
 
 /// Try getting the sampling rate from the environment variables
 fn sampling_from_env() -> Option<f64> {
-    std::env::var_os("OTEL_TRACES_SAMPLER_ARG").and_then(|s| s.to_str().map(|s| s.parse::<f64>().ok()).unwrap())
+    std::env::var_os("OTEL_TRACES_SAMPLER_ARG").and_then(|s| s.to_str().and_then(|s| s.parse::<f64>().ok()))
 }
 
 fn sampler() -> opentelemetry::sdk::trace::Sampler {
@@ -115,7 +115,9 @@ fn init_jaeger(name: &str) {
     println!("Using Jaeger tracing.");
     println!("{:#?}", pipeline);
 
-    let tracer = pipeline.install_batch(opentelemetry::runtime::Tokio).unwrap();
+    let tracer = pipeline
+        .install_batch(opentelemetry::runtime::Tokio)
+        .expect("unable to setup tracing pipeline");
 
     let formatting_layer = tracing_subscriber::fmt::Layer::default();
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 mod bom;
 mod config;
 mod provider;

--- a/integration-tests/tests/bombastic.rs
+++ b/integration-tests/tests/bombastic.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use integration_tests::{
     get_response, id, wait_for_package_search_result, wait_for_sbom_search_result, BombasticContext, Urlifier,
 };

--- a/integration-tests/tests/spog.rs
+++ b/integration-tests/tests/spog.rs
@@ -1,8 +1,9 @@
-use std::time::Duration;
+#![allow(clippy::unwrap_used)]
 
 use integration_tests::{id, SpogContext, Urlifier};
 use reqwest::StatusCode;
 use serde_json::{json, Value};
+use std::time::Duration;
 use test_context::test_context;
 use trustification_auth::client::TokenInjector;
 

--- a/integration-tests/tests/ui.rs
+++ b/integration-tests/tests/ui.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use integration_tests::SpogUiContext;
 use std::io::Write;
 use std::time::Duration;

--- a/integration-tests/tests/vexination.rs
+++ b/integration-tests/tests/vexination.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use integration_tests::{get_response, id, Urlifier, VexinationContext};
 use reqwest::StatusCode;
 use serde_json::{json, Value};

--- a/spog/api/examples/gen_openapi.rs
+++ b/spog/api/examples/gen_openapi.rs
@@ -3,6 +3,6 @@ use std::fs;
 use utoipa::OpenApi;
 
 fn main() {
-    let doc = ApiDoc::openapi().to_yaml().unwrap();
-    fs::write("spog/api/schema/api.yaml", doc).unwrap();
+    let doc = ApiDoc::openapi().to_yaml().expect("example may panic");
+    fs::write("spog/api/schema/api.yaml", doc).expect("example may panic");
 }

--- a/spog/ui/crates/common/src/components/html.rs
+++ b/spog/ui/crates/common/src/components/html.rs
@@ -13,25 +13,27 @@ pub struct SafeHtmlProperties {
 pub fn safe_html(props: &SafeHtmlProperties) -> Html {
     let node = use_memo((props.element.clone(), props.html.clone()), |(element, html)| {
         if !html.is_empty() {
-            let div = gloo_utils::document().create_element(element).unwrap();
-            div.set_inner_html(html);
-
-            let children = div.children();
-            let len = children.length();
-
             let mut content = VList::new();
-            match len > 0 {
-                true => {
-                    for i in 0..len {
-                        let node = children.item(i);
-                        if let Some(node) = node {
-                            content.add_child(Html::VRef(node.into()));
+            if let Ok(div) = gloo_utils::document().create_element(element) {
+                div.set_inner_html(html);
+
+                let children = div.children();
+                let len = children.length();
+
+                match len > 0 {
+                    true => {
+                        for i in 0..len {
+                            let node = children.item(i);
+                            if let Some(node) = node {
+                                content.add_child(Html::VRef(node.into()));
+                            }
                         }
                     }
-                }
-                false => content.add_child(Html::VRef(div.into())),
-            };
-
+                    false => content.add_child(Html::VRef(div.into())),
+                };
+            } else {
+                log::warn!("Failed to create element: {element}");
+            }
             Html::VList(content)
         } else {
             // if it's empty, use the default

--- a/spog/ui/crates/components/src/editor.rs
+++ b/spog/ui/crates/components/src/editor.rs
@@ -35,7 +35,7 @@ pub fn readonly_editor(props: &ReadonlyEditorProperties) -> Html {
     });
 
     let model = use_memo(props.content.clone(), |content| {
-        TextModel::create(content, Some("json"), None).unwrap()
+        TextModel::create(content, Some("json"), None).expect("JSON type won't fail")
     });
 
     html!(

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,8 +1,6 @@
 mod stream;
 pub mod validator;
 
-use std::borrow::Cow;
-
 use async_stream::try_stream;
 use bytes::Bytes;
 use futures::pin_mut;
@@ -16,6 +14,7 @@ use prometheus::{
 use s3::{creds::error::CredentialsError, error::S3Error, Bucket};
 pub use s3::{creds::Credentials, Region};
 use serde::Deserialize;
+use std::borrow::Cow;
 use validator::Validator;
 
 pub struct Storage {
@@ -326,7 +325,7 @@ impl Storage {
         headers.insert(VERSION_HEADER, VERSION.into());
         headers.insert(
             CONTENT_ENCODING,
-            HeaderValue::from_str(encoding.unwrap_or(DEFAULT_ENCODING)).unwrap(),
+            HeaderValue::from_str(encoding.unwrap_or(DEFAULT_ENCODING))?,
         );
         let bucket = self.bucket.with_extra_headers(headers);
 

--- a/v11y/client/Cargo.toml
+++ b/v11y/client/Cargo.toml
@@ -10,6 +10,7 @@ reqwest = "0.11.18"
 anyhow = "1"
 v11y-model = { path = "../model" }
 thiserror = "1.0.44"
+url = "2"
 
 trustification-api = { path = "../../api" }
 trustification-auth = { path = "../../auth" }

--- a/v11y/index/src/lib.rs
+++ b/v11y/index/src/lib.rs
@@ -386,7 +386,7 @@ impl trustification_index::WriteIndex for Index {
         self.schema
             .get_field("id")
             .map(|f| Term::from_field_text(f, id))
-            .unwrap()
+            .expect("the document schema defines this field")
     }
 }
 

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -473,7 +473,7 @@ impl trustification_index::WriteIndex for Index {
         self.schema
             .get_field("advisory_id")
             .map(|f| Term::from_field_text(f, id))
-            .unwrap()
+            .expect("the document schema defines this field")
     }
 
     fn schema(&self) -> Schema {

--- a/vexination/walker/src/lib.rs
+++ b/vexination/walker/src/lib.rs
@@ -77,7 +77,7 @@ impl Run {
                     let validation_date: Option<SystemTime> = match (self.policy_date, self.v3_signatures) {
                         (_, true) => Some(SystemTime::from(
                             Date::from_calendar_date(2007, Month::January, 1)
-                                .unwrap()
+                                .expect("known calendar date should parse")
                                 .midnight()
                                 .assume_offset(UtcOffset::UTC),
                         )),

--- a/xtask/src/common.rs
+++ b/xtask/src/common.rs
@@ -1,9 +1,8 @@
 use std::path::{Path, PathBuf};
 
-pub fn project_root() -> PathBuf {
+pub fn project_root() -> Option<PathBuf> {
     Path::new(&env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(1)
-        .unwrap()
-        .to_path_buf()
+        .map(|path| path.to_path_buf())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use clap::{Parser, Subcommand};
 
 mod common;

--- a/xtask/src/task/test.rs
+++ b/xtask/src/task/test.rs
@@ -1,5 +1,6 @@
 use crate::common::project_root;
 use crate::config::TestConfig;
+use anyhow::anyhow;
 use globset::Glob;
 use reqwest::blocking::get;
 use std::fs;
@@ -99,7 +100,7 @@ impl Test {
             return Ok(());
         }
 
-        sh.change_dir(project_root());
+        sh.change_dir(project_root().ok_or_else(|| anyhow!("failed to get project root"))?);
         if let Err(e) = Self::setup_coverage(&sh, &mut config) {
             eprintln!(
                 "Error: {e}\n\n\


### PR DESCRIPTION
Here's a proposal for getting rid of `.unwrap()`, which we use a bit to often for my taste.

I know it's controversial, and I think it's ok/good to keep them for test code. But not in the code we want to run in production. I also know that sometimes it's hard to work around that. But then let's isolate this, and be explicit about it.

This PR is a start, and if we agree we can do the rest before merging.

