### PR TITLE
RHTAPBUGS-1146: GUAC TLS Configuration

### DIFF
--- a/deploy/k8s/charts/trustification/templates/helpers/_guac.tpl
+++ b/deploy/k8s/charts/trustification/templates/helpers/_guac.tpl
@@ -19,7 +19,10 @@ Arguments (dict):
   * module - module object
 */}}
 {{- define "trustification.guac.graphql.envVars"}}
-{{- if eq ( include "trustification.openshift.useServiceCa" .root ) "true" }}
+{{- if and
+      (eq (include "trustification.openshift.useServiceCa" .root) "true")
+      (ne .root.Values.guac.database.sslMode "disable")
+}}
 - name: GUAC_GQL_TLS_CERT_FILE
   value: /etc/tls/tls.crt
 - name: GUAC_GQL_TLS_KEY_FILE


### PR DESCRIPTION
Only adding `GUAC_GQL_TLS_CERT_FILE` and `GUAC_GQL_TLS_KEY_FILE` when GUAC's database is configured to use TLS.