### PR TITLE
fix: add root certification to guac clients

### DIFF
--- a/deploy/k8s/charts/trustification/templates/helpers/_guac.tpl
+++ b/deploy/k8s/charts/trustification/templates/helpers/_guac.tpl
@@ -28,3 +28,20 @@ Arguments (dict):
 - name: GUAC_PROMETHEUS_ADDR
   value: {{ include "trustification.application.infrastructure.port" . | quote }}
 {{- end }}
+
+
+{{/*
+Additional env-vars for configuring the Guac clients.
+
+Arguments (dict):
+  * root - .
+  * module - module object
+*/}}
+{{- define "trustification.guac.client.envVars"}}
+{{- if eq ( include "trustification.openshift.useServiceCa" .root ) "true" }}
+- name: GUAC_CSUB_TLS_ROOT_CA
+  value: /run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+- name: GUAC_GQL_TLS_ROOT_CA
+  value: /run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+{{- end }}
+{{- end }}

--- a/deploy/k8s/charts/trustification/templates/services/guac/bombastic-collector/030-Deployment.yaml
+++ b/deploy/k8s/charts/trustification/templates/services/guac/bombastic-collector/030-Deployment.yaml
@@ -49,5 +49,5 @@ spec:
               value: {{ include "trustification.tls.http.protocol" $mod }}://guac-graphql.{{ .Release.Namespace }}.svc.cluster.local/query
             - name: GUAC_CSUB_ADDR
               value: guac-collectsub.{{ .Release.Namespace }}.svc.cluster.local:2782
-
+            {{- include "trustification.guac.client.envVars" $mod | nindent 12 }}
 {{- end }}

--- a/deploy/k8s/charts/trustification/templates/services/guac/vexination-collector/030-Deployment.yaml
+++ b/deploy/k8s/charts/trustification/templates/services/guac/vexination-collector/030-Deployment.yaml
@@ -49,5 +49,5 @@ spec:
               value: {{ include "trustification.tls.http.protocol" $mod }}://guac-graphql.{{ .Release.Namespace }}.svc.cluster.local/query
             - name: GUAC_CSUB_ADDR
               value: guac-collectsub.{{ .Release.Namespace }}.svc.cluster.local:2782
-
+            {{- include "trustification.guac.client.envVars" $mod | nindent 12 }}
 {{- end }}


### PR DESCRIPTION
Currently there's no root certificates set for the Guac clients (both graphql and grpc).
This should help with TC-1025