### PR TITLE
fix: only have the env-var once

### DIFF
--- a/deploy/k8s/charts/trustification/templates/helpers/_storage.tpl
+++ b/deploy/k8s/charts/trustification/templates/helpers/_storage.tpl
@@ -81,8 +81,6 @@ Arguments (dict):
 {{ else }}
 - name: STORAGE_REGION
   value: "{{ .storage.region }}"
-- name: STORAGE_REGION
-  value: "{{ .storage.region }}"
 {{ end }}
 
 {{- end }}


### PR DESCRIPTION
This fixes the warning:

```
spec.template.spec.containers[0].env[3].name: duplicate name "STORAGE_REGION"
```