### PR TITLE
[release/1.0.z] fix: align the search capabilities of CVE with advisories

### DIFF
--- a/vexination/model/src/search.rs
+++ b/vexination/model/src/search.rs
@@ -7,9 +7,9 @@ use utoipa::ToSchema;
 #[derive(Clone, Debug, PartialEq, Search)]
 pub enum Vulnerabilities<'a> {
     #[search(default)]
-    Id(&'a str),
+    Id(Primary<'a>),
     #[search(default)]
-    Cve(&'a str),
+    Cve(Primary<'a>),
     #[search(default)]
     Title(Primary<'a>),
     #[search(default)]


### PR DESCRIPTION
searching of a partial string of a CVE ID will yield results from v11y, but no from vexination. This change aligns that behavior.