### PR TITLE
[release/1.0.z] fix: allow the aggregated severity to be omitted

### DIFF
--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -1200,6 +1200,10 @@ pub fn field2str<'m>(schema: &'m Schema, doc: &'m Document, field: Field) -> Res
         .unwrap_or_else(|| Err(Error::FieldNotFound(schema.get_field_name(field).to_string())))
 }
 
+pub fn field2str_opt(doc: &Document, field: Field) -> Option<&str> {
+    doc.get_first(field).map(|s| s.as_text()).unwrap_or(None)
+}
+
 pub fn field2bool<'m>(schema: &'m Schema, doc: &'m Document, field: Field) -> Result<bool, Error> {
     let value = doc.get_first(field).map(|s| s.as_bool()).unwrap_or(None);
     value

--- a/spog/model/src/search.rs
+++ b/spog/model/src/search.rs
@@ -6,7 +6,7 @@ use time::OffsetDateTime;
 pub struct AdvisorySummary {
     pub id: String,
     pub title: String,
-    pub severity: String,
+    pub severity: Option<String>,
     pub snippet: String,
     pub desc: String,
     pub date: OffsetDateTime,

--- a/spog/ui/crates/components/src/advisory/mod.rs
+++ b/spog/ui/crates/components/src/advisory/mod.rs
@@ -62,7 +62,9 @@ impl TableEntryRenderer<Column> for AdvisoryEntry {
             ),
             Column::Title => html!(&self.summary.title),
             Column::Severity => html!(
-                <Severity severity={self.summary.severity.clone()} />
+                if let Some(severity) = self.summary.severity.clone() {
+                    <Severity {severity} />
+                }
             ),
             Column::Revision => date(self.summary.date),
             Column::Download => html!(if let Some(url) = &self.url {
@@ -434,7 +436,7 @@ fn csaf_product_status_entry_details(
             let component = product_html(trace_product(csaf, &r.product_reference.0));
 
             html!(<>
-                { component } {" "} { relationship } {" "} { product }  
+                { component } {" "} { relationship } {" "} { product }
             </>)
         })
         .chain(actual.map(|product| {

--- a/spog/ui/src/pages/cve/result/advisories.rs
+++ b/spog/ui/src/pages/cve/result/advisories.rs
@@ -35,7 +35,11 @@ pub fn related_advisories(props: &RelatedAdvisoriesProperties) -> Html {
                     )
                 }
                 Column::Title => html!(self.title.clone()),
-                Column::AggregatedSeverity => html!(<Severity severity={self.severity.clone()} />),
+                Column::AggregatedSeverity => html!(
+                    if let Some(severity) = self.severity.clone() {
+                        <Severity {severity} />
+                    }
+                ),
                 Column::Revision => html!(<Date timestamp={self.date} />),
                 Column::Vulnerabilities => html!(self.cves.len()),
             }

--- a/vexination/index/src/lib.rs
+++ b/vexination/index/src/lib.rs
@@ -14,7 +14,7 @@ use time::OffsetDateTime;
 use trustification_api::search::SearchOptions;
 use trustification_index::{
     boost, create_date_query, create_float_query, create_string_query, create_string_query_case, create_text_query,
-    field2date, field2float, field2str, field2strvec,
+    field2date, field2float, field2str, field2str_opt, field2strvec,
     metadata::doc2metadata,
     sort_by,
     tantivy::{
@@ -168,7 +168,7 @@ impl trustification_index::Index for Index {
 
         let advisory_id = field2str(&self.schema, &doc, self.fields.advisory_id)?;
         let advisory_title = field2str(&self.schema, &doc, self.fields.advisory_title)?;
-        let advisory_severity = field2str(&self.schema, &doc, self.fields.advisory_severity)?;
+        let advisory_severity = field2str_opt(&doc, self.fields.advisory_severity);
         let advisory_date = field2date(&self.schema, &doc, self.fields.advisory_current)?;
         let advisory_desc = field2str(&self.schema, &doc, self.fields.advisory_description).unwrap_or("");
 
@@ -193,7 +193,7 @@ impl trustification_index::Index for Index {
             advisory_title: advisory_title.to_string(),
             advisory_date,
             advisory_snippet,
-            advisory_severity: advisory_severity.to_string(),
+            advisory_severity: advisory_severity.map(ToString::to_string),
             advisory_desc: advisory_desc.to_string(),
             cves,
             cvss_max,

--- a/vexination/model/src/search.rs
+++ b/vexination/model/src/search.rs
@@ -56,7 +56,7 @@ pub struct SearchDocument {
     /// Advisory description
     pub advisory_desc: String,
     /// Advisory severity
-    pub advisory_severity: String,
+    pub advisory_severity: Option<String>,
     /// List of CVE identifiers that matched within the advisory
     pub cves: Vec<String>,
     /// Highest CVSS score in vulnerabilities matched within the advisory


### PR DESCRIPTION
The aggregated severity is optional. If we don't have it, skipping the document is not the right way to deal with this.