### PR TITLE
fix: Remove expandable "products using" package in "Package details" page

### DIFF
--- a/spog/ui/src/pages/package/result/related_products.rs
+++ b/spog/ui/src/pages/package/result/related_products.rs
@@ -208,7 +208,6 @@ pub fn related_products_table(props: &RelatedProductsTableProperties) -> Html {
         <div class="pf-v5-u-background-color-100">
             <PaginationWrapped {pagination} {total}>
                 <Table<Column, UseTableData<Column, MemoizedTableModel<TableData>>>
-                    mode={TableMode::Expandable}
                     {header}
                     {entries}
                     {onexpand}


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1051

I've seen that the "backstraces" field was never implemented and always return an empty array. As a consequence we always have an empty expandable section in the "package details => products using package" table.

This is the line where the `backstraces are set` https://github.com/trustification/trustification/blob/main/spog/api/src/service/guac.rs#L321

```rust
backtraces: vec![]
```

So it makes sense to me just to disable the expandable section for all rows as we don't expect to see data there.