### PR TITLE
fix: improve guac health check

### DIFF
--- a/deploy/k8s/charts/trustification/templates/services/guac/graphql/030-Deployment.yaml
+++ b/deploy/k8s/charts/trustification/templates/services/guac/graphql/030-Deployment.yaml
@@ -67,9 +67,11 @@ spec:
           volumeMounts:
             {{- include "trustification.application.httpServerVolumesMounts" $mod | nindent 12 }}
 
-          livenessProbe:
-            tcpSocket:
+          readinessProbe:
+            httpGet:
+              path: /healthz
               port: 8080
+              scheme: {{ include "trustification.tls.http.protocol" $mod | upper }}
 
           ports:
             {{- include "trustification.application.infrastructure.podPorts" $mod | nindent 12 }}


### PR DESCRIPTION
This should help with TLS errors due to current liveness probe.