### PR TITLE
Render cyclonedx spec version on the info tab within the sbom detail page

### DIFF
--- a/spog/ui/src/pages/sbom/mod.rs
+++ b/spog/ui/src/pages/sbom/mod.rs
@@ -215,7 +215,7 @@ fn details(props: &DetailsProps) -> Html {
                         <Stack gutter=true>
                             <StackItem>
                                 <Grid gutter=true>
-                                    <GridItem cols={[6]}>{cyclonedx_meta(bom)}</GridItem>
+                                    <GridItem cols={[6]}><CycloneDXMeta bom={bom.clone()} source={source.clone()}/></GridItem>
                                     <GridItem cols={[3]}>{cyclonedx_creator(bom)}</GridItem>
                                     <GridItem cols={[3]}>
                                         <GridItem cols={[2]}><Technical size={source.as_bytes().len()}/></GridItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1061
- The specVersion seems not to be part of the SBOM object, therefore I needed to parse the json and read the `specversion` field manually
- Replace `Serial number` by `Serial Number` to align it to the other fields pattern