### PR TITLE
Enhance error component and set hardcoded message when guac fails on "related advisories"

### DIFF
--- a/spog/ui/crates/common/src/error/components.rs
+++ b/spog/ui/crates/common/src/error/components.rs
@@ -17,12 +17,18 @@ pub struct ApiErrorProperties {
 pub fn api_error(props: &ApiErrorProperties) -> Html {
     match &*props.error.0 {
         ApiErrorKind::Api {
-            status: _,
+            status,
             details: ApiErrorDetails::Information(info),
         } => {
-            html!(
-                <Error title={props.title.clone()} message={info.message.clone()} err={info.details.clone()}/>
-            )
+            if status.as_u16() >= 500 {
+                html!(
+                    <Error title={"Internal server error"} message={info.message.clone()} err={info.details.clone()}/>
+                )
+            } else {
+                html!(
+                    <Error title={props.title.clone()} message={info.message.clone()} err={info.details.clone()}/>
+                )
+            }
         }
         _ => {
             html!(<Error title={props.title.clone()} message={props.message.clone().unwrap_or_else(|| "Error processing request".into() )} err={props.error.to_string()} />)
@@ -40,6 +46,9 @@ pub struct ErrorProperties {
 
     #[prop_or_default]
     pub err: String,
+
+    #[prop_or_default]
+    pub actions: Option<Html>,
 }
 
 #[function_component(Error)]
@@ -50,26 +59,47 @@ pub fn error(props: &ErrorProperties) -> Html {
 
     html!(
         <Bullseye>
-            <Grid gutter=true>
-                <GridItem cols={[2]}>
+            <Stack gutter=true>
+                <StackItem>
                     <div style="text-align: center;">
-                        <img src={error_image_src} alt="Error" />
+                        <img src={error_image_src} alt="Error" style="height: 52px;" />
                     </div>
-                </GridItem>
-                <GridItem cols={[10]}>
-                    <Title>{props.title.clone()}</Title>
-                    <Content>
-                        if let Some(message)  = &props.message {
-                            <p>{ &message }</p>
-                            <ExpandableSection>
-                                <p>{ &props.err }</p>
-                            </ExpandableSection>
-                        } else {
-                            <p>{ &props.err }</p>
-                        }
-                    </Content>
-                </GridItem>
-            </Grid>
+                </StackItem>
+                <StackItem>
+                    <Bullseye>
+                        <Stack>
+                            <StackItem>
+                                <div style="text-align: center;">
+                                    <Title size={Size::XLarge}>{props.title.clone()}</Title>
+                                </div>
+                            </StackItem>
+                            <StackItem>
+                                <Content>
+                                    if let Some(message)  = &props.message {
+                                        <p style="text-align: center;">{ &message }</p>
+                                        if !props.err.is_empty() {
+                                            <div style="max-width: 300px;">
+                                                <ExpandableSection>
+                                                    <p>{ &props.err }</p>
+                                                </ExpandableSection>
+                                            </div>
+                                        }
+                                    } else {
+                                        <p>{ &props.err }</p>
+                                    }
+                                </Content>
+                            </StackItem>
+                        </Stack>
+                    </Bullseye>
+                </StackItem>
+                if let Some(actions) = &props.actions {
+                    <StackItem>
+                        <div style="text-align: center;">
+                            {actions.clone()}
+                        </div>
+                    </StackItem>
+                }
+            </Stack>
         </Bullseye>
     )
 }

--- a/spog/ui/crates/common/src/error/mod.rs
+++ b/spog/ui/crates/common/src/error/mod.rs
@@ -65,7 +65,7 @@ impl Display for ApiErrorDetails {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Information(info) => {
-                write!(f, "{} ({})", info.message, info.error)
+                write!(f, "{} ({}) - {}", info.message, info.error, info.details)
             }
             Self::Plain(s) => f.write_str(s),
             Self::Empty => f.write_str("no information"),
@@ -75,7 +75,7 @@ impl Display for ApiErrorDetails {
 }
 
 #[derive(Clone, Debug)]
-pub struct ApiError(Rc<ApiErrorKind>);
+pub struct ApiError(pub Rc<ApiErrorKind>);
 
 impl Deref for ApiError {
     type Target = ApiErrorKind;


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1091

- Enhance error state component:
  - The main branch renders the error icon next to the error message (left to right)
  - This PR sets the error icon on top of the error message following the Patternfly patterns and examples https://www.patternfly.org/extensions/component-groups/error-boundary

## Current Error (Main branch)
![Screenshot from 2024-03-21 11-21-23](https://github.com/trustification/trustification/assets/2582866/6826c9cf-8b92-453a-8971-c883b1004b71)

## Error after this PR is applied
![Screenshot from 2024-03-21 16-09-58](https://github.com/trustification/trustification/assets/2582866/8f5e8cac-c02d-4ae0-910b-d4fad29ecbb5)

## Error for when we will be given a URL for best practices. The does not exist yet but once it exists we should add it

![Screenshot from 2024-03-21 16-13-00](https://github.com/trustification/trustification/assets/2582866/049043c2-6845-46e2-bed8-b240bedd7743)

