### PR TITLE
fix: allow access to metrics port to monitoring stack

### DIFF
--- a/deploy/k8s/charts/trustification/templates/services/guac/graphql/050-NetworkPolicy.yaml
+++ b/deploy/k8s/charts/trustification/templates/services/guac/graphql/050-NetworkPolicy.yaml
@@ -17,4 +17,12 @@ spec:
         - namespaceSelector:
             matchLabels:
               "kubernetes.io/metadata.name": {{ .Release.Namespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    - from:
+      - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 9010
 {{- end }}


### PR DESCRIPTION
Improve network policy for guac, so that it blocks the ingress for the graphql port, but allows access to metrics port.