### PR TITLE
fix: ensure that the storage key does not alter the path structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,6 +3035,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3133,12 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
@@ -5499,6 +5511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5660,6 +5678,35 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5316d2a1479eeef1ea21e7f9ddc67c191d497abc8fc3ba2467857abbb68330"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a9df72cc1f67020b0d63ad9bfe4a323e459ea7eb68e03bd9824db49f9a4c25"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.52",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -8016,6 +8063,7 @@ dependencies = [
  "http 0.2.12",
  "log",
  "prometheus",
+ "rstest",
  "rust-s3",
  "serde",
  "serde_json",

--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -294,7 +294,7 @@ where
                             log::info!("Reindexing {:?}", key);
                             // Not sending notifications for reindexing
                             for (index, writer) in self.indexes.iter().zip(writers.iter_mut()) {
-                                if let Err(e) = self.index_doc(index.index(), writer, key, &obj).await {
+                                if let Err(e) = self.index_doc(index.index(), writer, &key, &obj).await {
                                     log::warn!("(Ignored) Internal error when indexing {}: {:?}", key, e);
                                 }
                             }

--- a/integration-tests/tests/vexination.rs
+++ b/integration-tests/tests/vexination.rs
@@ -47,6 +47,7 @@ async fn vexination_roundtrip(vexination: &mut VexinationContext) {
 
             assert_eq!(response.status(), StatusCode::OK);
             let payload: Value = response.json().await.unwrap();
+
             if payload["total"].as_u64().unwrap() >= 1 {
                 assert_eq!(id, payload["result"][0]["document"]["advisory_id"].as_str().unwrap());
                 break;

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -22,3 +22,6 @@ prometheus = "0.13.3"
 bombastic-model = { path = "../bombastic/model" }
 csaf = "0.5.0"
 hide = "0.1.1"
+
+[dev-dependencies]
+rstest = "0.19"

--- a/storage/src/key.rs
+++ b/storage/src/key.rs
@@ -1,0 +1,42 @@
+use std::fmt::{Display, Formatter};
+
+/// A key for a document.
+#[derive(Copy, Clone)]
+pub struct Key<'a>(&'a str);
+
+impl Key<'_> {}
+
+impl<'a> From<&'a str> for Key<'a> {
+    fn from(value: &'a str) -> Self {
+        Self(value)
+    }
+}
+
+impl<'a> From<&'a String> for Key<'a> {
+    fn from(value: &'a String) -> Self {
+        value.as_str().into()
+    }
+}
+
+impl Display for Key<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&urlencoding::encode(self.0))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("foo bar", "foo%20bar")]
+    #[case("foo/bar", "foo%2Fbar")]
+    #[case("../bar", "..%2Fbar")]
+    #[case("bar/..", "bar%2F..")]
+    #[case("~/bar", "~%2Fbar")]
+    #[case("foo%bar", "foo%25bar")]
+    fn test_not_safe(#[case] name: &str, #[case] expected_path: &str) {
+        assert_eq!(format!("{}", Key::from(name)), expected_path)
+    }
+}

--- a/v11y/api/src/server/vulnerability.rs
+++ b/v11y/api/src/server/vulnerability.rs
@@ -4,7 +4,7 @@ use trustification_auth::authenticator::user::UserInformation;
 use trustification_auth::authorizer::Authorizer;
 use trustification_auth::Permission;
 use trustification_common::error::ErrorInformation;
-use trustification_storage::S3Path;
+use trustification_storage::{Key, S3Path};
 use v11y_model::Vulnerability;
 
 use crate::db::DbError;
@@ -62,7 +62,7 @@ pub(crate) async fn ingest_vulnerability(
 )]
 #[get("/cve/{id}")]
 pub(crate) async fn get_cve(state: web::Data<AppState>, id: web::Path<String>) -> Result<impl Responder, CveError> {
-    let path = S3Path::from_key(&id.to_uppercase());
+    let path = S3Path::from_key(Key::from(&id.to_uppercase()));
 
     let cve = state.storage.get_decoded_stream(&path).await?;
 

--- a/v11y/walker/src/lib.rs
+++ b/v11y/walker/src/lib.rs
@@ -125,7 +125,7 @@ impl Run {
 
                         const MAX_RETRIES: usize = 10;
                         for retry in 0..MAX_RETRIES {
-                            match storage.put_json_slice(key, &data).await {
+                            match storage.put_json_slice(key.into(), &data).await {
                                 Ok(_) => break,
                                 Err(e) => {
                                     log::warn!("Failed to store {} (attempt {}/{}): {:?}", key, retry, MAX_RETRIES, e);


### PR DESCRIPTION
The key has a direct impact on the path inside the S3 bucket. We must ensure that the user is not able to influence the location of the file, only the name of it.

This change ensures that they user provided key does not contain any character that might have an in impact on the location inside the bucket.