### PR TITLE
[release/1.0.z] fix: provide a way to retrieve public vs non-public frontend config

### DIFF
--- a/spog/api/src/server.rs
+++ b/spog/api/src/server.rs
@@ -42,8 +42,6 @@ impl Server {
             provider: provider.clone(),
         });
 
-        let config_configurator = config::configurator(self.run.config).await?;
-
         let (authn, authz) = self.run.auth.split(self.run.devmode)?.unzip();
         let authenticator: Option<Arc<Authenticator>> = Authenticator::from_config(authn)
             .await
@@ -62,6 +60,8 @@ impl Server {
         if self.run.snyk_token.is_some() {
             log::info!("Snyk token is present");
         }
+
+        let config_configurator = config::configurator(self.run.config, authenticator.clone()).await?;
 
         let crda = self
             .run

--- a/spog/ui/crates/backend/src/config.rs
+++ b/spog/ui/crates/backend/src/config.rs
@@ -15,8 +15,15 @@ impl ConfigService {
         Self { backend, access_token }
     }
 
-    pub async fn get_config(&self) -> Result<Configuration, ApiError> {
-        let url = self.backend.join(Endpoint::Api, "/api/v1/config")?;
+    pub async fn get_config(&self, public: bool) -> Result<Configuration, ApiError> {
+        let url = self.backend.join(
+            Endpoint::Api,
+            if public {
+                "/api/v1/config/public"
+            } else {
+                "/api/v1/config"
+            },
+        )?;
 
         let response = gloo_net::http::Request::get(url.as_str())
             .latest_access_token(&self.access_token)

--- a/spog/ui/crates/utils/src/config/components.rs
+++ b/spog/ui/crates/utils/src/config/components.rs
@@ -9,6 +9,8 @@ use yew_oauth2::hook::use_latest_access_token;
 pub struct ConfigurationProperties {
     #[prop_or_default]
     pub children: Children,
+    #[prop_or_default]
+    pub public: bool,
 }
 
 #[function_component(Configuration)]
@@ -17,13 +19,13 @@ pub fn configuration(props: &ConfigurationProperties) -> Html {
     let access_token = use_latest_access_token();
 
     let config = use_async_with_cloned_deps(
-        |backend| async {
+        |(backend, public)| async move {
             ConfigService::new(backend, access_token)
-                .get_config()
+                .get_config(public)
                 .await
                 .map(Rc::new)
         },
-        backend,
+        (backend, props.public),
     );
 
     match &*config {

--- a/spog/ui/src/app.rs
+++ b/spog/ui/src/app.rs
@@ -74,7 +74,7 @@ fn application_with_backend() -> Html {
                 scopes={backend.endpoints.oidc.scopes()}
                 {login_options}
             >
-                <Configuration>
+                <Configuration public=true>
                     { consent(html!(
                         <BackdropViewer>
                             <ToastViewer>

--- a/spog/ui/src/console/mod.rs
+++ b/spog/ui/src/console/mod.rs
@@ -7,6 +7,7 @@ use spog_ui_components::{
     theme::DarkModeEntry,
 };
 use spog_ui_navigation::{AppRoute, View};
+use spog_ui_utils::config::components::Configuration;
 use spog_ui_utils::{analytics::*, config::*, hints::*};
 use yew::prelude::*;
 use yew_consent::hook::use_consent_context;
@@ -203,9 +204,11 @@ fn authenticated_page(props: &ChildrenProperties) -> Html {
     );
 
     html!(
-        <Page {brand} {sidebar} {tools}>
-            { props.children.clone() }
-        </Page>
+        <Configuration>
+            <Page {brand} {sidebar} {tools}>
+                { props.children.clone() }
+            </Page>
+        </Configuration>
     )
 }
 


### PR DESCRIPTION
Some part of the configuration might be considered confidential. So we do remove most of the configuration information and create a dedicated, public endpoint.