### PR TITLE
Fix: CSAF/VEX 'Upload another' label

### DIFF
--- a/spog/ui/src/pages/vex_uploader/mod.rs
+++ b/spog/ui/src/pages/vex_uploader/mod.rs
@@ -91,7 +91,7 @@ fn common_header(props: &CommonHeaderProperties) -> Html {
                 <FlexItem modifiers={[FlexModifier::Align(Alignment::Right), FlexModifier::Align(Alignment::End)]}>
                     if let Some(onreset) = onreset {
                         <Button
-                            label={"Scan another"}
+                            label={"Upload another"}
                             icon={Icon::Redo}
                             variant={ButtonVariant::Secondary}
                             onclick={onreset}


### PR DESCRIPTION
Consistency with SBOM `Upload another` label
https://github.com/trustification/trustification/blob/621fc8abc1b67a25686e635a1f9ac5319a845b82/spog/ui/src/pages/uploader/mod.rs#L112