### PR TITLE
chore: upgrade guac image to v.0.3.30

### DIFF
--- a/deploy/compose/.env
+++ b/deploy/compose/.env
@@ -12,7 +12,7 @@ EXHORT_API_PORT=8088
 COLLECTORIST_API_PORT=8180
 COLLECTOR_OSV_API_PORT=8181
 COLLECTOR_SNYK_API_PORT=8182
-GUAC_IMAGE=ghcr.io/trustification/guac:v0.3.29
+GUAC_IMAGE=ghcr.io/trustification/guac:v0.3.30
 #GUAC_IMAGE=local-organic-guac
 
 CHROMEDRIVER_IMAGE=docker.io/selenium/standalone-chrome:117.0

--- a/deploy/k8s/charts/trustification/values.yaml
+++ b/deploy/k8s/charts/trustification/values.yaml
@@ -14,7 +14,7 @@ guac:
     name: guac
     registry: ghcr.io/trustification
     pullPolicy: IfNotPresent
-    version: "v0.3.29"
+    version: "v0.3.30"
   database: {}
 
 rust: {}


### PR DESCRIPTION
This Guac image:

- provides option to connect to kafka using tls
- fixes vex ingestion performance issue