### PR TITLE
chore: add option to set additional postgres configuration

### DIFF
--- a/deploy/compose/compose-guac.yaml
+++ b/deploy/compose/compose-guac.yaml
@@ -3,6 +3,9 @@ version: "3"
 services:
   postgres:
     image: docker.io/library/postgres:16
+    # If you wish to add additional configuration parameters to the database, uncomment the section below
+    # The example below contains configuration for logging queries with duration longer than 500ms
+    #command: postgres -c log_min_duration_statement=500 -c listen_addresses='*'
     environment:
       POSTGRES_USER: guac
       POSTGRES_DB: guac

--- a/deploy/k8s/charts/trustification-infrastructure/values.yaml
+++ b/deploy/k8s/charts/trustification-infrastructure/values.yaml
@@ -54,6 +54,12 @@ minioPostInstall:
 
 keycloak:
   enabled: false
+  # If you wish to add additional configuration parameters to the database, uncomment the section below
+  # The example below contains configuration for logging queries with duration longer than 500ms
+  # postgresql:
+  #   primary:
+  #     extendedConfiguration: |-
+  #       log_min_duration_statement = 500
 
 postgresql:
   enabled: false


### PR DESCRIPTION
It's handy to have config like this ready to use when someone wants to debug database operations