### PR TITLE
[TC-1224] Avoid frozing browser on big advisory details

### DIFF
--- a/spog/ui/crates/components/src/advisory/details/mod.rs
+++ b/spog/ui/crates/components/src/advisory/details/mod.rs
@@ -153,7 +153,7 @@ impl TableEntryRenderer<Column> for VulnerabilityWrapper {
 
                 <GridItem cols={[7]}>
                     <CardWrapper plain=true title="Product Status">
-                        <CsafProductStatus status={self.product_status.clone()} csaf={self.csaf.clone()} overview=false />
+                        <CsafProductStatus status={self.product_status.clone()} csaf={self.csaf.clone()} overview=true />
                     </CardWrapper>
                 </GridItem>
 

--- a/spog/ui/crates/components/src/advisory/details/product.rs
+++ b/spog/ui/crates/components/src/advisory/details/product.rs
@@ -63,6 +63,7 @@ pub fn product_info(props: &CsafProperties) -> Html {
             mode={TreeTableMode::Compact}
             {header}
             {model}
+            default_expansion=false
         />
     )
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1224

- Make the Product tree component not expanded by default
- Switch CsafProductStatus to use the "overview" visualization, otherwise big advisories also kills the browser