### PR TITLE
[TC-1237] [TC-1248] ui: about model to use public config & expose features in the public api

### DIFF
--- a/spog/api/src/config/mod.rs
+++ b/spog/api/src/config/mod.rs
@@ -37,6 +37,7 @@ impl Config {
     fn make_public(config: Configuration) -> Configuration {
         Configuration {
             global: config.global,
+            features: config.features,
             ..Default::default()
         }
     }

--- a/spog/ui/src/about.rs
+++ b/spog/ui/src/about.rs
@@ -1,6 +1,6 @@
 use patternfly_yew::prelude::*;
 use spog_ui_backend::{use_backend, VersionService};
-use spog_ui_utils::config::use_config_private;
+use spog_ui_common::config::use_config_public;
 use std::rc::Rc;
 use trustification_version::{version, VersionInformation};
 use yew::prelude::*;
@@ -9,7 +9,7 @@ use yew_oauth2::hook::use_latest_access_token;
 
 #[function_component(About)]
 pub fn about() -> Html {
-    let config = use_config_private();
+    let config = use_config_public();
     let backend = use_backend();
     let access_token = use_latest_access_token();
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/TC-1237 : spog-api: expose features in the public api
  - The features define which pages are going to be present; given the current hierarchy of components, the code that renders the pages only has access to the "public" configuration and not to the private one. This PR exposes also the features as part of the public api. The features are a set of boolean values which I don't consider to be a security thread to expose. I accept different opinions though.

```json
"features": {
        "scanner": false,
        "uploader": false,
        "extendSection": true,
        "dedicatedSearch": false,
        "additionalPackageInformation": false,
        "showSource": false,
        "showReport": true
    },
```

https://github.com/trustification/trustification/blob/f158e8354c0d56d7424ee15322c1930791f068b6/spog/ui/src/console/mod.rs#L240-L242

- https://issues.redhat.com/browse/TC-1248 : ui: about model to use public config
