### PR TITLE
[release/1.0.z] GuacClient to manage TLS

### DIFF
--- a/collector/osv/src/lib.rs
+++ b/collector/osv/src/lib.rs
@@ -115,8 +115,8 @@ impl AppState {
         P: TokenProvider + Clone + 'static,
     {
         Self {
-            v11y_client: v11y_client::V11yClient::new(client, v11y_url, provider),
-            guac_client: GuacClient::new(guac_url.as_str()),
+            v11y_client: v11y_client::V11yClient::new(client.clone(), v11y_url, provider),
+            guac_client: GuacClient::with_client(guac_url.to_string(), client),
             osv: OsvClient::new(),
         }
     }

--- a/collector/snyk/src/lib.rs
+++ b/collector/snyk/src/lib.rs
@@ -142,8 +142,8 @@ impl AppState {
         P: TokenProvider + Clone + 'static,
     {
         Self {
-            v11y_client: v11y_client::V11yClient::new(client, v11y_url, provider),
-            guac_client: GuacClient::new(guac_url.as_str()),
+            v11y_client: v11y_client::V11yClient::new(client.clone(), v11y_url, provider),
+            guac_client: GuacClient::with_client(guac_url.to_string(), client),
             snyk_org_id,
             snyk_token,
         }


### PR DESCRIPTION
Build GuacClient with provided reqwest::Client to manage TLS with ClientConfig

Backport https://github.com/trustification/trustification/pull/1353