### PR TITLE
fix: adds description for remaining commands

### DIFF
--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -4,6 +4,7 @@ mod delete;
 mod reindex;
 mod upload;
 
+/// Run admin services (`trust admin --help` for details)
 #[derive(clap::Subcommand, Debug)]
 pub enum Command {
     #[command(subcommand)]

--- a/bombastic/bombastic/src/lib.rs
+++ b/bombastic/bombastic/src/lib.rs
@@ -1,5 +1,6 @@
 use std::process::ExitCode;
 
+/// Run bombastic services (`trust bombastic --help` for details)
 #[derive(clap::Subcommand, Debug)]
 pub enum Command {
     Api(bombastic_api::Run),

--- a/collector/collector/src/lib.rs
+++ b/collector/collector/src/lib.rs
@@ -1,5 +1,6 @@
 use std::process::ExitCode;
 
+/// Run collector services (`trust collector --help` for details)
 #[derive(clap::Subcommand, Debug)]
 pub enum Command {
     Osv(collector_osv::Run),

--- a/collectorist/collectorist/src/lib.rs
+++ b/collectorist/collectorist/src/lib.rs
@@ -1,5 +1,6 @@
 use std::process::ExitCode;
 
+/// Run collectorist services (`trust collectorist --help` for details)
 #[derive(clap::Subcommand, Debug)]
 pub enum Command {
     Api(collectorist_api::Run),

--- a/exhort/exhort/src/lib.rs
+++ b/exhort/exhort/src/lib.rs
@@ -1,5 +1,6 @@
 use std::process::ExitCode;
 
+/// Run exhort services (`trust exhort --help` for details)
 #[derive(clap::Subcommand, Debug)]
 pub enum Command {
     Api(exhort_api::Run),

--- a/v11y/v11y/src/lib.rs
+++ b/v11y/v11y/src/lib.rs
@@ -1,5 +1,6 @@
 use std::process::ExitCode;
 
+/// Run v11y services (`trust v11y --help` for details)
 #[derive(clap::Subcommand, Debug)]
 pub enum Command {
     Api(v11y_api::Run),

--- a/vexination/vexination/src/lib.rs
+++ b/vexination/vexination/src/lib.rs
@@ -1,5 +1,6 @@
 use std::process::ExitCode;
 
+/// Run vexination services (`trust vexination --help` for details)
 #[derive(clap::Subcommand, Debug)]
 pub enum Command {
     Api(vexination_api::Run),


### PR DESCRIPTION
Related to #1127 

```console
Trust

Usage: trust <COMMAND>

Commands:
  vexination    Run vexination services (`trust vexination --help` for details)
  bombastic     Run bombastic services (`trust bombastic --help` for details)
  spog          Single Pane of Glass
  exhort        Run exhort services (`trust exhort --help` for details)
  collectorist  Run collectorist services (`trust collectorist --help` for details)
  collector     Run collector services (`trust collector --help` for details)
  v11y          Run v11y services (`trust v11y --help` for details)
  exporter      Run the exporter
  admin         Run admin services (`trust admin --help` for details)
  help          Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```