### PR TITLE
[release/1.0.z] Bump cve 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "cve"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ee1267b66dad96f0b01a465c0bbba05d3d54ba622a13af2f3182e80fd18726"
+checksum = "3c93fe9397675e55f01ae2f1268c9275bbc6d157c4966869f21aef3833ccac14"
 dependencies = [
  "serde",
  "serde_json",

--- a/spog/api/Cargo.toml
+++ b/spog/api/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1.73"
 bytes = "1"
 clap = { version = "4.0.29", features = ["derive"] }
 csaf = "0.5"
-cve = "0.2.1"
+cve = "0.3.0"
 cvss = "2"
 futures = "0.3"
 guac = { workspace = true }

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -14,7 +14,7 @@ browser-panic-hook = "0.2.0"
 chrono = { version = "0.4", default-features = false, features = ["wasmbind"] }
 convert_case = "0.6.0"
 csaf = { version = "0.5.0", default-features = false }
-cve = "0.2.1"
+cve = "0.3.0"
 cvss = { version = "2", features = ["serde"] }
 cyclonedx-bom = "0.4"
 futures = "0.3.29"

--- a/spog/ui/crates/backend/Cargo.toml
+++ b/spog/ui/crates/backend/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["wasmbind"] }
 csaf = { version = "0.5.0", default-features = false }
-cve = "0.2.1"
+cve = "0.3.0"
 cyclonedx-bom = "0.4"
 gloo-events = "0.2"
 gloo-net = "0.5.0"

--- a/v11y/index/Cargo.toml
+++ b/v11y/index/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cve = "0.2.1"
+cve = "0.3.0"
 sikula = { version = "0.4.0", features = ["time"] }
 log = "0.4"
 time = "0.3"


### PR DESCRIPTION
Backport https://github.com/trustification/trustification/pull/1364
Fixes https://issues.redhat.com/browse/TC-1495