### PR TITLE
fix: [TC-1225] - When opening an advisory to see its attributes, the display jumps to the top of the page

### DIFF
--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "cve"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ee1267b66dad96f0b01a465c0bbba05d3d54ba622a13af2f3182e80fd18726"
+checksum = "3c93fe9397675e55f01ae2f1268c9275bbc6d157c4966869f21aef3833ccac14"
 dependencies = [
  "serde",
  "serde_json",

--- a/spog/ui/crates/components/src/advisory/search.rs
+++ b/spog/ui/crates/components/src/advisory/search.rs
@@ -48,7 +48,7 @@ pub fn use_advisory_search(
 ) -> UseStandardSearch {
     let config = use_config_private();
     use_generic_search::<Vulnerabilities, _, _, _, _>(
-        0,
+        10_000,
         search_params,
         pagination,
         callback,

--- a/spog/ui/crates/components/src/advisory/search.rs
+++ b/spog/ui/crates/components/src/advisory/search.rs
@@ -48,7 +48,7 @@ pub fn use_advisory_search(
 ) -> UseStandardSearch {
     let config = use_config_private();
     use_generic_search::<Vulnerabilities, _, _, _, _>(
-        10_000,
+        0,
         search_params,
         pagination,
         callback,

--- a/spog/ui/crates/components/src/search/toolbar.rs
+++ b/spog/ui/crates/components/src/search/toolbar.rs
@@ -33,7 +33,7 @@ pub fn search_toolbar(props: &SearchToolbarProperties) -> Html {
                             <InputGroup>
                                 <TextInputGroup>
                                     <TextInput
-                                        autofocus=true
+                                        autofocus=false
                                         icon={Icon::Search}
                                         size="64"
                                         placeholder="Search"


### PR DESCRIPTION
Restore (as previously used with value of 0) fetch_interval to avoid user to browse page.

Fix https://issues.redhat.com/browse/TC-1225