### PR TITLE
Replace Guac DB secret name with template parameter

### DIFF
--- a/deploy/openshift/parameters.yaml
+++ b/deploy/openshift/parameters.yaml
@@ -119,6 +119,10 @@ parameters:
   required: true
 - name: K8S_NAMESPACE
   required: true
+- name: GUAC_ADMIN_DB_SECRET_NAME
+  value: guac-admin-db
+- name: GUAC_USER_DB_SECRET_NAME
+  value: guac-user-db
 - name: VEXINATION_WALKER_SCHEDULE
   value: "10 * * * *"
 - name: BOMBASTIC_WALKER_SCHEDULE

--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -756,33 +756,33 @@ objects:
                 - name: PGHOST
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.host
                 - name: PGPORT
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.port
                 - name: TC_PGOPTIONS
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.options
                       optional: true
                 - name: DB_NAME
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.name
                 - name: DB_USER
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.user
                 - name: DB_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.password
           containers:
             - image: ${GUAC_IMAGE}
@@ -815,33 +815,33 @@ objects:
                 - name: PGHOST
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.host
                 - name: PGPORT
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.port
                 - name: TC_PGOPTIONS
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.options
                       optional: true
                 - name: DB_NAME
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.name
                 - name: DB_USER
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.user
                 - name: DB_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.password
               volumeMounts:
                 - name: guac-config
@@ -2020,42 +2020,42 @@ objects:
                 - name: PGHOST
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.host
                 - name: PGPORT
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.port
                 - name: PGDATABASE
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.name
                 - name: PGUSER
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.user
                 - name: PGPASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.password
                 - name: DB_NAME
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.name
                 - name: DB_USER
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.user
                 - name: DB_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.password
               volumeMounts:
                 - mountPath: /etc/init-data
@@ -2167,6 +2167,10 @@ parameters:
   required: true
 - name: GUAC_COLLECTSUB_REPLICAS
   required: true
+- name: GUAC_ADMIN_DB_SECRET_NAME
+  value: guac-admin-db
+- name: GUAC_USER_DB_SECRET_NAME
+  value: guac-user-db
 - name: BOMBASTIC_API_REPLICAS
   required: true
 - name: BOMBASTIC_INDEXER_REPLICAS


### PR DESCRIPTION
The hardcoded value is now replaced with configurable parameter that allows user to set the secret name.