### PR TITLE
Use template params for OIDC and guac db secret

### DIFF
--- a/deploy/k8s/chart/templates/guac/graphql/030-Deployment.yaml
+++ b/deploy/k8s/chart/templates/guac/graphql/030-Deployment.yaml
@@ -53,28 +53,28 @@ spec:
             - name: PGHOST
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.host"
             - name: PGPORT
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.port"
             - name: DB_NAME
               valueFrom:
                 secretKeyRef:
                   # we indeed require the user database, as we set up guac's schema
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.name"
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.user"
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.password"
 {{ end }}
       containers:
@@ -111,27 +111,27 @@ spec:
             - name: PGHOST
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.host"
             - name: PGPORT
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.port"
             - name: DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.name"
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.user"
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.password"
 {{- end }}
           volumeMounts:

--- a/deploy/k8s/chart/templates/init-guac/020-Job.yaml
+++ b/deploy/k8s/chart/templates/init-guac/020-Job.yaml
@@ -42,45 +42,45 @@ spec:
             - name: PGHOST
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.host"
             - name: PGPORT
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.port"
             - name: PGDATABASE
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.name"
             - name: PGUSER
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.user"
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.password"
 
             - name: DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.name"
 
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.user"
 
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.password"
 
           volumeMounts:

--- a/deploy/openshift/database-recreate-template.yaml
+++ b/deploy/openshift/database-recreate-template.yaml
@@ -31,45 +31,45 @@ objects:
             - name: PGHOST
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.host"
             - name: PGPORT
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.port"
             - name: PGDATABASE
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.name"
             - name: PGUSER
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.user"
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.password"
 
             - name: DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.name"
 
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.user"
 
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.password"
 
           volumeMounts:
@@ -90,45 +90,45 @@ objects:
             - name: PGHOST
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.host"
             - name: PGPORT
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.port"
             - name: PGDATABASE
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.name"
             - name: PGUSER
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.user"
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.password"
 
             - name: DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.name"
 
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.user"
 
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.password"
 
           volumeMounts:
@@ -163,26 +163,26 @@ objects:
             - name: PGHOST
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.host"
             - name: PGPORT
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.port"
             - name: DB_NAME
               valueFrom:
                 secretKeyRef:
                   # we indeed require the user database, as we set up guac's schema
-                  name: guac-user-db
+                  name: {{ .Values.guac.database.user_db_secret_name }}
                   key: "db.name"
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.user"
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: guac-admin-db
+                  name: {{ .Values.guac.database.admin_db_secret_name }}
                   key: "db.password"

--- a/deploy/openshift/parameters.yaml
+++ b/deploy/openshift/parameters.yaml
@@ -61,6 +61,10 @@ parameters:
   required: true
 - name: OIDC_PROVIDER_CLIENT_SECRET_KEY
   required: true
+- name: OIDC_API_CLIENT_ID
+  value: trusted-content-api
+- name: OIDC_SPOG_CLIENT_ID
+  value: trusted-content-frontend
 - name: V11Y_API_RESOURCES
   required: true
 - name: V11Y_STORAGE_BUCKET
@@ -93,6 +97,10 @@ parameters:
   required: true
 - name: GUAC_COLLECTSUB_REPLICAS
   required: true
+- name: GUAC_ADMIN_DB_SECRET_NAME
+  value: guac-admin-db
+- name: GUAC_USER_DB_SECRET_NAME
+  value: guac-user-db
 - name: BOMBASTIC_API_REPLICAS
   required: true
 - name: BOMBASTIC_INDEXER_REPLICAS

--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -605,7 +605,7 @@ objects:
                 - name: GUAC_URL
                   value: http://guac-graphql:8080/query
                 - name: OIDC_PROVIDER_CLIENT_ID
-                  value: trusted-content-api
+                  value: ${OIDC_API_CLIENT_ID}
                 - name: OIDC_PROVIDER_CLIENT_SECRET
                   valueFrom:
                     secretKeyRef:
@@ -759,27 +759,27 @@ objects:
                 - name: PGHOST
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.host
                 - name: PGPORT
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.port
                 - name: DB_NAME
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.name
                 - name: DB_USER
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.user
                 - name: DB_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.password
           containers:
             - image: ${GUAC_IMAGE}
@@ -814,27 +814,27 @@ objects:
                 - name: PGHOST
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.host
                 - name: PGPORT
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.port
                 - name: DB_NAME
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.name
                 - name: DB_USER
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.user
                 - name: DB_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.password
               volumeMounts:
                 - name: guac-config
@@ -935,7 +935,7 @@ objects:
                 - name: SPOG_UI_CONFIG
                   value: /etc/config/spog-ui.yaml
                 - name: OIDC_PROVIDER_CLIENT_ID
-                  value: trusted-content-api
+                  value: ${OIDC_API_CLIENT_ID}
                 - name: OIDC_PROVIDER_CLIENT_SECRET
                   valueFrom:
                     secretKeyRef:
@@ -1029,7 +1029,7 @@ objects:
                 - name: ISSUER_URL
                   value: ${ISSUER_URL}
                 - name: CLIENT_ID
-                  value: trusted-content-frontend
+                  value: ${OIDC_SPOG_CLIENT_ID}
                 - name: SCOPES
                   value: openid email id.username api.trusted_content
                 - name: WRITE_KEY
@@ -1639,7 +1639,7 @@ objects:
                     - name: INFRASTRUCTURE_BIND
                       value: '[::]:9010'
                     - name: OIDC_PROVIDER_CLIENT_ID
-                      value: trusted-content-api
+                      value: ${OIDC_API_CLIENT_ID}
                     - name: OIDC_PROVIDER_CLIENT_SECRET
                       valueFrom:
                         secretKeyRef:
@@ -1710,7 +1710,7 @@ objects:
                       '
                   env:
                     - name: OIDC_PROVIDER_CLIENT_ID
-                      value: trusted-content-api
+                      value: ${OIDC_API_CLIENT_ID}
                     - name: OIDC_PROVIDER_CLIENT_SECRET
                       valueFrom:
                         secretKeyRef:
@@ -1794,7 +1794,7 @@ objects:
                     - name: INFRASTRUCTURE_BIND
                       value: '[::]:9010'
                     - name: OIDC_PROVIDER_CLIENT_ID
-                      value: trusted-content-api
+                      value: ${OIDC_API_CLIENT_ID}
                     - name: OIDC_PROVIDER_CLIENT_SECRET
                       valueFrom:
                         secretKeyRef:
@@ -1946,7 +1946,7 @@ objects:
                     - name: INFRASTRUCTURE_BIND
                       value: '[::]:9010'
                     - name: OIDC_PROVIDER_CLIENT_ID
-                      value: trusted-content-api
+                      value: ${OIDC_API_CLIENT_ID}
                     - name: OIDC_PROVIDER_CLIENT_SECRET
                       valueFrom:
                         secretKeyRef:
@@ -2008,42 +2008,42 @@ objects:
                 - name: PGHOST
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.host
                 - name: PGPORT
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.port
                 - name: PGDATABASE
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.name
                 - name: PGUSER
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.user
                 - name: PGPASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: guac-admin-db
+                      name: ${GUAC_ADMIN_DB_SECRET_NAME}
                       key: db.password
                 - name: DB_NAME
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.name
                 - name: DB_USER
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.user
                 - name: DB_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: guac-user-db
+                      name: ${GUAC_USER_DB_SECRET_NAME}
                       key: db.password
               volumeMounts:
                 - mountPath: /etc/init-data
@@ -2123,6 +2123,10 @@ parameters:
   required: true
 - name: OIDC_PROVIDER_CLIENT_SECRET_KEY
   required: true
+- name: OIDC_API_CLIENT_ID
+  value: trusted-content-api
+- name: OIDC_SPOG_CLIENT_ID
+  value: trusted-content-frontend
 - name: V11Y_API_RESOURCES
   required: true
 - name: V11Y_STORAGE_BUCKET
@@ -2155,6 +2159,10 @@ parameters:
   required: true
 - name: GUAC_COLLECTSUB_REPLICAS
   required: true
+- name: GUAC_ADMIN_DB_SECRET_NAME
+  value: guac-admin-db
+- name: GUAC_USER_DB_SECRET_NAME
+  value: guac-user-db
 - name: BOMBASTIC_API_REPLICAS
   required: true
 - name: BOMBASTIC_INDEXER_REPLICAS

--- a/deploy/openshift/values.yaml
+++ b/deploy/openshift/values.yaml
@@ -157,6 +157,8 @@ guac:
   database:
     enabled: true
     image: ${POSTGRESQL_IMAGE}
+    admin_db_secret_name: ${GUAC_ADMIN_DB_SECRET_NAME}
+    user_db_secret_name: ${GUAC_USER_DB_SECRET_NAME}
   initJob:
     serviceAccountName: ${GUAC_INIT_JOB_SERVICE_ACCOUNT}
   graphql:
@@ -168,12 +170,12 @@ oidcClients:
     issuerUrl: ${ISSUER_URL}
     scopes: "openid email id.username api.trusted_content"
     clientId:
-      value: trusted-content-frontend
+      value: ${OIDC_SPOG_CLIENT_ID}
   walker:
     issuerUrl: ${ISSUER_URL}
     scopes: "openid id.username"
     clientId:
-      value: trusted-content-api
+      value: ${OIDC_API_CLIENT_ID}
     clientSecret:
       valueFrom:
         secretKeyRef:
@@ -183,12 +185,12 @@ oidcClients:
     issuerUrl: ${ISSUER_URL}
     scopes: "openid id.username"
     clientId:
-      value: trusted-content-api
+      value: ${OIDC_API_CLIENT_ID}
   testingUser:
     issuerUrl: ${ISSUER_URL}
     scopes: "openid id.username"
     clientId:
-      value: trusted-content-api
+      value: ${OIDC_API_CLIENT_ID}
 dataset:
   enabled: false
   enabledJob: ${{DATASET_ENABLED_JOB}}


### PR DESCRIPTION
Both OIDC and guac secret use the hardcoded values. This commit make the values configurable using template parameter.