### PR TITLE
[TC-1263][SPoG-UI] - When opening a 'vendor fix' in a CVE ID under an advisory, the data is cut off

### DIFF
--- a/spog/ui/crates/components/src/advisory/details/remediation.rs
+++ b/spog/ui/crates/components/src/advisory/details/remediation.rs
@@ -95,6 +95,7 @@ pub fn remediation_table(props: &CsafRemediationTableProperties) -> Html {
             {entries}
             mode={TableMode::CompactExpandable}
             {onexpand}
+            class="advisory_vulnerability_remediation"
         />
     )
 }

--- a/spog/ui/styles/main.scss
+++ b/spog/ui/styles/main.scss
@@ -63,3 +63,12 @@ header {
 .tc-package-tree .pf-v5-c-accordion__expandable-content-body {
   padding-right: 0 !important;
 }
+
+// Advisory Vulnerability/remediations
+
+table.advisory_vulnerability_remediation
+  .pf-v5-c-table__expandable-row-content
+  .pf-v5-c-content {
+  overflow-wrap: break-word;
+  max-width: 550px;
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1263

How to reproduce the issue:
- Start this repo without the changes into this PR
- Upload a CSAF file [CVE-2023-44487.json](https://github.com/user-attachments/files/15787154/CVE-2023-44487.1.json)
- Open the advisory details page and navigate to the "Vulnerabilities" tab. There expand the table rows. Inside the expanded area of the tables you should see a "Remediations" section, expand it and you will see the text is overflowing the white area

After applying this PR, you can follow the same steps and the issue should be gone.
