### PR TITLE
[TC-1576]-Get SBOM file directly from bombastic and avoid restqwest default timeout

### DIFF
--- a/spog/ui/crates/backend/src/sbom.rs
+++ b/spog/ui/crates/backend/src/sbom.rs
@@ -44,7 +44,7 @@ impl SBOMService {
     }
 
     pub async fn get(&self, id: impl AsRef<str>) -> Result<Option<String>, ApiError> {
-        let mut url = self.backend.join(Endpoint::Api, "/api/v1/sbom")?;
+        let mut url = self.backend.join(Endpoint::Bombastic, "/api/v1/sbom")?;
         url.query_pairs_mut().append_pair("id", id.as_ref()).finish();
 
         let response = self


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1576

- Currently the UI is pointing to SpogApi to fetch a single SBOM, then SpogApi redirects the request to Bombastic. There is a chain
- The default timeout for requests in the backend is 30 seconds, so SpogApi -> Bombastic can not take minutes

I am making the UI to request directly the sbom from bombastic and avoid relying on an rest client  with 30 seconds of timeout by default.