### PR TITLE
TC-1582 None CVE alias found management

### DIFF
--- a/collector/osv/src/server.rs
+++ b/collector/osv/src/server.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use actix_web::{post, web, HttpResponse, Responder, ResponseError};
+use anyhow::anyhow;
 use derive_more::Display;
 use guac::client::intrinsic::certify_vuln::ScanMetadataInput;
 use guac::client::intrinsic::vuln_equal::VulnEqualInputSpec;
@@ -138,19 +139,30 @@ pub async fn collect_packages(
                         if !vuln.id.to_lowercase().starts_with("cve") {
                             match state.osv.vulns(&vuln.id).await {
                                 Ok(Some(osv_vuln)) => {
-                                    if let Some(aliases) = &osv_vuln.aliases {
-                                        for alias in aliases {
-                                            if alias.to_lowercase().starts_with("cve") {
-                                                vulnerability_input_specs.push(VulnerabilityInputSpec {
-                                                    r#type: "cve".to_string(),
-                                                    vulnerability_id: alias.clone(),
-                                                });
-                                            } else {
-                                                alias_vuln_input_specs.push(VulnerabilityInputSpec {
-                                                    r#type: "osv".to_string(),
-                                                    vulnerability_id: alias.clone(),
-                                                })
+                                    match &osv_vuln.aliases {
+                                        Some(aliases) => {
+                                            for alias in aliases {
+                                                if alias.to_lowercase().starts_with("cve") {
+                                                    vulnerability_input_specs.push(VulnerabilityInputSpec {
+                                                        r#type: "cve".to_string(),
+                                                        vulnerability_id: alias.clone(),
+                                                    });
+                                                } else {
+                                                    alias_vuln_input_specs.push(VulnerabilityInputSpec {
+                                                        r#type: "osv".to_string(),
+                                                        vulnerability_id: alias.clone(),
+                                                    })
+                                                }
                                             }
+                                        }
+                                        // No CVE ID alias found, re https://issues.redhat.com/browse/TC-1582
+                                        // check the comment below because now the lack of a CVE ID is reported as an OSV error
+                                        None => {
+                                            log::warn!(
+                                                "OSV vulnerability CVE alias retrieval for {} found no alias",
+                                                vuln.id
+                                            );
+                                            collected_osv_errors.push(anyhow!(Error::Osv));
                                         }
                                     }
 
@@ -173,14 +185,22 @@ pub async fn collect_packages(
                                 }
                             }
                         }
-                        if vulnerability_input_specs.is_empty() {
-                            // if no CVE ID alias has been found, then worth adding vulnerability with
-                            // the original vuln.id value
-                            vulnerability_input_specs.push(VulnerabilityInputSpec {
-                                r#type: "osv".to_string(),
-                                vulnerability_id: vuln.id.clone(),
-                            })
-                        } else {
+                        // After https://issues.redhat.com/browse/TC-1582, it's not worth adding it
+                        // if no CVE ID has been found because trustification isn't able to manage
+                        // other types of IDs, e.g. GHSA IDs, i.e. GHSA-9vm7-v8wj-3fqw
+                        // This is going to be commented waiting for an improved vulnerabilities
+                        // management capable of managing multiple IDs
+                        /*
+                                                if vulnerability_input_specs.is_empty() {
+                                                    // if no CVE ID alias has been found, then worth adding vulnerability with
+                                                    // the original vuln.id value
+                                                    vulnerability_input_specs.push(VulnerabilityInputSpec {
+                                                        r#type: "osv".to_string(),
+                                                        vulnerability_id: vuln.id.clone(),
+                                                    })
+                                                } else {
+                        */
+                        if !vulnerability_input_specs.is_empty() {
                             // otherwise the original vulnerability must be part of the aliases
                             alias_vuln_input_specs.push(VulnerabilityInputSpec {
                                 r#type: "osv".to_string(),


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1582

The case when `None` alias would have been found wasn't managed leading trustification to go on and ingest vulnerability with unexpected ID.

Since it's expected to improve this ID management, the previous code has been simply commented.