### PR TITLE
[TC-1599]: cover advisories without scores

### DIFF
--- a/spog/ui/crates/components/src/advisory/mod.rs
+++ b/spog/ui/crates/components/src/advisory/mod.rs
@@ -74,6 +74,8 @@ impl TableEntryRenderer<Column> for AdvisoryEntry {
                 let l = self.summary.cves.len();
                 if l == 0 {
                     "N/A".to_string().into()
+                } else if self.summary.cve_severity_count.is_empty() {
+                    self.summary.cves.len().to_string().into()
                 } else {
                     html!(<CvssMap map={self.summary.cve_severity_count.clone()} />)
                 }


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1599

### Reason of issue
- The vulnerabilities column is taken based on the `vulnerabiltities.scores` field
![Screenshot from 2024-06-26 13-36-41](https://github.com/trustification/trustification/assets/2582866/cd9f92b5-c302-4b7a-9584-f47ef90c8f5c)

- It seems not all CSAF files contain that file. For instance this CSAF file does not have scores 
[CVE-2001-0013.json](https://github.com/user-attachments/files/15987325/CVE-2001-0013.1.json)

### After this PR
In case an Advisory has vulnerabilities but no scores then we will render just the count of vulnerabilities without the shields with severity (as the shield of severity requires scrores)

![Screenshot from 2024-06-26 13-38-33](https://github.com/trustification/trustification/assets/2582866/6afba79c-b220-4d1d-b203-f75175d24102)