### PR TITLE
Upload SAST results

### DIFF
--- a/.tekton/trustification-service-pull-request.yaml
+++ b/.tekton/trustification-service-pull-request.yaml
@@ -351,7 +351,12 @@ spec:
         - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name

--- a/.tekton/trustification-service-push.yaml
+++ b/.tekton/trustification-service-push.yaml
@@ -348,7 +348,12 @@ spec:
         - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name

--- a/.tekton/trustification-tests-pull-request.yaml
+++ b/.tekton/trustification-tests-pull-request.yaml
@@ -351,7 +351,12 @@ spec:
         - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name

--- a/.tekton/trustification-tests-push.yaml
+++ b/.tekton/trustification-tests-push.yaml
@@ -348,7 +348,12 @@ spec:
         - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
These parameters will make it so that the sast task starts uploading sarif results to quay.io, for long-term storage.

Related: https://issues.redhat.com/browse/KONFLUX-2263