### PR TITLE
Upload SAST

### DIFF
--- a/.tekton/trustification-product-1-0-z-pull-request.yaml
+++ b/.tekton/trustification-product-1-0-z-pull-request.yaml
@@ -317,7 +317,12 @@ spec:
         - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name

--- a/.tekton/trustification-product-1-0-z-push.yaml
+++ b/.tekton/trustification-product-1-0-z-push.yaml
@@ -314,7 +314,12 @@ spec:
         - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name

--- a/.tekton/trustification-product-test-1-0-z-pull-request.yaml
+++ b/.tekton/trustification-product-test-1-0-z-pull-request.yaml
@@ -315,7 +315,12 @@ spec:
         - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name

--- a/.tekton/trustification-product-test-1-0-z-push.yaml
+++ b/.tekton/trustification-product-test-1-0-z-push.yaml
@@ -312,7 +312,12 @@ spec:
         - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
These parameters will make it so that the sast task starts uploading sarif results to quay.io, for long-term storage.

Related: https://issues.redhat.com/browse/KONFLUX-2263

see: https://github.com/trustification/trustification/pull/1512
