### PR TITLE
Upload SAST

### DIFF
--- a/.tekton/trustification-product-1-1-z-pull-request.yaml
+++ b/.tekton/trustification-product-1-1-z-pull-request.yaml
@@ -331,29 +331,34 @@ spec:
         operator: in
         values:
         - "false"
-    #- name: ecosystem-cert-preflight-checks
-    #  params:
-    #  - name: image-url
-    #    value: $(tasks.build-container.results.IMAGE_URL)
-    #  runAfter:
-    #  - build-container
-    #  taskRef:
-    #    params:
-    #    - name: name
-    #      value: ecosystem-cert-preflight-checks
-    #    - name: bundle
-    #      value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
-    #    - name: kind
-    #      value: task
-    #    resolver: bundles
-    #  when:
-    #  - input: $(params.skip-checks)
-    #    operator: in
-    #    values:
-    #    - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name

--- a/.tekton/trustification-product-1-1-z-push.yaml
+++ b/.tekton/trustification-product-1-1-z-push.yaml
@@ -350,7 +350,12 @@ spec:
         - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name

--- a/.tekton/trustification-product-test-1-1-z-pull-request.yaml
+++ b/.tekton/trustification-product-test-1-1-z-pull-request.yaml
@@ -331,29 +331,34 @@ spec:
         operator: in
         values:
         - "false"
-    #- name: ecosystem-cert-preflight-checks
-    #  params:
-    #  - name: image-url
-    #    value: $(tasks.build-container.results.IMAGE_URL)
-    #  runAfter:
-    #  - build-container
-    #  taskRef:
-    #    params:
-    #    - name: name
-    #      value: ecosystem-cert-preflight-checks
-    #    - name: bundle
-    #      value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
-    #    - name: kind
-    #      value: task
-    #    resolver: bundles
-    #  when:
-    #  - input: $(params.skip-checks)
-    #    operator: in
-    #    values:
-    #    - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name

--- a/.tekton/trustification-product-test-1-1-z-push.yaml
+++ b/.tekton/trustification-product-test-1-1-z-push.yaml
@@ -328,29 +328,34 @@ spec:
         operator: in
         values:
         - "false"
-    #- name: ecosystem-cert-preflight-checks
-    #  params:
-    #  - name: image-url
-    #    value: $(tasks.build-container.results.IMAGE_URL)
-    #  runAfter:
-    #  - build-container
-    #  taskRef:
-    #    params:
-    #    - name: name
-    #      value: ecosystem-cert-preflight-checks
-    #    - name: bundle
-    #      value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
-    #    - name: kind
-    #      value: task
-    #    resolver: bundles
-    #  when:
-    #  - input: $(params.skip-checks)
-    #    operator: in
-    #    values:
-    #    - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
hese parameters will make it so that the sast task starts uploading sarif results to quay.io, for long-term storage.

Related: https://issues.redhat.com/browse/KONFLUX-2263

See: https://github.com/trustification/trustification/pull/1512