### PR TITLE
TC-1578 Enhanced Vulnerabilities tab labels

### DIFF
--- a/spog/ui/src/pages/sbom/mod.rs
+++ b/spog/ui/src/pages/sbom/mod.rs
@@ -150,7 +150,23 @@ fn details(props: &DetailsProps) -> Html {
                         <Tabs<TabIndex> inset={TabInset::Page} detached=true selected={*tab} {onselect}>
                             <Tab<TabIndex> index={TabIndex::Info} title="Info" />
                             <Tab<TabIndex> index={TabIndex::Packages} title="Packages" />
-                            <Tab<TabIndex> index={TabIndex::Overview} title="Related vulnerabilities" />
+                            <Tab<TabIndex> index={TabIndex::Overview} title={html!(
+                                <>
+                                    { "Vulnerabilities" }
+                                    <Popover
+                                        target={html!(
+                                            <button class="pf-v5-c-button pf-m-plain pf-m-small" type="button" style="padding: 0px 0px 0px 5px;">
+                                                <span class="pf-v5-c-tabs__item-action-icon">
+                                                { Icon::QuestionCircle }
+                                                </span>
+                                            </button>
+                                        )}
+                                        body={html_nested!(
+                                            <PopoverBody>{"Any found vulnerabilities related to this SBOM. Fixed vulnerabilities are not listed."}</PopoverBody>
+                                        )}
+                                    />
+                                </>
+                            )}/>
                             { for config.features.show_report.then(|| html_nested!(
                                 <Tab<TabIndex> index={TabIndex::Report} title="Dependency Analytics Report" />
                             )) }


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1578

The updated label and tooltip look like:
![Screenshot from 2024-07-04 09-34-50](https://github.com/trustification/trustification/assets/7288588/0f206a2d-38f2-478f-8a7b-6b72ca0df087)
