### PR TITLE
fix: arm build improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,7 +240,7 @@ jobs:
 
     with:
       imageTag: ci
-      platforms: "linux/amd64, linux/arm64"
+      platforms: "linux/amd64"
 
   helm-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -320,7 +320,7 @@ jobs:
       - name: Generate container SBOM
         run: |
           syft ~/download/${{ matrix.name }}-container/${{ matrix.name }}-image.tar --output cyclonedx-json --catalogers rpm,cargo-auditable > staging/${{ matrix.name }}.sbom.json
-          cyclonedx merge --input-files staging/${{ matrix.name }}.sbom.json staging/trust-ui.project.sbom.json --output-file staging/${{ matrix.name }}.sbom.json 
+          cyclonedx merge --input-files staging/${{ matrix.name }}.sbom.json staging/trust-ui.project.sbom.json --output-file staging/${{ matrix.name }}.sbom.json
 
       - name: Log in to ghcr.io
         uses: redhat-actions/podman-login@v1
@@ -335,7 +335,7 @@ jobs:
           IMAGE="ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ needs.init.outputs.version }}"
           podman push \
             "${{ matrix.name }}:ci" \
-            "${IMAGE}" \
+            "${IMAGE}" --all \
             --digestfile "${RUNNER_TEMP}/push.${{ matrix.name }}.digest"
 
       - name: Push to ghcr.io (as latest)
@@ -344,7 +344,7 @@ jobs:
         run: |
           IMAGE="ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:latest"
           podman push \
-            "${{ matrix.name }}:ci" \
+            "${{ matrix.name }}:ci" --all \
             "${IMAGE}"
 
       - name: Sign the images with GitHub OIDC Token

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -121,7 +121,7 @@ jobs:
           IMAGE="ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ needs.init.outputs.version }}"
           podman push \
             "${{ matrix.name }}:ci" \
-            "${IMAGE}" \
+            "${IMAGE}" --all \
             --digestfile "${RUNNER_TEMP}/push.${{ matrix.name }}.digest"
 
       - name: Push to ghcr.io (as latest)
@@ -129,7 +129,7 @@ jobs:
         run: |
           IMAGE="ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:latest"
           podman push \
-            "${{ matrix.name }}:ci" \
+            "${{ matrix.name }}:ci" --all \
             "${IMAGE}"
 
       - name: Sign the images with GitHub OIDC Token


### PR DESCRIPTION
This PR should fix two things:

- Revert back from building arm images CI workflow as it's not needed and it makes PR checks very long
- It seems that podman is still pushing only the first manifest. Comparing to the trustify build which works properly, the only difference that I see is the usage of `--all` argument. I would try that first and if it doesn't work switch to using `redhat-actions/push-to-registry@v2` action