### PR TITLE
Make tests env vars configurable

### DIFF
--- a/deploy/openshift/integration-tests-template.yaml
+++ b/deploy/openshift/integration-tests-template.yaml
@@ -22,9 +22,9 @@ objects:
               - name: TRUST_URL
                 value: "https://${DOMAIN}"
               - name: TRUST_ID
-                value: trusted-content-api
+                value: "${TRUST_ID}"
               - name: TRUST_USER_ID
-                value: trusted-content-api
+                value: "${TRUST_USER_ID}"
               - name: ISSUER_URL
                 value: "${ISSUER_URL}"
               - name: TRUST_SECRET
@@ -49,6 +49,10 @@ parameters:
   required: true
 - name: ISSUER_URL
   required: true
+- name: TRUST_ID
+  value: trusted-content-api
+- name: TRUST_USER_ID
+  value: trusted-content-api
 - name: OIDC_CLIENT_SECRET
   required: true
 - name: OIDC_CLIENT_SECRET_KEY


### PR DESCRIPTION
The template for running a tests is now using parametrized arguments that allows running tests on any instance of the TPA.

JIRA: ISV-5038