### PR TITLE
Found new vulnerabilties for testing Ubuntu ecosystem

### DIFF
--- a/collector/osv/src/client/mod.rs
+++ b/collector/osv/src/client/mod.rs
@@ -228,9 +228,9 @@ mod tests {
     async fn query_vuln_ecosystem_ubuntu() -> Result<(), anyhow::Error> {
         let osv_client = OsvClient::new();
         // these three CVEs ensure full coverage (at commit date) of the Ubuntu Ecosystem
-        let _vuln: v11y_client::Vulnerability = osv_client.vulns("CVE-2024-40907").await?.unwrap().into();
-        let _vuln: v11y_client::Vulnerability = osv_client.vulns("CVE-2024-7264").await?.unwrap().into();
-        let _vuln: v11y_client::Vulnerability = osv_client.vulns("CVE-2024-4764").await?.unwrap().into();
+        let _vuln: v11y_client::Vulnerability = osv_client.vulns("USN-6969-1").await?.unwrap().into();
+        let _vuln: v11y_client::Vulnerability = osv_client.vulns("USN-6944-1").await?.unwrap().into();
+        let _vuln: v11y_client::Vulnerability = osv_client.vulns("USN-6944-2").await?.unwrap().into();
 
         Ok(())
     }


### PR DESCRIPTION
OSV isn't providing information for previously working CVE IDs used in `query_vuln_ecosystem_ubuntu` test causing failures like https://github.com/trustification/trustification/actions/runs/10578469221/job/29308681073?pr=1713#step:10:1566

New vulnerabilities affecting the whole set of Ubuntu versions have been identified.