### PR TITLE
[TC-1668] - Dashboard - Status panel - back end - Correct the issue of incorrect timestamp sorting

### DIFF
--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -463,7 +463,7 @@ async fn sbom_status(
             last_updated_sbom_id: Some(sbom.document.id.to_string()),
             last_updated_sbom_name: Some(sbom.document.name.to_string()),
             last_updated_date: Some(
-                OffsetDateTime::from_unix_timestamp(sbom.document.indexed_timestamp)
+                OffsetDateTime::from_unix_timestamp_nanos(sbom.document.indexed_timestamp as i128)
                     .unwrap_or(OffsetDateTime::UNIX_EPOCH),
             ),
         }))

--- a/bombastic/api/src/server.rs
+++ b/bombastic/api/src/server.rs
@@ -23,6 +23,7 @@ use trustification_auth::{
     swagger_ui::{swagger_ui_with_auth, SwaggerUiOidc},
     Permission,
 };
+use trustification_index::tantivy::time::OffsetDateTime;
 use trustification_index::Error as IndexError;
 use trustification_infrastructure::new_auth;
 use trustification_storage::{Error as StorageError, Key, S3Path};
@@ -461,7 +462,10 @@ async fn sbom_status(
             total: Some(total_docs),
             last_updated_sbom_id: Some(sbom.document.id.to_string()),
             last_updated_sbom_name: Some(sbom.document.name.to_string()),
-            last_updated_date: Some(sbom.document.indexed_timestamp),
+            last_updated_date: Some(
+                OffsetDateTime::from_unix_timestamp(sbom.document.indexed_timestamp)
+                    .unwrap_or(OffsetDateTime::UNIX_EPOCH),
+            ),
         }))
     } else {
         Ok(HttpResponse::Ok().json(StatusResult::default()))

--- a/bombastic/model/src/search.rs
+++ b/bombastic/model/src/search.rs
@@ -36,7 +36,7 @@ pub enum Packages<'a> {
     #[search(sort)]
     Created(Ordered<time::OffsetDateTime>),
     #[search(sort)]
-    IndexedTimestamp(Ordered<time::OffsetDateTime>),
+    IndexedTimestamp(Ordered<i64>),
     Digest(&'a str),
     #[search(scope)]
     License(&'a str),
@@ -64,7 +64,7 @@ pub struct SearchDocument {
     pub uid: Option<String>,
     /// The creation time of the document.
     #[schema(value_type = String)]
-    pub indexed_timestamp: time::OffsetDateTime,
+    pub indexed_timestamp: i64,
     /// SBOM package name
     pub name: String,
     /// SBOM package version
@@ -130,13 +130,3 @@ pub struct StatusResult {
     /// Updated time of last updated doc
     pub last_updated_date: Option<OffsetDateTime>,
 }
-
-// impl Default for StatusResult {
-//     fn default() -> Self {
-//         StatusResult {
-//             total: 0,
-//             last_updated_sbom: "".to_string(),
-//             last_updated_date: OffsetDateTime::now_utc(),
-//         }
-//     }
-// }

--- a/integration-tests/tests/bombastic.rs
+++ b/integration-tests/tests/bombastic.rs
@@ -196,12 +196,8 @@ async fn bombastic_reindexing(context: &mut BombasticContext) {
 
     wait_for_sbom_search_result(context, &[("q", key.as_str()), ("metadata", "true")], |response| {
         response["total"].as_u64().filter(|&t| t > 0).is_some_and(|_| {
-            let format = &time::format_description::well_known::Rfc3339;
-            let ts = OffsetDateTime::parse(
-                response["result"][0]["$metadata"]["indexed_timestamp"]["values"][0]
-                    .as_str()
-                    .unwrap(),
-                format,
+            let ts = OffsetDateTime::from_unix_timestamp_nanos(
+                response["result"][0]["document"]["indexed_timestamp"].as_i64().unwrap() as i128,
             )
             .unwrap();
             ts > now

--- a/v11y/api/src/server/search.rs
+++ b/v11y/api/src/server/search.rs
@@ -7,6 +7,7 @@ use trustification_api::search::{SearchOptions, SearchResult};
 use trustification_auth::authenticator::user::UserInformation;
 use trustification_auth::authorizer::Authorizer;
 use trustification_auth::Permission;
+use trustification_index::tantivy::time::OffsetDateTime;
 use v11y_model::search::StatusResult;
 
 /// Parameters for search query.
@@ -153,7 +154,10 @@ async fn cve_status(
         Ok(HttpResponse::Ok().json(StatusResult {
             total: Some(total_docs),
             last_updated_cve_id: Some(cve.document.id.to_string()),
-            last_updated_date: Some(cve.document.indexed_timestamp),
+            last_updated_date: Some(
+                OffsetDateTime::from_unix_timestamp(cve.document.indexed_timestamp)
+                    .unwrap_or(OffsetDateTime::UNIX_EPOCH),
+            ),
         }))
     } else {
         Ok(HttpResponse::Ok().json(StatusResult::default()))

--- a/v11y/api/src/server/search.rs
+++ b/v11y/api/src/server/search.rs
@@ -155,7 +155,7 @@ async fn cve_status(
             total: Some(total_docs),
             last_updated_cve_id: Some(cve.document.id.to_string()),
             last_updated_date: Some(
-                OffsetDateTime::from_unix_timestamp(cve.document.indexed_timestamp)
+                OffsetDateTime::from_unix_timestamp_nanos(cve.document.indexed_timestamp as i128)
                     .unwrap_or(OffsetDateTime::UNIX_EPOCH),
             ),
         }))

--- a/v11y/index/src/lib.rs
+++ b/v11y/index/src/lib.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 use time::OffsetDateTime;
 use trustification_api::search::SearchOptions;
 use trustification_index::{
-    create_boolean_query, create_date_query, create_float_query, create_string_query_case, create_text_query,
-    field2bool, field2date_opt, field2str, field2strvec,
+    create_boolean_query, create_date_query, create_float_query, create_i64_query, create_string_query_case,
+    create_text_query, field2bool, field2date_opt, field2str, field2strvec,
     metadata::doc2metadata,
     sort_by,
     tantivy::{
@@ -62,7 +62,7 @@ impl Index {
         let mut schema = Schema::builder();
 
         let fields = Fields {
-            indexed_timestamp: schema.add_date_field("indexed_timestamp", INDEXED | FAST | STORED),
+            indexed_timestamp: schema.add_i64_field("indexed_timestamp", INDEXED | FAST | STORED),
             id: schema.add_text_field("id", STRING | FAST | STORED),
             published: schema.add_bool_field("published", FAST | INDEXED | STORED),
 
@@ -87,10 +87,10 @@ impl Index {
     fn index_common(&self, document: &mut Document, metadata: &common::Metadata, _container: &common::CnaContainer) {
         document.add_text(self.fields.id, &metadata.id);
 
-        document.add_date(
-            self.fields.indexed_timestamp,
-            DateTime::from_utc(OffsetDateTime::now_utc()),
-        );
+        let now = OffsetDateTime::now_utc();
+        let nanos_since_epoch = now.unix_timestamp_nanos();
+        let nanos_since_epoch_i64 = nanos_since_epoch as i64;
+        document.add_i64(self.fields.indexed_timestamp, nanos_since_epoch_i64);
 
         Self::add_timestamp(document, self.fields.date_reserved, metadata.date_reserved);
         Self::add_timestamp(document, self.fields.date_published, metadata.date_published);
@@ -204,7 +204,7 @@ impl Index {
                 Occur::Should,
                 Term::from_field_text(self.fields.severity, Severity::Critical.as_str()),
             ),
-            Cves::IndexedTimestamp(value) => create_date_query(&self.schema, self.fields.indexed_timestamp, value),
+            Cves::IndexedTimestamp(value) => create_i64_query(&self.schema, self.fields.indexed_timestamp, value),
         }
     }
 
@@ -323,11 +323,10 @@ impl trustification_index::Index for Index {
         let indexed_timestamp = doc
             .get_first(self.fields.indexed_timestamp)
             .map(|s| {
-                s.as_date()
-                    .map(|d| d.into_utc())
-                    .unwrap_or(time::OffsetDateTime::UNIX_EPOCH)
+                s.as_i64()
+                    .unwrap_or(time::OffsetDateTime::UNIX_EPOCH.unix_timestamp_nanos() as i64)
             })
-            .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
+            .unwrap_or(time::OffsetDateTime::UNIX_EPOCH.unix_timestamp_nanos() as i64);
 
         let document = SearchDocument {
             id: id.to_string(),

--- a/v11y/index/src/lib.rs
+++ b/v11y/index/src/lib.rs
@@ -406,7 +406,11 @@ mod test {
     use std::path::Path;
     use trustification_index::{IndexStore, IndexWriter};
 
-    const TESTDATA: &[&str] = &["../testdata/CVE-2023-44487.json"];
+    const TESTDATA: &[&str] = &[
+        "../testdata/CVE-2023-44487.json",
+        "../testdata/CVE-2017-13052.json",
+        "../testdata/CVE-2023-33201.json",
+    ];
 
     fn load_valid_file(store: &mut IndexStore<Index>, writer: &mut IndexWriter, path: impl AsRef<Path>) {
         let data = std::fs::read(&path).unwrap();
@@ -451,6 +455,20 @@ mod test {
                 },
             )
             .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_search_sort_by_indexed_timestamp() {
+        assert_search(|index| {
+            let (last_update_docs, _size) = search(&index, "-sort:indexedTimestamp");
+            for doc in &last_update_docs {
+                println!(
+                    "name: {:?}  indexed_timestamp: {:?} created : {:?}",
+                    doc.document.id, doc.document.indexed_timestamp, doc.document.date_published
+                );
+            }
+            assert_eq!("CVE-2023-33201", &last_update_docs[0].document.id);
+        });
     }
 
     #[tokio::test]

--- a/v11y/model/src/search.rs
+++ b/v11y/model/src/search.rs
@@ -26,7 +26,7 @@ pub enum Cves<'a> {
     #[search(sort)]
     DateRejected(Ordered<OffsetDateTime>),
     #[search(sort)]
-    IndexedTimestamp(Ordered<time::OffsetDateTime>),
+    IndexedTimestamp(Ordered<i64>),
 
     Severity(&'a str),
     Low,
@@ -46,7 +46,7 @@ pub struct SearchDocument {
     pub published: bool,
     pub title: Option<String>,
     pub descriptions: Vec<String>,
-    pub indexed_timestamp: OffsetDateTime,
+    pub indexed_timestamp: i64,
     pub cvss3x_score: Option<f64>,
 
     #[serde(with = "time::serde::rfc3339::option")]

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -325,7 +325,7 @@ async fn vex_status(
             last_updated_vex_id: Some(vex.document.advisory_id.to_string()),
             last_updated_vex_name: Some(vex.document.advisory_title.to_string()),
             last_updated_date: Some(
-                OffsetDateTime::from_unix_timestamp(vex.document.indexed_timestamp)
+                OffsetDateTime::from_unix_timestamp_nanos(vex.document.indexed_timestamp as i128)
                     .unwrap_or(OffsetDateTime::UNIX_EPOCH),
             ),
         }))

--- a/vexination/api/src/server.rs
+++ b/vexination/api/src/server.rs
@@ -14,6 +14,7 @@ use trustification_auth::{
     swagger_ui::{swagger_ui_with_auth, SwaggerUiOidc},
     Permission,
 };
+use trustification_index::tantivy::time::OffsetDateTime;
 use trustification_index::Error as IndexError;
 use trustification_infrastructure::new_auth;
 use trustification_storage::{Error as StorageError, Key, S3Path, Storage};
@@ -323,7 +324,10 @@ async fn vex_status(
             total: Some(total_docs),
             last_updated_vex_id: Some(vex.document.advisory_id.to_string()),
             last_updated_vex_name: Some(vex.document.advisory_title.to_string()),
-            last_updated_date: Some(vex.document.indexed_timestamp),
+            last_updated_date: Some(
+                OffsetDateTime::from_unix_timestamp(vex.document.indexed_timestamp)
+                    .unwrap_or(OffsetDateTime::UNIX_EPOCH),
+            ),
         }))
     } else {
         Ok(HttpResponse::Ok().json(StatusResult::default()))

--- a/vexination/model/src/search.rs
+++ b/vexination/model/src/search.rs
@@ -36,7 +36,7 @@ pub enum Vulnerabilities<'a> {
     #[search]
     CveDiscovery(Ordered<time::OffsetDateTime>),
     #[search(sort)]
-    IndexedTimestamp(Ordered<time::OffsetDateTime>),
+    IndexedTimestamp(Ordered<i64>),
     Final,
     Critical,
     High,
@@ -67,7 +67,7 @@ pub struct SearchDocument {
     /// Number of severities by level
     pub cve_severity_count: HashMap<String, u64>,
     /// Time stamp for doc
-    pub indexed_timestamp: OffsetDateTime,
+    pub indexed_timestamp: i64,
 }
 
 /// The hit describes the document, its score and optionally an explanation of why that score was given.


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1668

This issue is caused by Tantivy's insufficient time precision when handling dates.

1 How to reproduce it.
  you can run unit test on [here](This test aims to prove that sorting can be done using indexed_timestamp. )(https://github.com/trustification/trustification/blob/main/bombastic/index/src/sbom/mod.rs#L755)
and got result 
`

> name: "kmm-1"  indexed_timestamp: 2024-09-23 6:39:09.070292 +00:00:00 created : 2023-06-26 11:24:00.0 +00:00:00
> name: "ubi9-sbom"  indexed_timestamp: 2024-09-23 6:39:09.162848 +00:00:00 created : 2023-03-30 13:59:00.0 +00:00:00
> name: "my-sbom"  indexed_timestamp: 2024-09-23 6:39:09.108631 +00:00:00 created : 2023-02-14 10:46:37.0 +00:00:00

`
but the order is not right. ubi9-sbom.json is last updated.

2 The reason after analysis
   IMO，Tantivy's insufficient time precision. You can find related in Tantivy's source.
`

> pub(crate) fn format_date(val: i64) -> crate::Result<String> {
>     let datetime = OffsetDateTime::from_unix_timestamp_nanos(val as i128).map_err(|err| {
>         TantivyError::InvalidArgument(format!(
>             "Could not convert {val:?} to OffsetDateTime, err {err:?}"
>         ))
>     })?;
>     let key_as_string = datetime
>         .format(&Rfc3339)
>         .map_err(|_err| TantivyError::InvalidArgument("Could not serialize date".to_string()))?;
>     Ok(key_as_string)
> }

`


[https://github.com/quickwit-oss/tantivy/blob/0.21.1/src/aggregation/bucket/range.rs#L413](url)

3 My PR want to fix it, and the result in here.
`

> name: "ubi9-sbom"  indexed_timestamp: 1727074795238658000 created : 2023-03-30 13:59:00.0 +00:00:00
> name: "my-sbom"  indexed_timestamp: 1727074795186721000 created : 2023-02-14 10:46:37.0 +00:00:00
> name: "kmm-1"  indexed_timestamp: 1727074795145148000 created : 2023-06-26 11:24:00.0 +00:00:00

`

