### PR TITLE
TC-1815 SBOM details page: enhance 'Info' tab formatting

### DIFF
--- a/spog/ui/crates/components/src/spdx/mod.rs
+++ b/spog/ui/crates/components/src/spdx/mod.rs
@@ -101,23 +101,15 @@ pub fn spdx_main(bom: &SPDX) -> Html {
                 },
                 None => vec![
                     html!(
-                            <CardBody>
-                                <DescriptionList>
-                                    <DescriptionGroup term="ID">{ desc.clone() }</DescriptionGroup>
-                                </DescriptionList>
-                            </CardBody>
-
-                    ),
-                    html!(
-                        <CardBody>
-                            { "ID could not be found in document" }
-                        </CardBody>
-                    ),
+                        <DescriptionList>
+                            <DescriptionGroup term="ID">{ desc.clone() }</DescriptionGroup>
+                        </DescriptionList>
+                    )
                 ],
             };
 
             html!(
-                <Card full_height=true>
+                <Card>
                     <CardTitle><Title size={Size::XLarge}>{ "Package" }</Title></CardTitle>
                     {
                         for content.into_iter()


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1815

As reported in the related Jira issue, currently the "Info" tab in the SBOM details page could "waste" a lot of space just like in the next screenshot.

![Screenshot from 2024-10-09 17-10-26](https://github.com/user-attachments/assets/a62972f8-36c9-4f90-804f-fef815cd6612)

With the changes, the "Package" box looks like this (with the "Package" box properly ending before the end of the page)

![Screenshot from 2024-10-10 09-02-41](https://github.com/user-attachments/assets/cf6e70b8-efb9-4ff1-8937-325c8d4e14c0)

