### PR TITLE
TC-1818 Collector OSV: fix 'CVE' prefixed vulnerabilities management

### DIFF
--- a/collector/osv/src/server.rs
+++ b/collector/osv/src/server.rs
@@ -132,6 +132,7 @@ pub async fn collect_packages(
                         let mut vulnerability_input_specs = Vec::new();
                         let mut alias_vuln_input_specs = Vec::new();
                         let mut cvss_v3s = Vec::new();
+                        let mut alias_required = false;
                         // If available ingest a vulnerability using its CVE-ID as the unique key
                         // adopted everywhere in trustification.
                         // To retrieve a vulnerability's CVE-ID, OSV must be called again
@@ -149,6 +150,7 @@ pub async fn collect_packages(
                                                             vulnerability_id: alias.clone(),
                                                         },
                                                     ));
+                                                    alias_required = true;
                                                 } else {
                                                     alias_vuln_input_specs.push(IDorVulnerabilityInput::from(
                                                         &VulnerabilityInputSpec {
@@ -188,6 +190,11 @@ pub async fn collect_packages(
                                     collected_osv_errors.push(err);
                                 }
                             }
+                        } else {
+                            vulnerability_input_specs.push(IDorVulnerabilityInput::from(&VulnerabilityInputSpec {
+                                r#type: "osv".to_string(),
+                                vulnerability_id: vuln.id.clone(),
+                            }));
                         }
                         // After https://issues.redhat.com/browse/TC-1582, it's not worth adding it
                         // if no CVE ID has been found because trustification isn't able to manage
@@ -204,7 +211,7 @@ pub async fn collect_packages(
                                                     })
                                                 } else {
                         */
-                        if !vulnerability_input_specs.is_empty() {
+                        if alias_required {
                             // otherwise the original vulnerability must be part of the aliases
                             alias_vuln_input_specs.push(IDorVulnerabilityInput::from(&VulnerabilityInputSpec {
                                 r#type: "osv".to_string(),

--- a/collectorist/api/src/coordinator/collector.rs
+++ b/collectorist/api/src/coordinator/collector.rs
@@ -64,7 +64,7 @@ impl Collector {
         match response {
             Ok(response) => {
                 for purl in response.purls.keys() {
-                    log::info!("[{id}] scanned {} {:?}", purl, response.purls.values());
+                    log::info!("[{id}] scanned {} {:?}", purl, response.purls.get(purl));
                     let _ = state.db.insert_purl(purl).await.ok();
                     let _ = state.db.update_purl_scan_time(&id, purl).await.ok();
                 }


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1818

Basically the fix address the happy path when OSV returns vulnerabilties referring already to their CVE ID, in which case there's no need any further call to OSV itself to retrieve the aliases and to then ingest "vulnEqual" entities into Guac.

As a "bonus" fix, during the development I've figured out that a collectorist API log entry reports for each single PURL all the vulnerabilities found for all the PURLs in the same request instead of just logging the vulnerabilities related to that specific PURL so I've fixed it to ease future investigations.
For example, previously it was

`
[osv] scanned pkg:deb/debian/tar@1.34+dfsg-1.2?arch=amd64&distro=debian-12 [["CVE-2023-24329", "CVE-2023-27043", "CVE-2023-40217", "CVE-2023-41105", "CVE-2023-6597", "CVE-2024-0397", "CVE-2024-0450", "CVE-2024-4032", "CVE-2024-6232", "CVE-2024-6923", "CVE-2024-7592", "CVE-2024-8088", "DSA-5759-1"], ["CVE-2005-2541", "CVE-2022-48303", "CVE-2023-39804"]]
`

and now it logs only the 3 vulnerabilities (i.e. `CVE-2005-2541, CVE-2022-48303, CVE-2023-39804`) affecting that package

`
 [osv] scanned pkg:deb/debian/tar@1.34+dfsg-1.2?arch=amd64&distro=debian-12 Some(["CVE-2005-2541", "CVE-2022-48303", "CVE-2023-39804"])
 `