### PR TITLE
[TC-1839] - Change TPA home page

### DIFF
--- a/spog/ui/src/pages/index.rs
+++ b/spog/ui/src/pages/index.rs
@@ -90,7 +90,7 @@ pub fn index() -> Html {
                                     <input type="submit" hidden=true formmethod="dialog" />
 
                                     <Grid gutter=true>
-                                        <GridItem offset={[4]} cols={[4]}>
+                                        <GridItem cols={[4]}>
                                             <SearchInput {onchange} autofocus=true />
                                         </GridItem>
 

--- a/spog/ui/src/pages/search/search_input.rs
+++ b/spog/ui/src/pages/search/search_input.rs
@@ -234,7 +234,7 @@ pub fn search_input(props: &SearchProperties) -> Html {
             <patternfly_yew::prelude::SearchInput
                 id={ID_SEARCH_ELEMENT}
                 inner_ref={input_ref.clone()}
-                placeholder="Search for an SBOM, advisory, or CVE"
+                placeholder="Search for an SBOM, VEX, or CVE"
                 value={(**value).clone()}
                 {onchange}
                 {onclear}


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1839

The image below is how it should look like.

![image](https://github.com/user-attachments/assets/2fdd62a6-87dd-40c9-abb2-c804671f302d)

This PR only:
- Aligns the Search input text to the left
- Make the Input Search placeholder to match the mockups

All the other changes should be done in the Helm Chart Definition