### PR TITLE
TC-1842 CycloneDX CPE management

### DIFF
--- a/bombastic/index/src/sbom/mod.rs
+++ b/bombastic/index/src/sbom/mod.rs
@@ -334,6 +334,10 @@ impl Index {
             });
         }
 
+        if let Some(cpe) = &component.cpe {
+            document.add_text(fields.cpe, cpe);
+        };
+
         document.add_text(fields.classifier, component.component_type.to_string());
     }
 
@@ -791,7 +795,15 @@ mod tests {
             let result = search(&index, "ubi9-containe in:package");
             assert_eq!(result.0.len(), 1);
 
+            // SPDX CPE
             let result = search(&index, "\"cpe:/a:redhat:kernel_module_management:1.0::el9\" in:package");
+            assert_eq!(result.0.len(), 1);
+
+            // CycloneDX CPE
+            let result = search(
+                &index,
+                "\"cpe:/o:io.seedwing:seedwing-java-example:1.0.0-SNAPSHOT::\" in:package",
+            );
             assert_eq!(result.0.len(), 1);
         });
     }

--- a/bombastic/testdata/my-sbom.json
+++ b/bombastic/testdata/my-sbom.json
@@ -53,7 +53,8 @@
       "licenses" : [ ],
       "purl" : "pkg:maven/io.seedwing/seedwing-java-example@1.0.0-SNAPSHOT?type=jar",
       "type" : "library",
-      "bom-ref" : "pkg:maven/io.seedwing/seedwing-java-example@1.0.0-SNAPSHOT?type=jar"
+      "bom-ref" : "pkg:maven/io.seedwing/seedwing-java-example@1.0.0-SNAPSHOT?type=jar",
+      "cpe": "cpe:/o:io.seedwing:seedwing-java-example:1.0.0-SNAPSHOT::"
     }
   },
   "components" : [
@@ -7297,3 +7298,4 @@
     }
   ]
 }
+

--- a/spog/ui/src/pages/sbom/mod.rs
+++ b/spog/ui/src/pages/sbom/mod.rs
@@ -258,6 +258,11 @@ fn details(props: &DetailsProps) -> Html {
                                     </GridItem>
                                 </Grid>
                             </StackItem>
+                            <StackItem>
+                                <Grid gutter=true>
+                                    <GridItem cols={[12]}>{cyclonedx_main(bom)}</GridItem>
+                                </Grid>
+                            </StackItem>
                         </Stack>
                     </PageSection>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1842

Consistently with what already implemented for SPDX SBOM details page, I've added the `Package` card also to the CycloneDX SBOM details page in order to report the CPE information (together with all the other external references).

The final result is something like this:
![Screenshot from 2024-10-30 12-44-14](https://github.com/user-attachments/assets/2f208618-8251-4df2-8a8b-338633f1ccb6)


Furthermore, for consistency, I've added the `cpe` field also to the index (with test) when indexing a CycloneDX SBOM just like it already happens for the SPDX SBOM in https://github.com/trustification/trustification/blob/18910f498096e07ca22ca6591aa612ca014fbb91/bombastic/index/src/sbom/mod.rs#L185