### PR TITLE
[release/1.2.z] TC-1819: reverse search order to find last 10 sboms ingested (#1841)

### DIFF
--- a/spog/api/src/endpoints/sbom/search.rs
+++ b/spog/api/src/endpoints/sbom/search.rs
@@ -109,7 +109,7 @@ pub async fn sboms_with_vulnerability_summary(
 ) -> actix_web::Result<HttpResponse> {
     let ten_latest_sboms = state
         .search_sbom(
-            "sort:indexedTimestamp",
+            "-sort:indexedTimestamp",
             0,
             10,
             SearchOptions {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/1.2.z`:
 - [TC-1819: reverse search order to find last 10 sboms ingested (#1841)](https://github.com/trustification/trustification/pull/1841)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)