### PR TITLE
Fix: update an indentation of container in v11y-walker

### DIFF
--- a/deploy/k8s/charts/trustification/templates/services/v11y/walker/030-CronJob.yaml
+++ b/deploy/k8s/charts/trustification/templates/services/v11y/walker/030-CronJob.yaml
@@ -55,7 +55,7 @@ spec:
             - name: walker
               {{- include "trustification.common.defaultImage" $mod | nindent 14 }}
               {{- include "trustification.application.infrastructure.probes" $mod | nindent 14 }}
-              {{- include "trustification.application.container" $mod | nindent 10 }}
+              {{- include "trustification.application.container" $mod | nindent 14 }}
 
               volumeMounts:
                 - mountPath: /mnt


### PR DESCRIPTION
The container macro used a wrong indentation and was placed in a wrong spot.

Backports:

- #1936 