### PR TITLE
TC-1865 Fix multiple prefixes management

### DIFF
--- a/v11y/walker/src/lib.rs
+++ b/v11y/walker/src/lib.rs
@@ -108,10 +108,16 @@ impl Run {
                             continue;
                         }
 
+                        let mut name_matches_prefix = false;
                         for prefix in &self.require_prefix {
-                            if !name.starts_with(prefix) {
-                                continue 'entry;
+                            if name.starts_with(prefix) {
+                                name_matches_prefix = true;
+                                continue;
                             }
+                        }
+                        match name_matches_prefix {
+                            true => (),
+                            false => continue 'entry,
                         }
 
                         if let Some(key) = name.strip_suffix(".json") {


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1865

There was an issue: when more prefixes were provided, e.g. `CVE-2023-` and `CVE-2024-`, when a file to be analyzed was evaluated, e.g. `CVE-2023-1234.json`, it would match with the first prefix, i.e. `CVE-2023-`, the condition `if !name.starts_with(prefix)` would have been `false`, meaning to not skip that file and analyze it, but with the next iteration of the `for` loop, with the `CVE-2024-` prefix, the  condition `if !name.starts_with(prefix)` would have been `true` and the `continue 'entry;` statement then executed which would make the  `CVE-2023-1234.json` to be skipped which is the bug.