### PR TITLE
[release/1.2.z] use cyclonedx-bom v0.8.0, and recode to use updated validation within it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,7 +1207,7 @@ name = "bombastic-index"
 version = "0.1.0"
 dependencies = [
  "bombastic-model",
- "cyclonedx-bom",
+ "cyclonedx-bom 0.8.0",
  "env_logger 0.10.2",
  "log",
  "packageurl 0.4.0",
@@ -1243,7 +1243,7 @@ dependencies = [
 name = "bombastic-model"
 version = "0.1.0"
 dependencies = [
- "cyclonedx-bom",
+ "cyclonedx-bom 0.8.0",
  "log",
  "serde",
  "serde_json",
@@ -2050,6 +2050,30 @@ name = "cyclonedx-bom"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4bc2b1186cf894ec0192863b5d6e6164de1a39ab66d2a281a4157b4ea45138"
+dependencies = [
+ "base64 0.21.7",
+ "cyclonedx-bom-macros",
+ "fluent-uri 0.1.4",
+ "indexmap 2.2.6",
+ "once_cell",
+ "ordered-float 4.2.0",
+ "purl",
+ "regex",
+ "serde",
+ "serde_json",
+ "spdx",
+ "strum 0.26.2",
+ "thiserror",
+ "time",
+ "uuid",
+ "xml-rs",
+]
+
+[[package]]
+name = "cyclonedx-bom"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2ec98a191e17f63b92b132f6852462de9eaee03ca8dbf2df401b9fd809bcac"
 dependencies = [
  "base64 0.21.7",
  "cyclonedx-bom-macros",
@@ -5795,7 +5819,7 @@ dependencies = [
  "bytes",
  "chrono",
  "csv",
- "cyclonedx-bom",
+ "cyclonedx-bom 0.7.0",
  "digest",
  "filetime",
  "fluent-uri 0.2.0",

--- a/bombastic/index/Cargo.toml
+++ b/bombastic/index/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bombastic-model = { path = "../model" }
-cyclonedx-bom = "0.7.0"
+cyclonedx-bom = "0.8.0"
 log = "0.4"
 packageurl = "0.4"
 serde_json = "1.0.68"

--- a/bombastic/model/Cargo.toml
+++ b/bombastic/model/Cargo.toml
@@ -18,7 +18,7 @@ utoipa = { version = "4" }
 serde_json = "1"
 urlencoding = "2"
 
-cyclonedx-bom = { version = "0.7.0", optional =  true }
+cyclonedx-bom = { version = "0.8.0", optional =  true }
 spdx-rs = { version = "0.5.5", optional = true }
 
 [features]

--- a/bombastic/model/src/data.rs
+++ b/bombastic/model/src/data.rs
@@ -1,11 +1,8 @@
-use serde_json::Value;
+use cyclonedx_bom::errors::JsonReadError;
+use cyclonedx_bom::prelude::{Validate, ValidationResult};
+use cyclonedx_bom::validation::ValidationErrorsKind;
 use std::collections::HashSet;
 use std::fmt::Formatter;
-use std::str::FromStr;
-
-use cyclonedx_bom::errors::JsonReadError;
-use cyclonedx_bom::prelude::{SpecVersion, Validate, ValidationResult};
-use cyclonedx_bom::validation::ValidationErrorsKind;
 use tracing::{info_span, instrument};
 
 #[derive(Debug)]
@@ -80,8 +77,7 @@ impl SBOM {
                     // the serial number is missing and this isn't what we want because
                     // serial number is mandatory for trustification to correlate properly
                     Some(_) => {
-                        let spec_version = Self::get_cyclonedx_spec_version(data)?;
-                        let result = bom.validate_version(spec_version);
+                        let result = bom.validate();
                         match result.passed() {
                             true => return Ok(SBOM::CycloneDX(bom)),
                             false => {
@@ -119,33 +115,6 @@ impl SBOM {
             }
         }
 
-        Err(err)
-    }
-
-    fn get_cyclonedx_spec_version(data: &[u8]) -> Result<SpecVersion, Error> {
-        let mut err: Error = Default::default();
-        let spec_version_error: serde_json::Error = serde::de::Error::custom("No field 'specVersion' found");
-        let error = Some(JsonReadError::from(spec_version_error));
-        //workaround to deal with cyclonedx-rust-cargo validate() method
-        //validating against SpecVersion::V1_3, the default, in all cases
-        //we therefore have to discover the spec version from the json data
-        //to pass into validate_version() as the parsed bom doesn't contain this info
-        // let mut spec_version = SpecVersion::V1_3;
-        match serde_json::from_slice::<Value>(data) {
-            Ok(parsed_json) => match parsed_json.get("specVersion") {
-                Some(version) => match version.as_str() {
-                    Some(version) => match SpecVersion::from_str(version) {
-                        Ok(spec_version) => return Ok(spec_version),
-                        Err(e) => err.cyclonedx = Some(JsonReadError::from(e)),
-                    },
-                    None => err.cyclonedx = error,
-                },
-                None => {
-                    err.cyclonedx = error;
-                }
-            },
-            Err(e) => err.cyclonedx = Some(JsonReadError::from(e)),
-        }
         Err(err)
     }
 

--- a/spog/ui/Cargo.lock
+++ b/spog/ui/Cargo.lock
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "cyclonedx-bom"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4bc2b1186cf894ec0192863b5d6e6164de1a39ab66d2a281a4157b4ea45138"
+checksum = "ce2ec98a191e17f63b92b132f6852462de9eaee03ca8dbf2df401b9fd809bcac"
 dependencies = [
  "base64 0.21.7",
  "cyclonedx-bom-macros",

--- a/spog/ui/Cargo.toml
+++ b/spog/ui/Cargo.toml
@@ -16,7 +16,7 @@ convert_case = "0.6.0"
 csaf = { version = "0.5.0", default-features = false }
 cve = "0.3.1"
 cvss = { version = "2", features = ["serde"] }
-cyclonedx-bom = "0.7"
+cyclonedx-bom = "0.8.0"
 futures = "0.3.29"
 gloo-events = "0.2"
 gloo-net = "0.5"

--- a/spog/ui/crates/backend/Cargo.toml
+++ b/spog/ui/crates/backend/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["wasmbind"] }
 csaf = { version = "0.5.0", default-features = false }
 cve = "0.3.1"
-cyclonedx-bom = "0.7"
+cyclonedx-bom = "0.8.0"
 gloo-events = "0.2"
 gloo-net = "0.5.0"
 gloo-storage = "0.3.0"

--- a/spog/ui/crates/components/Cargo.toml
+++ b/spog/ui/crates/components/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["wasmbind"] }
 csaf = { version = "0.5.0", default-features = false }
 cvss = { version = "2", features = ["serde"] }
-cyclonedx-bom = "0.7"
+cyclonedx-bom = "0.8.0"
 gloo-events = "0.2"
 gloo-net = "0.5.0"
 gloo-storage = "0.3.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/1.2.z`:
 - [use cyclonedx-bom v0.8.0, and recode to use updated validation within it](https://github.com/trustification/trustification/pull/1990)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)