### PR TITLE
Increase a livenessProbe delay

### DIFF
--- a/deploy/k8s/charts/trustification/templates/helpers/_infrastructure.tpl
+++ b/deploy/k8s/charts/trustification/templates/helpers/_infrastructure.tpl
@@ -58,7 +58,7 @@ Arguments (dict):
 */}}
 {{ define "trustification.application.infrastructure.probes" }}
 livenessProbe:
-  initialDelaySeconds: 2
+  initialDelaySeconds: 30
   httpGet:
     path: /health/live
     port: {{ include "trustification.application.infrastructure.port" . }}


### PR DESCRIPTION
The short initial delay is cause a problem for pods that require an access to the index. The 2 seconds isn't enough for bombastic-api to properly start. Increasing it to 30 should give an app enough time.

Having a low values here causes the K8s kills a pod before it can start properly.

JIRA: ISV-1880