### PR TITLE
TC-1865: Prevent all cve files being ignored without prefix input

### DIFF
--- a/v11y/walker/src/lib.rs
+++ b/v11y/walker/src/lib.rs
@@ -107,8 +107,8 @@ impl Run {
                         if !name.starts_with("CVE-") {
                             continue;
                         }
-
-                        let mut name_matches_prefix = false;
+                        //this is done to stop this section from ignoring files when there's no prefix
+                        let mut name_matches_prefix = self.require_prefix.is_empty();
                         for prefix in &self.require_prefix {
                             if name.starts_with(prefix) {
                                 name_matches_prefix = true;


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1865

the v11y walker was ignoring all CVE files in a source folder if no prefix parameter was supplied
