### PR TITLE
TC-1970 Dashboard: enhance vulnerabilities retrieval

### DIFF
--- a/spog/ui/crates/backend/src/sbom.rs
+++ b/spog/ui/crates/backend/src/sbom.rs
@@ -74,9 +74,9 @@ impl SBOMService {
         Ok(response.api_error_for_status().await?.json().await?)
     }
 
-    pub async fn get_sbom_vulns(&self, id: impl AsRef<str>) -> Result<Option<SbomReport>, ApiError> {
+    pub async fn get_sbom_vulns(&self, id: impl AsRef<str>, retrieve_remediation: bool) -> Result<Option<SbomReport>, ApiError> {
         let mut url = self.backend.join(Endpoint::Api, "/api/v1/sbom/vulnerabilities")?;
-        url.query_pairs_mut().append_pair("id", id.as_ref()).finish();
+        url.query_pairs_mut().append_pair("id", id.as_ref()).append_pair("retrieve_remediation", retrieve_remediation.to_string().as_ref()).finish();
 
         let response = self
             .client

--- a/spog/ui/src/pages/index.rs
+++ b/spog/ui/src/pages/index.rs
@@ -603,7 +603,7 @@ pub fn sbom_donut_chart(props: &SbomDonutChartProperties) -> Html {
     let vulnerabilities = use_async_with_cloned_deps(
         |(id, backend)| async move {
             spog_ui_backend::SBOMService::new(backend.clone(), access_token)
-                .get_sbom_vulns(id)
+                .get_sbom_vulns(id, false)
                 .await
                 .map(|r| r.map(Rc::new))
         },

--- a/spog/ui/src/pages/sbom_report/mod.rs
+++ b/spog/ui/src/pages/sbom_report/mod.rs
@@ -44,7 +44,7 @@ pub fn sbom(props: &SbomReportProperties) -> Html {
     let info = use_async_with_cloned_deps(
         |(id, backend)| async move {
             spog_ui_backend::SBOMService::new(backend.clone(), access_token)
-                .get_sbom_vulns(id)
+                .get_sbom_vulns(id, true)
                 .await
                 .map(|r| r.map(Rc::new))
         },


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1970

`/api/v1/sbom/latestwithvulns`
- retrieval of vulnerabilities concurrently (instead of current serial approach) for the 10 SBOMs in scope for the Dashboard bars chart
- dropped `process_get_vulnerabilities` usage (i.e. avoid downloading each SBOM and each CVE JSON each time from S3-compatible storage) in favor of using search indexes
- retrieved CVE info from `v11y.search` in bulk of 25 CVEs

`/api/v1/sbom/vulnerabilities`
- added the `retrieve_remediation` param to the `get_vulnerabilities` endpoint used by the four donut charts in the dashboard in order to avoid loading the remediation because there are useless for those charts (but still required in the `Vulnerabilities` tab in the SBOM details page) and changed the UI components accordingly
- dropped `v11y.fetch_cve` (i.e. avoid downloading each CVE JSON each time from S3-compatible storage) in favor of `v11y.search` to leverage the search index to get data
- refactoring due to [`clippy::too-many-arguments`](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments)

Both the endpoints get a further improvement from enhanced Guac `find_vulnerability_by_uid`, ref. https://github.com/trustification/guac/pull/183