### PR TITLE
[TC-1978] task: remove dependency analytics

### DIFF
--- a/spog/ui/src/pages/sbom/mod.rs
+++ b/spog/ui/src/pages/sbom/mod.rs
@@ -234,9 +234,9 @@ fn details(props: &DetailsProps) -> Html {
                                     />
                                 </>
                             )}/>
-                            { for config.features.show_report.then(|| html_nested!(
-                                <Tab<TabIndex> index={TabIndex::Report} title="Dependency Analytics Report" />
-                            )) }
+                            // { for config.features.show_report.then(|| html_nested!(
+                            //     <Tab<TabIndex> index={TabIndex::Report} title="Dependency Analytics Report" />
+                            // )) }
                             { for config.features.show_source.then(|| html_nested!(
                                 <Tab<TabIndex> index={TabIndex::Source} title="Source" />
                             )) }

--- a/spog/ui/src/pages/sbom/mod.rs
+++ b/spog/ui/src/pages/sbom/mod.rs
@@ -167,9 +167,9 @@ fn details(props: &DetailsProps) -> Html {
                                     />
                                 </>
                             )}/>
-                            { for config.features.show_report.then(|| html_nested!(
-                                <Tab<TabIndex> index={TabIndex::Report} title="Dependency Analytics Report" />
-                            )) }
+                            // { for config.features.show_report.then(|| html_nested!(
+                            //     <Tab<TabIndex> index={TabIndex::Report} title="Dependency Analytics Report" />
+                            // )) }
                             { for config.features.show_source.then(|| html_nested!(
                                 <Tab<TabIndex> index={TabIndex::Source} title="Source" />
                             )) }

--- a/spog/ui/src/pages/scanner/mod.rs
+++ b/spog/ui/src/pages/scanner/mod.rs
@@ -105,9 +105,9 @@ pub fn validate(data: &[u8]) -> Result<SBOM, anyhow::Error> {
             });
 
             match supported_packages {
-                Some(false) => bail!(
-                    "The SBOM contains package type(s) not supported by Dependency Analytics. The Dependency Analytics report may be unavailable for this SBOM."
-                ),
+                Some(false) => {
+                    // bail!("The SBOM contains package type(s) not supported by Dependency Analytics. The Dependency Analytics report may be unavailable for this SBOM.")
+                }
                 _ => {}
             }
         }
@@ -130,9 +130,9 @@ pub fn validate(data: &[u8]) -> Result<SBOM, anyhow::Error> {
 
             match supported_packages {
                 Some(true) => {}
-                _ => bail!(
-                    "The SBOM contains package type(s) not supported by Dependency Analytics. The Dependency Analytics report may be unavailable for this SBOM."
-                ),
+                _ => {
+                    // bail!("The SBOM contains package type(s) not supported by Dependency Analytics. The Dependency Analytics report may be unavailable for this SBOM.")
+                }
             }
         }
     }

--- a/spog/ui/src/pages/scanner/mod.rs
+++ b/spog/ui/src/pages/scanner/mod.rs
@@ -6,7 +6,6 @@ use analytics_next::TrackingEvent;
 use anyhow::bail;
 use bombastic_model::prelude::SBOM;
 use inspect::Inspect;
-use packageurl::PackageUrl;
 use patternfly_yew::prelude::*;
 use serde_json::{json, Value};
 use spog_ui_utils::{
@@ -15,7 +14,7 @@ use spog_ui_utils::{
     hints::{Hint as HintView, Hints},
     tracking_event,
 };
-use std::{rc::Rc, str::FromStr};
+use std::rc::Rc;
 use upload::Upload;
 use yew::prelude::*;
 use yew_more_hooks::prelude::*;

--- a/spog/ui/src/pages/scanner/mod.rs
+++ b/spog/ui/src/pages/scanner/mod.rs
@@ -42,18 +42,18 @@ impl<'a> From<ParseOutcome<'a>> for TrackingEvent<'static> {
     }
 }
 
-fn is_supported_package(purl: &str) -> bool {
-    match PackageUrl::from_str(purl) {
-        Ok(package) => {
-            package.ty() == "maven"
-                || package.ty() == "gradle"
-                || package.ty() == "npm"
-                || package.ty() == "golang"
-                || package.ty() == "pypi"
-        }
-        Err(_) => false,
-    }
-}
+// fn is_supported_package(purl: &str) -> bool {
+//     match PackageUrl::from_str(purl) {
+//         Ok(package) => {
+//             package.ty() == "maven"
+//                 || package.ty() == "gradle"
+//                 || package.ty() == "npm"
+//                 || package.ty() == "golang"
+//                 || package.ty() == "pypi"
+//         }
+//         Err(_) => false,
+//     }
+// }
 
 pub fn parse_and_validate(data: &[u8]) -> Result<SBOM, anyhow::Error> {
     parse(data).and_then(|_| validate(data))
@@ -86,56 +86,56 @@ pub fn parse(data: &[u8]) -> Result<SBOM, anyhow::Error> {
 pub fn validate(data: &[u8]) -> Result<SBOM, anyhow::Error> {
     let sbom = SBOM::parse(data)?;
 
-    #[allow(clippy::single_match)]
-    match &sbom {
-        SBOM::CycloneDX(_bom) => {
-            // re-parse to check for the spec version
-            let json = serde_json::from_slice::<Value>(data).ok();
-
-            let supported_packages = json.as_ref().map(|json| {
-                if let Some(components) = json["components"].as_array() {
-                    let are_all_supported_packages = components
-                        .iter()
-                        .filter_map(|external_ref| external_ref["purl"].as_str())
-                        .all(is_supported_package);
-                    are_all_supported_packages
-                } else {
-                    false
-                }
-            });
-
-            match supported_packages {
-                Some(false) => {
-                    // bail!("The SBOM contains package type(s) not supported by Dependency Analytics. The Dependency Analytics report may be unavailable for this SBOM.")
-                }
-                _ => {}
-            }
-        }
-        SBOM::SPDX(_bom) => {
-            let json = serde_json::from_slice::<Value>(data).ok();
-
-            let supported_packages = json.as_ref().map(|json| {
-                if let Some(packages) = json["packages"].as_array() {
-                    let are_all_supported_packages = packages
-                        .iter()
-                        .filter_map(|package| package["externalRefs"].as_array())
-                        .flatten()
-                        .filter_map(|external_ref| external_ref["referenceLocator"].as_str())
-                        .all(is_supported_package);
-                    are_all_supported_packages
-                } else {
-                    false
-                }
-            });
-
-            match supported_packages {
-                Some(true) => {}
-                _ => {
-                    // bail!("The SBOM contains package type(s) not supported by Dependency Analytics. The Dependency Analytics report may be unavailable for this SBOM.")
-                }
-            }
-        }
-    }
+    // #[allow(clippy::single_match)]
+    // match &sbom {
+    //     SBOM::CycloneDX(_bom) => {
+    //         // re-parse to check for the spec version
+    //         let json = serde_json::from_slice::<Value>(data).ok();
+    //
+    //         let supported_packages = json.as_ref().map(|json| {
+    //             if let Some(components) = json["components"].as_array() {
+    //                 let are_all_supported_packages = components
+    //                     .iter()
+    //                     .filter_map(|external_ref| external_ref["purl"].as_str())
+    //                     .all(is_supported_package);
+    //                 are_all_supported_packages
+    //             } else {
+    //                 false
+    //             }
+    //         });
+    //
+    //         match supported_packages {
+    //             Some(false) => {
+    //                 bail!("The SBOM contains package type(s) not supported by Dependency Analytics. The Dependency Analytics report may be unavailable for this SBOM.")
+    //             }
+    //             _ => {}
+    //         }
+    //     }
+    //     SBOM::SPDX(_bom) => {
+    //         let json = serde_json::from_slice::<Value>(data).ok();
+    //
+    //         let supported_packages = json.as_ref().map(|json| {
+    //             if let Some(packages) = json["packages"].as_array() {
+    //                 let are_all_supported_packages = packages
+    //                     .iter()
+    //                     .filter_map(|package| package["externalRefs"].as_array())
+    //                     .flatten()
+    //                     .filter_map(|external_ref| external_ref["referenceLocator"].as_str())
+    //                     .all(is_supported_package);
+    //                 are_all_supported_packages
+    //             } else {
+    //                 false
+    //             }
+    //         });
+    //
+    //         match supported_packages {
+    //             Some(true) => {}
+    //             _ => {
+    //                 bail!("The SBOM contains package type(s) not supported by Dependency Analytics. The Dependency Analytics report may be unavailable for this SBOM.")
+    //             }
+    //         }
+    //     }
+    // }
 
     Ok(sbom)
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1978

- Remove the Tab "Dependency analytics Report" from the SBOM Page details
- Remove the Warning message when an SBOM is uploaded because the warning message refers to Dependency Analytics supported packages