### PR TITLE
[TC-1892] fix: hardcoded provided version on API

### DIFF
--- a/spog/ui/src/about.rs
+++ b/spog/ui/src/about.rs
@@ -66,7 +66,7 @@ fn version_info(props: &VersionInfoProperties) -> Html {
     html!(
         <dl>
             <dt>{ "Version" }</dt>
-            <dd>{ &props.version.version.full }</dd>
+            <dd>{ &props.version.version }</dd>
             if let Some(info) = &props.version.git.describe {
                 <dt>{ "Git" }</dt>
                 <dd>{ &info }</dd>

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -50,7 +50,7 @@ pub mod version;
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct VersionInformation {
     pub name: String,
-    pub version: Version,
+    pub version: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
 
@@ -95,16 +95,16 @@ pub struct Version {
 macro_rules! version {
     () => {
         $crate::VersionInformation {
-            version: $crate::Version {
-                full: env!("CARGO_PKG_VERSION").to_string(),
-                major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap_or_default(),
-                minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap_or_default(),
-                patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap_or_default(),
-                pre: option_env!("CARGO_PKG_VERSION_PRE")
-                    .filter(|s| !s.is_empty())
-                    .map(ToString::to_string),
-            },
-
+            version: String::from("main"),
+            // version: $crate::Version {
+            //     full: env!("CARGO_PKG_VERSION").to_string(),
+            //     major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap_or_default(),
+            //     minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap_or_default(),
+            //     patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap_or_default(),
+            //     pre: option_env!("CARGO_PKG_VERSION_PRE")
+            //         .filter(|s| !s.is_empty())
+            //         .map(ToString::to_string),
+            // },
             name: env!("CARGO_PKG_NAME").into(),
             description: env!("CARGO_PKG_DESCRIPTION").into(),
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-1892

Following the strategy of https://github.com/trustification/trustification/pull/2088 and https://github.com/trustification/trustification/pull/2089 this PR is hardcoding the version provided in the endpoint `.well-known/trustification/version` which currently always returns `0.1.0` ( this value is wrong)

After this changes the response of the endpoint should be similar to:
```json
{
    "name": "spog-api",
    "version": "main",
    "description": "An API server for trusted content",
    "git": {
        "describe": "v0.1.0-nightly.420e67b0-2681-g72d645d2-dirty",
        "commit": "72d645d2563dc3361a1decfe512ecc8e04d33153"
    },
    "build": {
        "timestamp": "2024-12-09T09:48:26.734823656Z"
    }
}
```

> The main branch will always have `version=main` and all the other branches should have that value changed

The main branch code, currently takes the version written in the Cargo.toml files and exposes it in the endpoint `.well-known/trustification/version` but since our pipelines, at the moment, lack the ability to update the Cargo.toml files for each release we do for RHTPA then the current version we are exposing is always wrong.

Although not ideal this PR should allow us to expose a correct version in RHTPA. The other option is to change our release pipelines and change the Cargo.toml files which I think it's not realistic at this point.