### PR TITLE
TC-2022 Fix OSV CVSS_V4 severity type ingestion

### DIFF
--- a/collector/osv/src/client/schema.rs
+++ b/collector/osv/src/client/schema.rs
@@ -299,6 +299,12 @@ pub enum SeverityType {
     #[serde(rename = "UNSPECIFIED")]
     Unspecified,
 
+    /// A CVSS vector string representing the unique characterictics and severity of the
+    /// vulnerability using a version on the Common Vulnerability Scoring System notation that is
+    /// >= 4.0 and < 5.0 (e.g. "CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N").
+    #[serde(rename = "CVSS_V4")]
+    CVSSv4,
+
     /// A CVSS vector string representing the unique characteristics and severity of the
     /// vulnerability using a version of the Common Vulnerability Scoring System notation that is
     /// >= 3.0 and < 4.0 (e.g.`"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N"`).

--- a/collector/osv/src/server.rs
+++ b/collector/osv/src/server.rs
@@ -174,9 +174,27 @@ pub async fn collect_packages(
 
                                     if let Some(severities) = &osv_vuln.severity {
                                         for severity in severities {
-                                            if matches!(severity.severity_type, SeverityType::CVSSv3) {
-                                                if let Ok(cvss) = cvss::v3::Base::from_str(&severity.score) {
-                                                    cvss_v3s.push(cvss);
+                                            match severity.severity_type {
+                                                SeverityType::CVSSv3 => {
+                                                    match cvss::v3::Base::from_str(&severity.score) {
+                                                        Ok(cvss) => {
+                                                            cvss_v3s.push(cvss);
+                                                        }
+                                                        Err(err) => {
+                                                            log::warn!(
+                                                                "Score {} has not been parsed due to {}",
+                                                                severity.score,
+                                                                err
+                                                            );
+                                                        }
+                                                    }
+                                                }
+                                                _ => {
+                                                    log::warn!(
+                                                        "Vulnerability {} has got an unmanaged severity type {:?}",
+                                                        osv_vuln.id,
+                                                        severity.severity_type
+                                                    );
                                                 }
                                             }
                                         }


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2022

- enhanced the schema to work with `CVSS_V4` value for severity type
- refactored the severity and score management:
  - `CVSSv3` management remains the same, i.e. `cvss_v3s.push(cvss);` but in case of error in getting the score then it's logged with a warn message
  - all other severity types got reported with a warning log