### PR TITLE
[WIP] Making git clone more robust

### DIFF
--- a/deploy/k8s/charts/trustification/templates/services/v11y/walker/030-CronJob.yaml
+++ b/deploy/k8s/charts/trustification/templates/services/v11y/walker/030-CronJob.yaml
@@ -42,15 +42,27 @@ spec:
               args:
                 - "-ec"
                 - |
-                  if test -d cvelistV5; then
-                    cd cvelistV5
-                    git stash
-                    git stash clear
-                    git pull
+                  echo "Check cvelistV5 directory is a valid Git repository" 
+                  if test -d "cvelistV5/.git" && git -C cvelistV5 rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+                    echo "Check cvelistV5 repository integrity"
+                    if git -C cvelistV5 fsck --full >/dev/null 2>&1; then
+                      echo "cvelistV5 repository is clean. Pulling latest changes"
+                      cd cvelistV5
+                      git stash
+                      git stash clear
+                      git pull
+                      exit 0
+                    else
+                      echo "cvelistV5 repository corrupted. Cleaning up"
+                      rm -rf cvelistV5/*
+                    fi
                   else
-                    git clone https://github.com/CVEProject/cvelistV5
+                    echo "Not a valid Git repository. Cleaning up..."
+                    rm -rf cvelistV5/*
                   fi
-
+                  
+                  echo "Cloning cvelistV5 repository"
+                  git clone https://github.com/CVEProject/cvelistV5 cvelistV5
           containers:
             - name: walker
               {{- include "trustification.common.defaultImage" $mod | nindent 14 }}


### PR DESCRIPTION
From https://issues.redhat.com/browse/TC-1979 we discovered that the cronjob pod failed for some reasons which left the git folder in a corrupted state on the PVC. 

Without trying to identify what could create such situation, I believe the initContainer job is to provide a valid cvelistV5 repo so the main job can run. So we can make the command more robust this way. 