### PR TITLE
Updating tofu script PSQL version to 16.3

### DIFF
--- a/docs/modules/admin/examples/trustification/database.tf
+++ b/docs/modules/admin/examples/trustification/database.tf
@@ -114,7 +114,7 @@ resource "aws_db_instance" "guac" {
 
   db_name             = "postgres"
   engine              = "postgres"
-  engine_version      = "15.5"
+  engine_version      = "16.3"
   instance_class      = "db.m7g.large"
   username            = var.db-master-user
   password            = random_password.guac-db-admin-password.result


### PR DESCRIPTION
As tofu script failed for psql version 15.5, updating the version to 16.3 referring to AWS
![image](https://github.com/user-attachments/assets/93ec27b6-9b43-44e4-bf51-cb3acdb6c878)
Screenshots from tofu script run for reference:
![image](https://github.com/user-attachments/assets/55d11498-7166-4325-b0a8-d2c1e9a459e6)
![image](https://github.com/user-attachments/assets/0aa5107d-ade4-41f8-948d-a8f8a420d6c3)

