### PR TITLE
[release/1.3.z] fix: update version to 1.3.0

### DIFF
--- a/spog/ui/src/about.rs
+++ b/spog/ui/src/about.rs
@@ -47,7 +47,7 @@ pub fn about() -> Html {
                     <dl>
                         <dt>{"Version"}</dt>
                         <dd>
-                            {"1.2.1"}
+                            {"1.3.0"}
                         </dd>
                     </dl>
                 </div>

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -95,7 +95,7 @@ pub struct Version {
 macro_rules! version {
     () => {
         $crate::VersionInformation {
-            version: String::from("1.2.1"),
+            version: String::from("1.3.0"),
             // version: $crate::Version {
             //     full: env!("CARGO_PKG_VERSION").to_string(),
             //     major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap_or_default(),


### PR DESCRIPTION
This PR will change the version hard-coded in the UI About modal and also on the `.well-known/trustification/version` endpoint from spog-api