### PR TITLE
[release/1.3.z][TC-1710] Inconsistent visuals when a CVE has multiple CVSS scores (#2144)

### DIFF
--- a/v11y/testdata/CVE-2023-6260.json
+++ b/v11y/testdata/CVE-2023-6260.json
@@ -1,0 +1,249 @@
+{
+  "dataType": "CVE_RECORD",
+  "dataVersion": "5.1",
+  "cveMetadata": {
+    "cveId": "CVE-2023-6260",
+    "assignerOrgId": "57dba5dd-1a03-47f6-8b36-e84e47d335d8",
+    "state": "PUBLISHED",
+    "assignerShortName": "SRA",
+    "dateReserved": "2023-11-22T17:16:37.736Z",
+    "datePublished": "2024-02-19T21:30:20.947Z",
+    "dateUpdated": "2024-08-02T08:28:20.371Z"
+  },
+  "containers": {
+    "cna": {
+      "affected": [
+        {
+          "defaultStatus": "unknown",
+          "product": "ACS100, ACS300",
+          "vendor": "Brivo",
+          "versions": [
+            {
+              "lessThan": "6.2.4.3",
+              "status": "affected",
+              "version": "5.2.4",
+              "versionType": "semver"
+            }
+          ]
+        }
+      ],
+      "credits": [
+        {
+          "lang": "en",
+          "type": "finder",
+          "user": "00000000-0000-4000-9000-000000000000",
+          "value": "Gabe Siftar (SRA)"
+        },
+        {
+          "lang": "en",
+          "type": "finder",
+          "user": "00000000-0000-4000-9000-000000000000",
+          "value": "Krzysztof Grochal (SRA)"
+        }
+      ],
+      "descriptions": [
+        {
+          "lang": "en",
+          "supportingMedia": [
+            {
+              "base64": false,
+              "type": "text/html",
+              "value": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection') vulnerability in Brivo ACS100, ACS300 allows OS Command Injection, Bypassing Physical Security.<p>This issue affects ACS100 (Network Adjacent Access), ACS300 (Physical Access): from 5.2.4 before 6.2.4.3.</p>"
+            }
+          ],
+          "value": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection') vulnerability in Brivo ACS100, ACS300 allows OS Command Injection, Bypassing Physical Security.This issue affects ACS100 (Network Adjacent Access), ACS300 (Physical Access): from 5.2.4 before 6.2.4.3.\n\n"
+        }
+      ],
+      "impacts": [
+        {
+          "capecId": "CAPEC-88",
+          "descriptions": [
+            {
+              "lang": "en",
+              "value": "CAPEC-88 OS Command Injection"
+            }
+          ]
+        },
+        {
+          "capecId": "CAPEC-390",
+          "descriptions": [
+            {
+              "lang": "en",
+              "value": "CAPEC-390 Bypassing Physical Security"
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "cvssV3_1": {
+            "attackComplexity": "LOW",
+            "attackVector": "PHYSICAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.4,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:P/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "format": "CVSS",
+          "scenarios": [
+            {
+              "lang": "en",
+              "value": "ACS300 (Physical Access)"
+            }
+          ]
+        },
+        {
+          "cvssV3_1": {
+            "attackComplexity": "LOW",
+            "attackVector": "ADJACENT_NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "format": "CVSS",
+          "scenarios": [
+            {
+              "lang": "en",
+              "value": "ACS100 (Adjacent Network Access)"
+            }
+          ]
+        }
+      ],
+      "problemTypes": [
+        {
+          "descriptions": [
+            {
+              "cweId": "CWE-78",
+              "description": "CWE-78 Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
+              "lang": "en",
+              "type": "CWE"
+            }
+          ]
+        }
+      ],
+      "providerMetadata": {
+        "orgId": "57dba5dd-1a03-47f6-8b36-e84e47d335d8",
+        "shortName": "SRA",
+        "dateUpdated": "2024-02-21T14:49:22.819Z"
+      },
+      "references": [
+        {
+          "url": "https://sra.io/advisories/"
+        },
+        {
+          "url": "https://support.brivo.com/l/en/article/g82txdwepa-brivo-firmware-release-notes#brivo_firmware_release_6_2_4_3"
+        }
+      ],
+      "source": {
+        "discovery": "UNKNOWN"
+      },
+      "title": "Web UI OS Command Injection in Brivo ACS100, ACS300",
+      "x_generator": {
+        "engine": "Vulnogram 0.1.0-dev"
+      }
+    },
+    "adp": [
+      {
+        "affected": [
+          {
+            "vendor": "brivo",
+            "product": "acs100_firmware",
+            "cpes": [
+              "cpe:2.3:o:brivo:acs100_firmware:*:*:*:*:*:*:*:*"
+            ],
+            "defaultStatus": "unknown",
+            "versions": [
+              {
+                "version": "5.2.4",
+                "status": "affected",
+                "lessThan": "6.2.4.3",
+                "versionType": "semver"
+              }
+            ]
+          },
+          {
+            "vendor": "brivo",
+            "product": "acs300_firmware",
+            "cpes": [
+              "cpe:2.3:o:brivo:acs300_firmware:*:*:*:*:*:*:*:*"
+            ],
+            "defaultStatus": "unknown",
+            "versions": [
+              {
+                "version": "5.2.4",
+                "status": "affected",
+                "lessThan": "6.2.4.3",
+                "versionType": "semver"
+              }
+            ]
+          }
+        ],
+        "metrics": [
+          {
+            "other": {
+              "type": "ssvc",
+              "content": {
+                "timestamp": "2024-02-20T15:38:03.370421Z",
+                "id": "CVE-2023-6260",
+                "options": [
+                  {
+                    "Exploitation": "none"
+                  },
+                  {
+                    "Automatable": "no"
+                  },
+                  {
+                    "Technical Impact": "total"
+                  }
+                ],
+                "role": "CISA Coordinator",
+                "version": "2.0.3"
+              }
+            }
+          }
+        ],
+        "title": "CISA ADP Vulnrichment",
+        "providerMetadata": {
+          "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+          "shortName": "CISA-ADP",
+          "dateUpdated": "2024-06-27T19:33:58.599Z"
+        }
+      },
+      {
+        "providerMetadata": {
+          "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+          "shortName": "CVE",
+          "dateUpdated": "2024-08-02T08:28:20.371Z"
+        },
+        "title": "CVE Program Container",
+        "references": [
+          {
+            "url": "https://sra.io/advisories/",
+            "tags": [
+              "x_transferred"
+            ]
+          },
+          {
+            "url": "https://support.brivo.com/l/en/article/g82txdwepa-brivo-firmware-release-notes#brivo_firmware_release_6_2_4_3",
+            "tags": [
+              "x_transferred"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Backport of https://github.com/trustification/trustification/pull/2144

https://issues.redhat.com/browse/TC-1710