### PR TITLE
TC-2182 Avoid ReportViewwer fetching data

### DIFF
--- a/spog/ui/src/pages/sbom/mod.rs
+++ b/spog/ui/src/pages/sbom/mod.rs
@@ -134,7 +134,7 @@ fn details(props: &DetailsProps) -> Html {
         Info,
         Packages,
         Source,
-        Report,
+        // Report,
     }
 
     let config = use_config_private();
@@ -204,9 +204,9 @@ fn details(props: &DetailsProps) -> Html {
                     <PageSection hidden={*tab != TabIndex::Source} variant={PageSectionVariant::Light} fill={PageSectionFill::Fill}>
                         <SourceCode source={source.clone()} />
                     </PageSection>
-                    <PageSection hidden={*tab != TabIndex::Report} variant={PageSectionVariant::Light} fill={PageSectionFill::Fill}>
-                        <ReportViewwer raw={source.clone()}/>
-                    </PageSection>
+                    // <PageSection hidden={*tab != TabIndex::Report} variant={PageSectionVariant::Light} fill={PageSectionFill::Fill}>
+                    //     <ReportViewwer raw={source.clone()}/>
+                    // </PageSection>
                 </>
             )
         }
@@ -273,9 +273,9 @@ fn details(props: &DetailsProps) -> Html {
                     <PageSection hidden={*tab != TabIndex::Source} fill={PageSectionFill::Fill}>
                         <SourceCode source={source.clone()} />
                     </PageSection>
-                    <PageSection hidden={*tab != TabIndex::Report} fill={PageSectionFill::Fill}>
-                        <ReportViewwer raw={source.clone()}/>
-                    </PageSection>
+                    // <PageSection hidden={*tab != TabIndex::Report} fill={PageSectionFill::Fill}>
+                    //     <ReportViewwer raw={source.clone()}/>
+                    // </PageSection>
                 </>
             )
         }
@@ -303,9 +303,9 @@ fn details(props: &DetailsProps) -> Html {
                     <PageSection hidden={*tab != TabIndex::Source} fill={PageSectionFill::Fill}>
                         <SourceCode source={source.clone()} />
                     </PageSection>
-                    <PageSection hidden={*tab != TabIndex::Report} fill={PageSectionFill::Fill}>
-                        <ReportViewwer raw={source.clone()}/>
-                    </PageSection>
+                    // <PageSection hidden={*tab != TabIndex::Report} fill={PageSectionFill::Fill}>
+                    //     <ReportViewwer raw={source.clone()}/>
+                    // </PageSection>
                 </>
             )
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2182
Also referenced in https://issues.redhat.com/browse/TC-1978?focusedId=26496176&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-26496176

In the issue, the [screenshot](https://issues.redhat.com/secure/attachment/13342161/image-2025-01-29-10-22-29-363.png) shows the slow requests are `Stalled` and the reasons behind are explained in [Timing breakdown phases explained](https://developer.chrome.com/docs/devtools/network/reference/?utm_source=devtools#timing-explanation) which clarifies is something that happens on the browser.
This situation is confirmed also by the server's log where those requests have fast execution times (some milliseconds).

This `queueing` situations always started after the SBOM details page was opened while with any other page (e.g. Package/CVE/Advisory details pages) nothing happened.