### PR TITLE
[TC-2219] fix: When changing zoom in the Home screen, the pie charts are overlapping their boarders

### DIFF
--- a/spog/ui/src/pages/index.rs
+++ b/spog/ui/src/pages/index.rs
@@ -645,7 +645,7 @@ pub fn sbom_donut_chart(props: &SbomDonutChartProperties) -> Html {
             let options = donut_options(data);
             html!(
                 <>
-                    <Donut {options} {labels} style="width: 350px;" />
+                    <Donut {options} {labels} style="max-width: 350px;" />
                 </>
             )
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2219

The width of the div that wraps the Chart should change automatically but with a limit. So setting the `max-width` prop rather than `width`.

https://github.com/user-attachments/assets/b1ba05e7-250a-4724-b1fa-a3e5369cb212

