### PR TITLE
[release/1.3.z][TC-2219] fix: When changing zoom in the Home screen, the pie charts are overlapping their boarders (#2165)

### DIFF
--- a/spog/ui/src/pages/index.rs
+++ b/spog/ui/src/pages/index.rs
@@ -645,7 +645,7 @@ pub fn sbom_donut_chart(props: &SbomDonutChartProperties) -> Html {
             let options = donut_options(data);
             html!(
                 <>
-                    <Donut {options} {labels} style="width: 350px;" />
+                    <Donut {options} {labels} style="max-width: 350px;" />
                 </>
             )
         }


### PR DESCRIPTION
Backport of https://github.com/trustification/trustification/pull/2165

https://issues.redhat.com/browse/TC-2219